### PR TITLE
Fix ConcurrentModificationException in Datafeed loop #475

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2.java
@@ -73,7 +73,7 @@ public class DatafeedLoopV2 extends AbstractDatafeedLoop {
     } catch (AuthUnauthorizedException | ApiException | NestedRetryException exception) {
       throw exception;
     } catch (Throwable throwable) {
-      log.error(networkIssueMessageError(throwable,datafeedApi.getApiClient().getBasePath()) + "\n" + throwable);
+      log.error(networkIssueMessageError(throwable, datafeedApi.getApiClient().getBasePath()) + "\n" + throwable);
     }
   }
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2Test.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2Test.java
@@ -38,335 +38,424 @@ import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.ws.rs.ProcessingException;
 
-public class DatafeedLoopV2Test {
+class DatafeedLoopV2Test {
 
-    private DatafeedLoopV2 datafeedService;
-    private ApiClient datafeedApiClient;
-    private DatafeedApi datafeedApi;
-    private AuthSession authSession;
-    private RealTimeEventListener listener;
+  private DatafeedLoopV2 datafeedService;
+  private ApiClient datafeedApiClient;
+  private DatafeedApi datafeedApi;
+  private AuthSession authSession;
+  private RealTimeEventListener listener;
 
-    @BeforeEach
-    void setUp() throws BdkConfigException {
-        BdkConfig bdkConfig = BdkConfigLoader.loadFromClasspath("/config/config.yaml");
-        BdkDatafeedConfig datafeedConfig = bdkConfig.getDatafeed();
-        datafeedConfig.setVersion("v2");
-        bdkConfig.setDatafeed(datafeedConfig);
-        bdkConfig.setRetry(ofMinimalInterval(2));
+  @BeforeEach
+  void setUp() throws BdkConfigException {
+    BdkConfig bdkConfig = BdkConfigLoader.loadFromClasspath("/config/config.yaml");
+    BdkDatafeedConfig datafeedConfig = bdkConfig.getDatafeed();
+    datafeedConfig.setVersion("v2");
+    bdkConfig.setDatafeed(datafeedConfig);
+    bdkConfig.setRetry(ofMinimalInterval(2));
 
-        this.authSession = Mockito.mock(AuthSessionRsaImpl.class);
-        when(this.authSession.getSessionToken()).thenReturn("1234");
-        when(this.authSession.getKeyManagerToken()).thenReturn("1234");
+    this.authSession = Mockito.mock(AuthSessionRsaImpl.class);
+    when(this.authSession.getSessionToken()).thenReturn("1234");
+    when(this.authSession.getKeyManagerToken()).thenReturn("1234");
 
-        this.datafeedApiClient = mock(ApiClient.class);
-        doNothing().when(this.datafeedApiClient).rotate();
+    this.datafeedApiClient = mock(ApiClient.class);
+    doNothing().when(this.datafeedApiClient).rotate();
 
-        this.datafeedApi = mock(DatafeedApi.class);
-        when(this.datafeedApi.getApiClient()).thenReturn(this.datafeedApiClient);
+    this.datafeedApi = mock(DatafeedApi.class);
+    when(this.datafeedApi.getApiClient()).thenReturn(this.datafeedApiClient);
 
-        this.datafeedService = new DatafeedLoopV2(
-                this.datafeedApi,
-                this.authSession,
-                bdkConfig
-        );
-        this.listener = new RealTimeEventListener() {
-          @Override
-          public boolean isAcceptingEvent(V4Event event, String username) {
-            return true;
+    this.datafeedService = new DatafeedLoopV2(
+        this.datafeedApi,
+        this.authSession,
+        bdkConfig
+    );
+    this.listener = new RealTimeEventListener() {
+      @Override
+      public boolean isAcceptingEvent(V4Event event, String username) {
+        return true;
+      }
+
+      @Override
+      public void onMessageSent(V4Initiator initiator, V4MessageSent event) {
+        datafeedService.stop();
+      }
+    };
+    this.datafeedService.subscribe(listener);
+  }
+
+  @Test
+  void testStart() throws ApiException, AuthUnauthorizedException {
+    List<V5Datafeed> datafeeds = new ArrayList<>();
+    datafeeds.add(new V5Datafeed().id("test-id"));
+    when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(datafeeds);
+    AckId ackId = datafeedService.getAckId();
+    when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId))
+        .thenReturn(new V5EventList().addEventsItem(
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id"));
+
+    this.datafeedService.start();
+
+    verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
+    verify(datafeedApi, times(1)).readDatafeed("test-id", "1234", "1234", ackId);
+    verify(datafeedApiClient, times(0)).rotate();
+  }
+
+  @Test
+  void testStartMultiThreaded() throws ApiException, InterruptedException,
+      ExecutionException {
+    List<V5Datafeed> datafeeds = new ArrayList<>();
+    datafeeds.add(new V5Datafeed().id("test-id"));
+    when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(datafeeds);
+    AckId ackId = datafeedService.getAckId();
+    when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId))
+        .thenReturn(new V5EventList().addEventsItem(
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id"));
+
+    // remove default listener that stops the DF loop
+    datafeedService.unsubscribe(listener);
+
+    CountDownLatch blockDispatchingToListeners = new CountDownLatch(1);
+    CountDownLatch blockNewListenerIsAdded = new CountDownLatch(1);
+    datafeedService.subscribe(new RealTimeEventListener() {
+      @Override
+      public boolean isAcceptingEvent(V4Event event, String username) {
+        blockDispatchingToListeners.countDown();
+        try {
+          blockNewListenerIsAdded.await();
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+        return false;
+      }
+    });
+
+    ExecutorService executorService = Executors.newFixedThreadPool(2);
+    Future<Void> datafeedLoop = executorService.submit(() -> {
+      datafeedService.start();
+      return null;
+    });
+
+    // we wait until the DF loop is blocked in event dispatching
+    blockDispatchingToListeners.await();
+
+    // we try to add a new listener that will cause the DF loop to run twice and then to end
+    Future<Void> addANewListener = executorService.submit(() -> {
+      datafeedService.subscribe(new RealTimeEventListener() {
+        @Override
+        public boolean isAcceptingEvent(V4Event event, String username) {
+          if(datafeedService.getAckId().getAckId().equals("finished")){
+            datafeedService.stop();
           }
+          return false;
+        }
+      });
+      when(datafeedApi.readDatafeed("test-id", "1234", "1234", new AckId().ackId("ack-id")))
+          .thenReturn(new V5EventList().addEventsItem(
+              new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("finished"));
+      return null;
+    });
 
-          @Override
-            public void onMessageSent(V4Initiator initiator, V4MessageSent event) {
-                datafeedService.stop();
-            }
-        };
-        this.datafeedService.subscribe(listener);
-    }
+    // we want to make sure the addANewListener is started and blocking before unblocking the first listener
+    Thread.sleep(100);
+    blockNewListenerIsAdded.countDown();
 
-    @Test
-    void testStart() throws ApiException, AuthUnauthorizedException {
-        List<V5Datafeed> datafeeds = new ArrayList<>();
-        datafeeds.add(new V5Datafeed().id("test-id"));
-        when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(datafeeds);
-        AckId ackId = datafeedService.getAckId();
-        when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId))
-                .thenReturn(new V5EventList().addEventsItem(new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id"));
+    // make sure DF loop ends without error (otherwise get() throws an exception)
+    datafeedLoop.get();
+    addANewListener.get();
 
-        this.datafeedService.start();
+    // make sure we ran the DF loop twice (otherwise it could silently fail)
+    assertEquals("finished", datafeedService.getAckId().getAckId());
 
-        verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
-        verify(datafeedApi, times(1)).readDatafeed("test-id", "1234", "1234", ackId);
-        verify(datafeedApiClient, times(0)).rotate();
-    }
+    executorService.shutdown();
+  }
 
-    @Test
-    void testStartEmptyListDatafeed() throws ApiException, AuthUnauthorizedException {
-        when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(Collections.emptyList());
-        when(datafeedApi.createDatafeed("1234", "1234")).thenReturn(new V5Datafeed().id("test-id"));
-        AckId ackId = datafeedService.getAckId();
-        when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId))
-                .thenReturn(new V5EventList().addEventsItem(new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id"));
+  @Test
+  void testStartEmptyListDatafeed() throws ApiException, AuthUnauthorizedException {
+    when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(Collections.emptyList());
+    when(datafeedApi.createDatafeed("1234", "1234")).thenReturn(new V5Datafeed().id("test-id"));
+    AckId ackId = datafeedService.getAckId();
+    when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId))
+        .thenReturn(new V5EventList().addEventsItem(
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id"));
 
-        this.datafeedService.start();
+    this.datafeedService.start();
 
-        verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
-        verify(datafeedApi, times(1)).createDatafeed("1234", "1234");
-        verify(datafeedApi, times(1)).readDatafeed("test-id", "1234", "1234", ackId);
-        verify(datafeedApiClient, times(0)).rotate();
-    }
+    verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
+    verify(datafeedApi, times(1)).createDatafeed("1234", "1234");
+    verify(datafeedApi, times(1)).readDatafeed("test-id", "1234", "1234", ackId);
+    verify(datafeedApiClient, times(0)).rotate();
+  }
 
-    @Test
-    void testStartServiceAlreadyStarted() throws ApiException, AuthUnauthorizedException {
-        AtomicInteger signal = new AtomicInteger(0);
-        List<V5Datafeed> datafeeds = new ArrayList<>();
-        datafeeds.add(new V5Datafeed().id("test-id"));
-        when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(datafeeds);
-        AckId ackId = datafeedService.getAckId();
-        when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId))
-                .thenReturn(new V5EventList()
-                        .addEventsItem(new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload()))
-                        .ackId("ack-id"));
+  @Test
+  void testStartServiceAlreadyStarted() throws ApiException, AuthUnauthorizedException {
+    AtomicInteger signal = new AtomicInteger(0);
+    List<V5Datafeed> datafeeds = new ArrayList<>();
+    datafeeds.add(new V5Datafeed().id("test-id"));
+    when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(datafeeds);
+    AckId ackId = datafeedService.getAckId();
+    when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId))
+        .thenReturn(new V5EventList()
+            .addEventsItem(new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload()))
+            .ackId("ack-id"));
 
-        this.datafeedService.unsubscribe(this.listener);
-        this.datafeedService.subscribe(new RealTimeEventListener() {
-          @Override
-          public boolean isAcceptingEvent(V4Event event, String username) {
-            return true;
-          }
+    this.datafeedService.unsubscribe(this.listener);
+    this.datafeedService.subscribe(new RealTimeEventListener() {
+      @Override
+      public boolean isAcceptingEvent(V4Event event, String username) {
+        return true;
+      }
 
-          @Override
-            public void onMessageSent(V4Initiator initiator, V4MessageSent event) {
-                try {
-                    datafeedService.start();
-                } catch (AuthUnauthorizedException | ApiException e) {
-                    e.printStackTrace();
-                } catch (IllegalStateException e) {
-                    signal.incrementAndGet();
-                } finally {
-                    datafeedService.stop();
-                }
-            }
-        });
-        this.datafeedService.start();
-        assertEquals(signal.get(), 1);
-    }
+      @Override
+      public void onMessageSent(V4Initiator initiator, V4MessageSent event) {
+        try {
+          datafeedService.start();
+        } catch (AuthUnauthorizedException | ApiException e) {
+          e.printStackTrace();
+        } catch (IllegalStateException e) {
+          signal.incrementAndGet();
+        } finally {
+          datafeedService.stop();
+        }
+      }
+    });
+    this.datafeedService.start();
+    assertEquals(1, signal.get());
+  }
 
