### PR TITLE
PLAT-10720 - Add configuration to disable reusing datafeed id

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkDatafeedConfig.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/config/model/BdkDatafeedConfig.java
@@ -11,17 +11,26 @@ import java.io.File;
 @API(status = API.Status.STABLE)
 public class BdkDatafeedConfig {
 
-    private String version = "v1";
-    private String idFilePath;
-    private BdkRetryConfig retry = new BdkRetryConfig(BdkRetryConfig.INFINITE_MAX_ATTEMPTS);
+  private String version = "v1";
+  private String idFilePath;
+  private BdkRetryConfig retry = new BdkRetryConfig(BdkRetryConfig.INFINITE_MAX_ATTEMPTS);
+  private Boolean reuseDatafeedId;
 
-    public String getIdFilePath() {
-        if (idFilePath == null || idFilePath.isEmpty()) {
-            return "." + File.separator;
-        }
-        if (!idFilePath.endsWith(File.separator)) {
-            return idFilePath + File.separator;
-        }
-        return idFilePath;
+  public String getIdFilePath() {
+    if (idFilePath == null || idFilePath.isEmpty()) {
+      return "." + File.separator;
     }
+    if (!idFilePath.endsWith(File.separator)) {
+      return idFilePath + File.separator;
+    }
+    return idFilePath;
+  }
+
+  public boolean getReuseDatafeedId() {
+    if (reuseDatafeedId == null) {
+      return true;
+    } else {
+      return reuseDatafeedId;
+    }
+  }
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV1.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV1.java
@@ -50,7 +50,8 @@ public class DatafeedLoopV1 extends AbstractDatafeedLoop {
   private String datafeedId;
 
   public DatafeedLoopV1(DatafeedApi datafeedApi, AuthSession authSession, BdkConfig config) {
-    this(datafeedApi, authSession, config, new OnDiskDatafeedIdRepository(config));
+    this(datafeedApi, authSession, config, config.getDatafeed().getReuseDatafeedId() ?
+        new OnDiskDatafeedIdRepository(config) : new InMemoryDatafeedIdRepository(config));
   }
 
   public DatafeedLoopV1(DatafeedApi datafeedApi, AuthSession authSession, BdkConfig config,

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/InMemoryDatafeedIdRepository.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/InMemoryDatafeedIdRepository.java
@@ -1,0 +1,58 @@
+package com.symphony.bdk.core.service.datafeed.impl;
+
+import com.symphony.bdk.core.config.model.BdkConfig;
+import com.symphony.bdk.core.service.datafeed.DatafeedIdRepository;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apiguardian.api.API;
+
+/**
+ * The implementation of {@link DatafeedIdRepository} interface for a
+ * non-persistent in memory Datafeed.
+ */
+@Slf4j
+@API(status = API.Status.INTERNAL)
+public class InMemoryDatafeedIdRepository implements DatafeedIdRepository {
+
+  private final BdkConfig config;
+  private String datafeedId = null;
+  private String agentBasePath = null;
+
+  public InMemoryDatafeedIdRepository(BdkConfig config) {
+    this.config = config;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void write(String datafeedId) {
+    write(datafeedId, this.config.getAgent().getBasePath());
+  }
+
+  public void write(String datafeedId, String agentBasePath) {
+    log.debug("Writing datafeed id {} to memory.", datafeedId);
+    this.datafeedId = datafeedId;
+    this.agentBasePath = agentBasePath;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Optional<String> read() {
+    if (datafeedId == null) {
+      return Optional.empty();
+    } else {
+      return Optional.of(datafeedId);
+    }
+  }
+
+  public Optional<String> readAgentBasePath() {
+    if (agentBasePath == null) {
+      return Optional.empty();
+    } else {
+      return Optional.of(agentBasePath);
+    }
+  }
+}

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/config/BdkConfigTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/config/BdkConfigTest.java
@@ -1,9 +1,7 @@
 package com.symphony.bdk.core.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.symphony.bdk.core.client.exception.ApiClientInitializationException;
 import com.symphony.bdk.core.config.model.BdkBotConfig;
@@ -97,5 +95,17 @@ public class BdkConfigTest {
     assertThat(config.getDatafeed().getRetry().getInitialIntervalMillis()).isEqualTo(BdkRetryConfig.DEFAULT_INITIAL_INTERVAL_MILLIS);
     assertThat(config.getDatafeed().getRetry().getMultiplier()).isEqualTo(BdkRetryConfig.DEFAULT_MULTIPLIER);
     assertThat(config.getDatafeed().getRetry().getMaxIntervalMillis()).isEqualTo(BdkRetryConfig.DEFAULT_MAX_INTERVAL_MILLIS);
+  }
+
+  @Test
+  void checkDatafeedPersistenceFalse() throws Exception {
+    final BdkConfig config = BdkConfigLoader.loadFromClasspath("/config/df_no_reuse.yaml");
+    assertFalse(config.getDatafeed().getReuseDatafeedId());
+  }
+
+  @Test
+  void checkDatafeedPersistenceNotSet() throws Exception {
+    final BdkConfig config = BdkConfigLoader.loadFromClasspath("/config/config.yaml");
+    assertTrue(config.getDatafeed().getReuseDatafeedId());
   }
 }

--- a/symphony-bdk-core/src/test/resources/config/df_no_reuse.yaml
+++ b/symphony-bdk-core/src/test/resources/config/df_no_reuse.yaml
@@ -1,0 +1,2 @@
+datafeed:
+  reuseDatafeedId: false


### PR DESCRIPTION
### Ticket
PLAT-10720

### Description
Add configuration value to bypass the reusing of datafeed id as some sites do not handle this properly.