### PR TITLE
Update Spring Boot to 2.4.3

### DIFF
--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     // import Spring Boot's BOM
-    api platform('org.springframework.boot:spring-boot-dependencies:2.4.1')
+    api platform('org.springframework.boot:spring-boot-dependencies:2.4.3')
 
     // define all our dependencies versions
     constraints {

--- a/symphony-bdk-core/build.gradle
+++ b/symphony-bdk-core/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     implementation 'io.github.resilience4j:resilience4j-retry'
     implementation 'io.swagger:swagger-annotations'
     implementation 'com.google.code.findbugs:jsr305'
+    implementation 'javax.annotation:jsr250-api:1.0'
 
     testImplementation project(':symphony-bdk-http:symphony-bdk-http-jersey2')
     testRuntimeOnly project(':symphony-bdk-template:symphony-bdk-template-freemarker')

--- a/symphony-bdk-examples/bdk-app-spring-boot-example/build.gradle
+++ b/symphony-bdk-examples/bdk-app-spring-boot-example/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'bdk.java-common-conventions'
-    id 'org.springframework.boot' version "2.4.1"
+    id 'org.springframework.boot' version "2.4.3"
 }
 
 description = 'Symphony Java BDK Examples for the SpringBoot integration'

--- a/symphony-bdk-examples/bdk-multi-instances-example/build.gradle
+++ b/symphony-bdk-examples/bdk-multi-instances-example/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'bdk.java-common-conventions'
-    id 'org.springframework.boot' version "2.4.1"
+    id 'org.springframework.boot' version "2.4.3"
 }
 
 description = 'How to run multiple bot instances in //'

--- a/symphony-bdk-examples/bdk-spring-boot-example/build.gradle
+++ b/symphony-bdk-examples/bdk-spring-boot-example/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'bdk.java-common-conventions'
-    id 'org.springframework.boot' version "2.4.1"
+    id 'org.springframework.boot' version "2.4.3"
 }
 
 description = 'Symphony Java BDK Examples for the SpringBoot integration'


### PR DESCRIPTION
This fixes security vulnerabilities reported by Snyk.

Along the way we lost the javax.annotation.Generated classes, add it
explicitly as a dependency.