-    @Test
-    void testStartClientErrorListDatafeed() throws ApiException {
-        when(datafeedApi.listDatafeed("1234", "1234")).thenThrow(new ApiException(400, "client-error"));
+  @Test
+  void testStartClientErrorListDatafeed() throws ApiException {
+    when(datafeedApi.listDatafeed("1234", "1234")).thenThrow(new ApiException(400, "client-error"));
 
-        assertThrows(ApiException.class, this.datafeedService::start);
-        verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
-        verify(datafeedApiClient, times(1)).rotate();
-    }
+    assertThrows(ApiException.class, this.datafeedService::start);
+    verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
+    verify(datafeedApiClient, times(1)).rotate();
+  }
 
-    @Test
-    void testStartAuthRefreshListDatafeed() throws ApiException, AuthUnauthorizedException {
-        when(datafeedApi.listDatafeed("1234", "1234")).thenThrow(new ApiException(401, "unauthorized-error"));
-        doThrow(AuthUnauthorizedException.class).when(authSession).refresh();
+  @Test
+  void testStartAuthRefreshListDatafeed() throws ApiException, AuthUnauthorizedException {
+    when(datafeedApi.listDatafeed("1234", "1234")).thenThrow(new ApiException(401, "unauthorized-error"));
+    doThrow(AuthUnauthorizedException.class).when(authSession).refresh();
 
-        assertThrows(AuthUnauthorizedException.class, this.datafeedService::start);
-        verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
-        verify(authSession, times(1)).refresh();
-        verify(datafeedApiClient, times(1)).rotate();
-    }
+    assertThrows(AuthUnauthorizedException.class, this.datafeedService::start);
+    verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
+    verify(authSession, times(1)).refresh();
+    verify(datafeedApiClient, times(1)).rotate();
+  }
 
