### PR TITLE
#483 Jwt Cookie set with SameSite=Strict

### DIFF
--- a/docs/spring-boot/app-starter.md
+++ b/docs/spring-boot/app-starter.md
@@ -91,6 +91,7 @@ bdk-app:
       enabled: true # activate the CircleOfTrust endpoints (default is true)
       jwtCookie:
         enabled: true # activate the jwt cookie storage (default is false)
+        sameSite: Strict # same site configuration to restrict the jwt cookie from cross-site domain (default is Strict)
         expireIn: 1d # jwt cookie duration (default value is 1d, see https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-conversion-duration) 
     cors: # enable Cross-Origin Resource Sharing (CORS) communication
       "[/**]": # url mapping

--- a/symphony-bdk-examples/bdk-app-spring-boot-example/src/main/resources/application.yaml
+++ b/symphony-bdk-examples/bdk-app-spring-boot-example/src/main/resources/application.yaml
@@ -18,6 +18,7 @@ bdk-app:
     jwtCookie:
       enabled: true
       maxAge: 1d
+      sameSite: None
   cors:
     "[/**]":
       allowed-origins: "*"

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/auth/CircleOfTrustController.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/auth/CircleOfTrustController.java
@@ -68,7 +68,7 @@ public class CircleOfTrustController {
         .secure(true)
         .httpOnly(true)
         .path(path)
-        .sameSite("None") // Cookie is always sent in cross-site requests.
+        .sameSite("Strict")
         .build();
   }
 

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/auth/CircleOfTrustController.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/auth/CircleOfTrustController.java
@@ -61,6 +61,8 @@ public class CircleOfTrustController {
 
   private ResponseCookie jwtCookie(String jwt, String path) {
     final int maxAgeInSeconds = (int) this.properties.getAuth().getJwtCookie().getMaxAge().getSeconds();
+    final String sameSite = this.properties.getAuth().getJwtCookie().getSameSite();
+
     log.debug("Creating JWT cookie: maxAge={}s", maxAgeInSeconds);
 
     return ResponseCookie.from("userJwt", jwt)
@@ -68,7 +70,7 @@ public class CircleOfTrustController {
         .secure(true)
         .httpOnly(true)
         .path(path)
-        .sameSite("Strict")
+        .sameSite(sameSite)
         .build();
   }
 

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/properties/JwtCookieProperties.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/properties/JwtCookieProperties.java
@@ -22,6 +22,11 @@ public class JwtCookieProperties {
   private Boolean enabled = false;
 
   /**
+   * The SameSite attribute for JWT cookie. Default: Strict
+   */
+  private String sameSite = "Strict";
+
+  /**
    * The maximum duration that the JWT will be stored in cookie.
    */
   @DurationUnit(ChronoUnit.SECONDS)

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/auth/CircleOfTrustControllerTest.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/auth/CircleOfTrustControllerTest.java
@@ -135,7 +135,7 @@ public class CircleOfTrustControllerTest {
 
     final MockCookie cookie = (MockCookie) response.getCookie("userJwt");
     assertNotNull(cookie);
-    assertEquals("None", cookie.getSameSite());
+    assertEquals("Strict", cookie.getSameSite());
     assertTrue(cookie.isHttpOnly());
     assertTrue(cookie.getSecure());
     assertEquals(this.appProperties.getAuth().getJwtCookie().getMaxAge().getSeconds(), cookie.getMaxAge());


### PR DESCRIPTION
### Ticket
Closes #483

### Description
The request to /bdk/v1/app/auth appears to be vulnerable
to cross-site request forgery (CSRF) attacks against authenticated users.

The request can be issued cross-domain.
The BDK relies solely on HTTP cookies to identify the user that issued the request.
The request performs some privileged action within the application, which returns a token.
The attacker can determine all the parameters required to construct a request that
performs the action. If the request contains any values that the attacker cannot
determine or predict, then it is not vulnerable.

Setting the SameSite=Strict will prevent sending the cookie when the request is done from another domain.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
