### PR TITLE
#464 Infinite number of attempts for the Datafeed retry configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,9 @@ name: Build
 
 on:
   push:
-    branches: [ 'master', '*-rc' ]
+    branches: [ 'main', '*-rc' ]
   pull_request:
-    branches: [ 'master', '*-rc' ]
+    branches: [ 'main', '*-rc' ]
 
 jobs:
   build:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -119,7 +119,7 @@ datafeed:
     maxIntervalMillis: 10000
 
 retry:
-  maxAttempts: 6
+  maxAttempts: 6 # set '-1' for an infinite number of attempts, default value is '10'
   initialIntervalMillis: 2000
   multiplier: 1.5
   maxIntervalMillis: 10000

--- a/docs/datafeed.md
+++ b/docs/datafeed.md
@@ -63,6 +63,17 @@ Bot developers can also configure a dedicated retry mechanism which will be used
 Basically, the datafeed service retry configuration has the field same as the global retry configuration with the fields for implementing 
 the exponential backoff mechanism.
 
+### Infinite retries
+By default, Datafeed retry is configured to have an infinite number of attempts. This is equivalent to: 
+```yaml
+datafeed:
+  retry:
+    maxAttempts: -1 # infinite number of attemps
+    initialIntervalMillis: 2000
+    multiplier: 1.5
+    maxIntervalMillis: 10000
+```
+
 ## Subscribe/Unsubscribe RealTimeEventListener
 
 [RealTimeEventListener](https://javadoc.io/doc/org.finos.symphony.bdk/symphony-bdk-core/latest/com/symphony/bdk/core/service/datafeed/RealTimeEventListener.html) is an interface definition for a callback to be invoked when a real-time event is received from the datafeed.

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkDatafeedConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkDatafeedConfig.java
@@ -13,7 +13,7 @@ public class BdkDatafeedConfig {
 
     private String version = "v1";
     private String idFilePath;
-    private BdkRetryConfig retry;
+    private BdkRetryConfig retry = new BdkRetryConfig(BdkRetryConfig.INFINITE_MAX_ATTEMPTS);
 
     public String getIdFilePath() {
         if (idFilePath == null || idFilePath.isEmpty()) {

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkRetryConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkRetryConfig.java
@@ -1,28 +1,66 @@
 package com.symphony.bdk.core.config.model;
 
-import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.apiguardian.api.API;
 
-@Getter
 @Setter
+@NoArgsConstructor
 @API(status = API.Status.STABLE)
 public class BdkRetryConfig {
 
-    public static final int DEFAULT_MAX_ATTEMPTS = 10;
-    public static final long DEFAULT_INITIAL_INTERVAL_MILLIS = 500L;
-    public static final double DEFAULT_MULTIPLIER = 2;
-    public static final long DEFAULT_MAX_INTERVAL_MILLIS = 5*60*1000;
+  public static final int INFINITE_MAX_ATTEMPTS = -1;
+  public static final int DEFAULT_MAX_ATTEMPTS = 10;
+  public static final long DEFAULT_INITIAL_INTERVAL_MILLIS = 500L;
+  public static final double DEFAULT_MULTIPLIER = 2;
+  public static final long DEFAULT_MAX_INTERVAL_MILLIS = 5 * 60 * 1000;
 
-    private int maxAttempts = DEFAULT_MAX_ATTEMPTS;
-    private long initialIntervalMillis = DEFAULT_INITIAL_INTERVAL_MILLIS;
-    private double multiplier = DEFAULT_MULTIPLIER;
-    private long maxIntervalMillis = DEFAULT_MAX_INTERVAL_MILLIS;
+  private Integer maxAttempts;
+  private Long initialIntervalMillis;
+  private Double multiplier;
+  private Long maxIntervalMillis;
 
-    public double getMultiplier() {
-        if (this.multiplier < 1) {
-            return 1;
-        }
-        return this.multiplier;
+  public BdkRetryConfig(Integer maxAttempts) {
+    this.maxAttempts = maxAttempts;
+  }
+
+  public Integer getMaxAttempts() {
+
+    if (this.maxAttempts == null) {
+      return DEFAULT_MAX_ATTEMPTS;
     }
+
+    if (this.maxAttempts < 0) {
+      // negative value means infinite number of attempts
+      return Integer.MAX_VALUE;
+    }
+
+    return this.maxAttempts;
+  }
+
+  public Long getInitialIntervalMillis() {
+    
+    if (this.initialIntervalMillis == null) {
+      return DEFAULT_INITIAL_INTERVAL_MILLIS;
+    }
+    
+    return this.initialIntervalMillis;
+  }
+
+  public Double getMultiplier() {
+
+    if (this.multiplier == null || this.multiplier < 1) {
+      return DEFAULT_MULTIPLIER;
+    }
+    return this.multiplier;
+  }
+
+  public Long getMaxIntervalMillis() {
+
+    if (this.maxIntervalMillis == null) {
+      return DEFAULT_MAX_INTERVAL_MILLIS;
+    }
+
+    return this.maxIntervalMillis;
+  }
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/retry/RecoveryStrategy.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/retry/RecoveryStrategy.java
@@ -14,8 +14,8 @@ import java.util.function.Predicate;
 @API(status = API.Status.INTERNAL)
 public class RecoveryStrategy {
 
-  private Predicate<Exception> condition;
-  private ConsumerWithThrowable recovery;
+  private final Predicate<Exception> condition;
+  private final ConsumerWithThrowable recovery;
 
   /**
    *
@@ -36,15 +36,15 @@ public class RecoveryStrategy {
    * @return true if the provided exception corresponds to the recovery strategy
    */
   public boolean matches(Exception e) {
-    return condition.test(e);
+    return this.condition.test(e);
   }
 
   /**
    * Runs the recovery function.
    *
-   * @throws Throwable
+   * @throws Throwable can be thrown by {@link ConsumerWithThrowable#consume()}
    */
   public void runRecovery() throws Throwable {
-    recovery.consume();
+    this.recovery.consume();
   }
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/retry/RetryWithRecovery.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/retry/RetryWithRecovery.java
@@ -26,10 +26,11 @@ import javax.net.ssl.SSLHandshakeException;
 @Slf4j
 @API(status = API.Status.INTERNAL)
 public abstract class RetryWithRecovery<T> {
-  private SupplierWithApiException<T> supplier;
-  private Predicate<Exception> ignoreException;
-  private List<RecoveryStrategy> recoveryStrategies;
-  private String address;
+
+  private final SupplierWithApiException<T> supplier;
+  private final Predicate<Exception> ignoreException;
+  private final List<RecoveryStrategy> recoveryStrategies;
+  private final String address;
 
   /**
    * This is a helper function designed to cover most of the retry cases.
@@ -44,9 +45,14 @@ public abstract class RetryWithRecovery<T> {
    * @throws ApiRuntimeException if a non-handled {@link ApiException} thrown or if the max number of retries has been reached.
    * @throws RuntimeException    if any other exception thrown.
    */
-  public static <T> T executeAndRetry(RetryWithRecoveryBuilder baseRetryBuilder, String name, String address,
-      SupplierWithApiException<T> supplier) {
-    RetryWithRecovery<T> retry = RetryWithRecoveryBuilder.<T>from(baseRetryBuilder)
+  public static <T> T executeAndRetry(
+      final RetryWithRecoveryBuilder<?> baseRetryBuilder,
+      final String name,
+      final String address,
+      final SupplierWithApiException<T> supplier
+  ) {
+
+    final RetryWithRecovery<T> retry = RetryWithRecoveryBuilder.<T>from(baseRetryBuilder)
         .name(name)
         .supplier(supplier)
         .basePath(address)
@@ -61,8 +67,12 @@ public abstract class RetryWithRecovery<T> {
     }
   }
 
-  public RetryWithRecovery(SupplierWithApiException<T> supplier, Predicate<Exception> ignoreException,
-      List<RecoveryStrategy> recoveryStrategies, String address) {
+  public RetryWithRecovery(
+      SupplierWithApiException<T> supplier,
+      Predicate<Exception> ignoreException,
+      List<RecoveryStrategy> recoveryStrategies,
+      String address
+  ) {
     this.supplier = supplier;
     this.ignoreException = ignoreException;
     this.recoveryStrategies = recoveryStrategies;

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/retry/resilience4j/Resilience4jRetryWithRecovery.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/retry/resilience4j/Resilience4jRetryWithRecovery.java
@@ -65,15 +65,19 @@ public class Resilience4jRetryWithRecovery<T> extends RetryWithRecovery<T> {
     return this.retry.executeCheckedSupplier(this::executeOnce);
   }
 
-  private Retry createRetry(String name, BdkRetryConfig bdkRetryConfig,
-      Predicate<Throwable> retryOnExceptionPredicate) {
-    RetryConfig retryConfig = RetryConfig.custom()
+  private Retry createRetry(
+      final String name,
+      final BdkRetryConfig bdkRetryConfig,
+      final Predicate<Throwable> retryOnExceptionPredicate
+  ) {
+
+    final RetryConfig retryConfig = RetryConfig.custom()
         .maxAttempts(bdkRetryConfig.getMaxAttempts())
         .intervalFunction(BdkExponentialFunction.ofExponentialBackoff(bdkRetryConfig))
         .retryOnException(retryOnExceptionPredicate)
         .build();
 
-    Retry retry = Retry.of(name, retryConfig);
+    final Retry retry = Retry.of(name, retryConfig);
     retry.getEventPublisher().onRetry(event -> {
       double interval = event.getWaitInterval().toMillis() / 1000.0;
       if (event.getLastThrowable() != null) {

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/test/BdkRetryConfigTestHelper.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/test/BdkRetryConfigTestHelper.java
@@ -10,9 +10,9 @@ public class BdkRetryConfigTestHelper {
 
   public static BdkRetryConfig ofMinimalInterval(int maxAttempts) {
     BdkRetryConfig retryConfig = new BdkRetryConfig();
-    retryConfig.setMultiplier(1);
-    retryConfig.setInitialIntervalMillis(10);
-    retryConfig.setMaxIntervalMillis(10);
+    retryConfig.setMultiplier(1.0);
+    retryConfig.setInitialIntervalMillis(10L);
+    retryConfig.setMaxIntervalMillis(10L);
     retryConfig.setMaxAttempts(maxAttempts);
 
     return retryConfig;

--- a/symphony-bdk-core/src/test/resources/config/config.yaml
+++ b/symphony-bdk-core/src/test/resources/config/config.yaml
@@ -18,3 +18,8 @@ app:
   appId: tibapp
   privateKey:
     path: /Users/local/conf/agent/privatekey.pem
+
+datafeed:
+  retry:
+    maxAttempts: 2
+

--- a/symphony-bdk-core/src/test/resources/config/df_retry_config.yaml
+++ b/symphony-bdk-core/src/test/resources/config/df_retry_config.yaml
@@ -1,0 +1,13 @@
+host: acme.symphony.com
+
+bot:
+  username: tibot
+  privateKeyPath: /Users/local/conf/agent/privatekey.pem
+
+retry:
+  maxAttempts: 2
+  initialIntervalMillis: 1000
+  multiplier: 3.0
+  maxIntervalMillis: 2000
+
+# here we don't want to configure datafeed retry, to ensure that it has an infinite number of retries by default


### PR DESCRIPTION
### Ticket
Closes https://github.com/finos/symphony-bdk-java/issues/464

### Description
Now datafeed is by default configured to have an infinite number of retry attempts. Global retry configuration keeps the same default value (`10`). 

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
