### PR TITLE
Clarify stickiness on Agent LB is only needed for DFv1

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -190,7 +190,7 @@ The `agent.loadBalancing` part of the configuration contains the information in 
 None of the fields `scheme`, `host`, `port`, `context` should be set if field `loadBalancing` is defined.
 Fields inside `loadBalancing` are:
 - `mode`: mandatory, can be `external`, `roundRobin` or `random`.
-- `stickiness`: optional boolean, default value is true.
+- `stickiness`: optional boolean, default value is true. (DFv2 does not need to be persisted therefore stickiness is only required for DFv1)
 - `nodes`: mandatory and must contain at least one element. List items must have at least `host` field put and can contain the following other fields: `scheme`, `port`, `context`.
 
 `roundRobin` and `random` modes mean calls to the agent are load balanced across all `nodes`, respectively in a round robin and random fashion.


### PR DESCRIPTION
### Description
DFv2 is using long polling and the agent is not storing any feedId (as for DFv1) so there’s no need to always call the same instance of the Agent for a given feedId. That's why the stickiness of a load balancer is only needed in case of DFv1.

### Dependencies
No dependency on this PR.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