-    @Test
-    void testStartServerErrorListDatafeed() throws ApiException {
-        when(datafeedApi.listDatafeed("1234", "1234")).thenThrow(new ApiException(502, "server-error"));
+  @Test
+  void testStartServerErrorListDatafeed() throws ApiException {
+    when(datafeedApi.listDatafeed("1234", "1234")).thenThrow(new ApiException(502, "server-error"));
 
-        assertThrows(ApiException.class, this.datafeedService::start);
-        verify(datafeedApi, times(2)).listDatafeed("1234", "1234");
-        verify(datafeedApiClient, times(2)).rotate();
-    }
+    assertThrows(ApiException.class, this.datafeedService::start);
+    verify(datafeedApi, times(2)).listDatafeed("1234", "1234");
+    verify(datafeedApiClient, times(2)).rotate();
+  }
 
-    @Test
-    void testStartErrorListDatafeedThenRetrySuccess() throws ApiException, AuthUnauthorizedException {
-        AtomicInteger count = new AtomicInteger(0);
-        when(datafeedApi.listDatafeed("1234", "1234"))
-            .thenThrow(new ApiException(502, "server-error"))
-            .thenReturn(Collections.singletonList(new V5Datafeed().id("test-id")));
+  @Test
+  void testStartErrorListDatafeedThenRetrySuccess() throws ApiException, AuthUnauthorizedException {
+    when(datafeedApi.listDatafeed("1234", "1234"))
+        .thenThrow(new ApiException(502, "server-error"))
+        .thenReturn(Collections.singletonList(new V5Datafeed().id("test-id")));
 
-        AckId ackId = datafeedService.getAckId();
-        when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId))
-                .thenReturn(new V5EventList().addEventsItem(new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id"));
+    AckId ackId = datafeedService.getAckId();
+    when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId))
+        .thenReturn(new V5EventList().addEventsItem(
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id"));
 
-        this.datafeedService.start();
+    this.datafeedService.start();
 
-        verify(datafeedApi, times(2)).listDatafeed("1234", "1234");
-        verify(datafeedApi, times(1)).readDatafeed("test-id", "1234", "1234", ackId);
-        verify(datafeedApiClient, times(1)).rotate();
-    }
+    verify(datafeedApi, times(2)).listDatafeed("1234", "1234");
+    verify(datafeedApi, times(1)).readDatafeed("test-id", "1234", "1234", ackId);
+    verify(datafeedApiClient, times(1)).rotate();
+  }
 
-    @Test
-    void testStartAuthErrorCreateDatafeed() throws ApiException, AuthUnauthorizedException {
-        when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(Collections.emptyList());
-        when(datafeedApi.createDatafeed("1234", "1234")).thenThrow(new ApiException(401, "unauthorized-error"));
-        doThrow(AuthUnauthorizedException.class).when(authSession).refresh();
+  @Test
+  void testStartAuthErrorCreateDatafeed() throws ApiException, AuthUnauthorizedException {
+    when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(Collections.emptyList());
+    when(datafeedApi.createDatafeed("1234", "1234")).thenThrow(new ApiException(401, "unauthorized-error"));
+    doThrow(AuthUnauthorizedException.class).when(authSession).refresh();
 
-        assertThrows(AuthUnauthorizedException.class, this.datafeedService::start);
-        verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
-        verify(datafeedApi, times(1)).createDatafeed("1234", "1234");
-        verify(datafeedApiClient, times(1)).rotate();
-    }
+    assertThrows(AuthUnauthorizedException.class, this.datafeedService::start);
+    verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
+    verify(datafeedApi, times(1)).createDatafeed("1234", "1234");
+    verify(datafeedApiClient, times(1)).rotate();
+  }
 
-    @Test
-    void testStartClientErrorCreateDatafeed() throws ApiException {
-        when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(Collections.emptyList());
-        when(datafeedApi.createDatafeed("1234", "1234")).thenThrow(new ApiException(400, "client-error"));
+  @Test
+  void testStartClientErrorCreateDatafeed() throws ApiException {
+    when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(Collections.emptyList());
+    when(datafeedApi.createDatafeed("1234", "1234")).thenThrow(new ApiException(400, "client-error"));
 
-        assertThrows(ApiException.class, this.datafeedService::start);
-        verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
-        verify(datafeedApi, times(1)).createDatafeed("1234", "1234");
-        verify(datafeedApiClient, times(1)).rotate();
-    }
+    assertThrows(ApiException.class, this.datafeedService::start);
+    verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
+    verify(datafeedApi, times(1)).createDatafeed("1234", "1234");
+    verify(datafeedApiClient, times(1)).rotate();
+  }
 
-    @Test
-    void testStartServerErrorCreateDatafeed() throws ApiException {
-        when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(Collections.emptyList());
-        when(datafeedApi.createDatafeed("1234", "1234")).thenThrow(new ApiException(502, "server-error"));
+  @Test
+  void testStartServerErrorCreateDatafeed() throws ApiException {
+    when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(Collections.emptyList());
+    when(datafeedApi.createDatafeed("1234", "1234")).thenThrow(new ApiException(502, "server-error"));
 
-        assertThrows(ApiException.class, this.datafeedService::start);
-        verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
-        verify(datafeedApi, times(2)).createDatafeed("1234", "1234");
-        verify(datafeedApiClient, times(2)).rotate();
-    }
+    assertThrows(ApiException.class, this.datafeedService::start);
+    verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
+    verify(datafeedApi, times(2)).createDatafeed("1234", "1234");
+    verify(datafeedApiClient, times(2)).rotate();
+  }
 
-    @Test
-    void testStartClientErrorReadDatafeed() throws ApiException, AuthUnauthorizedException {
-        AckId ackId = datafeedService.getAckId();
-        when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(Collections.singletonList(new V5Datafeed().id("test-id")));
-        when(datafeedApi.createDatafeed("1234", "1234")).thenReturn(new V5Datafeed().id("recreate-df-id"));
-        when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(new ApiException(400, "client-error"));
-        when(datafeedApi.readDatafeed("recreate-df-id", "1234", "1234", ackId))
-                .thenReturn(new V5EventList().addEventsItem(new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id"));
+  @Test
+  void testStartClientErrorReadDatafeed() throws ApiException, AuthUnauthorizedException {
+    AckId ackId = datafeedService.getAckId();
+    when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(
+        Collections.singletonList(new V5Datafeed().id("test-id")));
+    when(datafeedApi.createDatafeed("1234", "1234")).thenReturn(new V5Datafeed().id("recreate-df-id"));
+    when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(new ApiException(400, "client-error"));
+    when(datafeedApi.readDatafeed("recreate-df-id", "1234", "1234", ackId))
+        .thenReturn(new V5EventList().addEventsItem(
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id"));
 
-        this.datafeedService.start();
-        verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
-        verify(datafeedApi, times(1)).readDatafeed("test-id", "1234", "1234", ackId);
-        verify(datafeedApi, times(1)).readDatafeed("recreate-df-id", "1234", "1234", ackId);
-        verify(datafeedApi, times(1)).createDatafeed("1234", "1234");
-        verify(datafeedApi, times(1)).deleteDatafeed("test-id", "1234", "1234");
-        verify(datafeedApiClient, times(1)).rotate();
-    }
+    this.datafeedService.start();
+    verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
+    verify(datafeedApi, times(1)).readDatafeed("test-id", "1234", "1234", ackId);
+    verify(datafeedApi, times(1)).readDatafeed("recreate-df-id", "1234", "1234", ackId);
+    verify(datafeedApi, times(1)).createDatafeed("1234", "1234");
+    verify(datafeedApi, times(1)).deleteDatafeed("test-id", "1234", "1234");
+    verify(datafeedApiClient, times(1)).rotate();
+  }
 
-    @Test
-    void testStartSocketTimeoutReadDatafeed() throws ApiException, AuthUnauthorizedException {
-        AckId ackId = datafeedService.getAckId();
-        when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(Collections.singletonList(new V5Datafeed().id("test-id")));
-        when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(new ProcessingException(new SocketTimeoutException()));
+  @Test
+  void testStartSocketTimeoutReadDatafeed() throws ApiException, AuthUnauthorizedException {
+    AckId ackId = datafeedService.getAckId();
+    when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(
+        Collections.singletonList(new V5Datafeed().id("test-id")));
+    when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(
+        new ProcessingException(new SocketTimeoutException()));
 
-        ApiClient client = mock(ApiClient.class);
-        when(datafeedApi.getApiClient()).thenReturn(client);
-        when(client.getBasePath()).thenReturn("path/to/the/agent");
+    ApiClient client = mock(ApiClient.class);
+    when(datafeedApi.getApiClient()).thenReturn(client);
+    when(client.getBasePath()).thenReturn("path/to/the/agent");
 
-        this.datafeedService.start();
-        verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
-        verify(datafeedApi, times(2)).readDatafeed("test-id", "1234", "1234", ackId);
-        verify(datafeedApiClient, times(2)).rotate();
-    }
+    this.datafeedService.start();
+    verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
+    verify(datafeedApi, times(2)).readDatafeed("test-id", "1234", "1234", ackId);
+    verify(datafeedApiClient, times(2)).rotate();
+  }
 
-    @Test
-    void testStartAuthErrorReadDatafeed() throws ApiException, AuthUnauthorizedException {
-        AckId ackId = datafeedService.getAckId();
-        when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(Collections.singletonList(new V5Datafeed().id("test-id")));
-        when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(new ApiException(401, "client-error"));
-        doThrow(AuthUnauthorizedException.class).when(authSession).refresh();
+  @Test
+  void testStartAuthErrorReadDatafeed() throws ApiException, AuthUnauthorizedException {
+    AckId ackId = datafeedService.getAckId();
+    when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(
+        Collections.singletonList(new V5Datafeed().id("test-id")));
+    when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(new ApiException(401, "client-error"));
+    doThrow(AuthUnauthorizedException.class).when(authSession).refresh();
 
-        assertThrows(AuthUnauthorizedException.class, this.datafeedService::start);
-        verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
-        verify(datafeedApi, times(1)).readDatafeed("test-id", "1234", "1234", ackId);
-        verify(authSession, times(1)).refresh();
-        verify(datafeedApiClient, times(1)).rotate();
-    }
+    assertThrows(AuthUnauthorizedException.class, this.datafeedService::start);
+    verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
+    verify(datafeedApi, times(1)).readDatafeed("test-id", "1234", "1234", ackId);
+    verify(authSession, times(1)).refresh();
+    verify(datafeedApiClient, times(1)).rotate();
+  }
 
-    @Test
-    void testStartServerErrorReadDatafeed() throws ApiException {
-        AckId ackId = datafeedService.getAckId();
-        when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(Collections.singletonList(new V5Datafeed().id("test-id")));
-        when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(new ApiException(502, "client-error"));
+  @Test
+  void testStartServerErrorReadDatafeed() throws ApiException {
+    AckId ackId = datafeedService.getAckId();
+    when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(
+        Collections.singletonList(new V5Datafeed().id("test-id")));
+    when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(new ApiException(502, "client-error"));
 
-        assertThrows(ApiException.class, this.datafeedService::start);
-        verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
-        verify(datafeedApi, times(2)).readDatafeed("test-id", "1234", "1234", ackId);
-        verify(datafeedApiClient, times(2)).rotate();
-    }
+    assertThrows(ApiException.class, this.datafeedService::start);
+    verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
+    verify(datafeedApi, times(2)).readDatafeed("test-id", "1234", "1234", ackId);
+    verify(datafeedApiClient, times(2)).rotate();
+  }
 
-    @Test
-    void testStartInternalServerErrorReadDatafeedShouldNotBeRetried() throws ApiException {
-        AckId ackId = datafeedService.getAckId();
-        when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(Collections.singletonList(new V5Datafeed().id("test-id")));
-        when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(new ApiException(500, "client-error"));
+  @Test
+  void testStartInternalServerErrorReadDatafeedShouldNotBeRetried() throws ApiException {
+    AckId ackId = datafeedService.getAckId();
+    when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(
+        Collections.singletonList(new V5Datafeed().id("test-id")));
+    when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(new ApiException(500, "client-error"));
 
-        assertThrows(ApiException.class, this.datafeedService::start);
-        verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
-        verify(datafeedApi, times(1)).readDatafeed("test-id", "1234", "1234", ackId);
-        verify(datafeedApiClient, times(1)).rotate();
-    }
+    assertThrows(ApiException.class, this.datafeedService::start);
+    verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
+    verify(datafeedApi, times(1)).readDatafeed("test-id", "1234", "1234", ackId);
+    verify(datafeedApiClient, times(1)).rotate();
+  }
 
-    @Test
-    void testStartTooManyRequestsReadDatafeedShouldBeRetried() throws ApiException {
-        AckId ackId = datafeedService.getAckId();
-        when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(Collections.singletonList(new V5Datafeed().id("test-id")));
-        when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(new ApiException(429, "too-many-requests"));
+  @Test
+  void testStartTooManyRequestsReadDatafeedShouldBeRetried() throws ApiException {
+    AckId ackId = datafeedService.getAckId();
+    when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(
+        Collections.singletonList(new V5Datafeed().id("test-id")));
+    when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(
+        new ApiException(429, "too-many-requests"));
 
-        assertThrows(ApiException.class, this.datafeedService::start);
-        verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
-        verify(datafeedApi, times(2)).readDatafeed("test-id", "1234", "1234", ackId);
-        verify(datafeedApiClient, times(2)).rotate();
-    }
+    assertThrows(ApiException.class, this.datafeedService::start);
+    verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
+    verify(datafeedApi, times(2)).readDatafeed("test-id", "1234", "1234", ackId);
+    verify(datafeedApiClient, times(2)).rotate();
+  }
 
-    @Test
-    void testStartClientErrorDeleteDatafeed() throws ApiException, AuthUnauthorizedException {
-        AckId ackId = datafeedService.getAckId();
-        when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(Collections.singletonList(new V5Datafeed().id("test-id")));
-        when(datafeedApi.createDatafeed("1234", "1234")).thenReturn(new V5Datafeed().id("recreate-df-id"));
-        when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(new ApiException(400, "client-error"));
-        when(datafeedApi.readDatafeed("recreate-df-id", "1234", "1234", ackId))
-                .thenReturn(new V5EventList().addEventsItem(new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id"));
-        when(datafeedApi.deleteDatafeed("test-id", "1234", "1234")).thenThrow(new ApiException(400, "client-error"));
+  @Test
+  void testStartClientErrorDeleteDatafeed() throws ApiException, AuthUnauthorizedException {
+    AckId ackId = datafeedService.getAckId();
+    when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(
+        Collections.singletonList(new V5Datafeed().id("test-id")));
+    when(datafeedApi.createDatafeed("1234", "1234")).thenReturn(new V5Datafeed().id("recreate-df-id"));
+    when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(new ApiException(400, "client-error"));
+    when(datafeedApi.readDatafeed("recreate-df-id", "1234", "1234", ackId))
+        .thenReturn(new V5EventList().addEventsItem(
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id"));
+    when(datafeedApi.deleteDatafeed("test-id", "1234", "1234")).thenThrow(new ApiException(400, "client-error"));
 
-        this.datafeedService.start();
-        verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
-        verify(datafeedApi, times(1)).readDatafeed("test-id", "1234", "1234", ackId);
-        verify(datafeedApi, times(1)).readDatafeed("recreate-df-id", "1234", "1234", ackId);
-        verify(datafeedApi, times(1)).createDatafeed("1234", "1234");
-        verify(datafeedApi, times(1)).deleteDatafeed("test-id", "1234", "1234");
-        verify(datafeedApiClient, times(1)).rotate();
-    }
+    this.datafeedService.start();
+    verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
+    verify(datafeedApi, times(1)).readDatafeed("test-id", "1234", "1234", ackId);
+    verify(datafeedApi, times(1)).readDatafeed("recreate-df-id", "1234", "1234", ackId);
+    verify(datafeedApi, times(1)).createDatafeed("1234", "1234");
+    verify(datafeedApi, times(1)).deleteDatafeed("test-id", "1234", "1234");
+    verify(datafeedApiClient, times(1)).rotate();
+  }
 
-    @Test
-    void testStartServerErrorDeleteDatafeed() throws ApiException {
-        AckId ackId = datafeedService.getAckId();
-        when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(Collections.singletonList(new V5Datafeed().id("test-id")));
-        when(datafeedApi.createDatafeed("1234", "1234")).thenReturn(new V5Datafeed().id("recreate-df-id"));
-        when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(new ApiException(400, "client-error"));
-        when(datafeedApi.deleteDatafeed("test-id", "1234", "1234")).thenThrow(new ApiException(502, "client-error"));
+  @Test
+  void testStartServerErrorDeleteDatafeed() throws ApiException {
+    AckId ackId = datafeedService.getAckId();
+    when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(
+        Collections.singletonList(new V5Datafeed().id("test-id")));
+    when(datafeedApi.createDatafeed("1234", "1234")).thenReturn(new V5Datafeed().id("recreate-df-id"));
+    when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(new ApiException(400, "client-error"));
+    when(datafeedApi.deleteDatafeed("test-id", "1234", "1234")).thenThrow(new ApiException(502, "client-error"));
 
-        assertThrows(NestedRetryException.class, this.datafeedService::start);
-        verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
-        verify(datafeedApi, times(1)).readDatafeed("test-id", "1234", "1234", ackId);
-        verify(datafeedApi, times(2)).deleteDatafeed("test-id", "1234", "1234");
-        verify(datafeedApiClient, times(3)).rotate();
-    }
+    assertThrows(NestedRetryException.class, this.datafeedService::start);
+    verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
+    verify(datafeedApi, times(1)).readDatafeed("test-id", "1234", "1234", ackId);
+    verify(datafeedApi, times(2)).deleteDatafeed("test-id", "1234", "1234");
+    verify(datafeedApiClient, times(3)).rotate();
+  }
 
-    @Test
-    void testStartAuthErrorDeleteDatafeed() throws ApiException, AuthUnauthorizedException {
-        AckId ackId = datafeedService.getAckId();
-        when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(Collections.singletonList(new V5Datafeed().id("test-id")));
-        when(datafeedApi.createDatafeed("1234", "1234")).thenReturn(new V5Datafeed().id("recreate-df-id"));
-        when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(new ApiException(400, "client-error"));
-        when(datafeedApi.deleteDatafeed("test-id", "1234", "1234")).thenThrow(new ApiException(401, "client-error"));
-        doThrow(AuthUnauthorizedException.class).when(authSession).refresh();
+  @Test
+  void testStartAuthErrorDeleteDatafeed() throws ApiException, AuthUnauthorizedException {
+    AckId ackId = datafeedService.getAckId();
+    when(datafeedApi.listDatafeed("1234", "1234")).thenReturn(
+        Collections.singletonList(new V5Datafeed().id("test-id")));
+    when(datafeedApi.createDatafeed("1234", "1234")).thenReturn(new V5Datafeed().id("recreate-df-id"));
+    when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(new ApiException(400, "client-error"));
+    when(datafeedApi.deleteDatafeed("test-id", "1234", "1234")).thenThrow(new ApiException(401, "client-error"));
+    doThrow(AuthUnauthorizedException.class).when(authSession).refresh();
 
-        assertThrows(NestedRetryException.class, this.datafeedService::start);
-        verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
-        verify(datafeedApi, times(1)).readDatafeed("test-id", "1234", "1234", ackId);
-        verify(datafeedApi, times(1)).deleteDatafeed("test-id", "1234", "1234");
-        verify(datafeedApiClient, times(2)).rotate();
-    }
+    assertThrows(NestedRetryException.class, this.datafeedService::start);
+    verify(datafeedApi, times(1)).listDatafeed("1234", "1234");
+    verify(datafeedApi, times(1)).readDatafeed("test-id", "1234", "1234", ackId);
+    verify(datafeedApi, times(1)).deleteDatafeed("test-id", "1234", "1234");
+    verify(datafeedApiClient, times(2)).rotate();
+  }
 }


### PR DESCRIPTION
A ConcurrentModificationException can happen in the Datafeed (DF) loop upon startup.
The access to the listeners collection in the DF loop is not protected
and accessed by multiple threads.

Because of the for loop we need to synchronize on the list itself.

Fixes #475 