### PR TITLE
Whitesource: remove unused dependency

### DIFF
--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     // import Spring Boot's BOM
-    api platform('org.springframework.boot:spring-boot-dependencies:2.4.3')
+    api platform('org.springframework.boot:spring-boot-dependencies:2.4.5')
 
     // define all our dependencies versions
     constraints {

--- a/symphony-bdk-examples/bdk-app-spring-boot-example/build.gradle
+++ b/symphony-bdk-examples/bdk-app-spring-boot-example/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'bdk.java-common-conventions'
-    id 'org.springframework.boot' version "2.4.3"
+    id 'org.springframework.boot' version "2.4.5"
 }
 
 description = 'Symphony Java BDK Examples for the SpringBoot integration'

--- a/symphony-bdk-examples/bdk-multi-instances-example/build.gradle
+++ b/symphony-bdk-examples/bdk-multi-instances-example/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'bdk.java-common-conventions'
-    id 'org.springframework.boot' version "2.4.3"
+    id 'org.springframework.boot' version "2.4.5"
 }
 
 description = 'How to run multiple bot instances in //'

--- a/symphony-bdk-examples/bdk-spring-boot-example/build.gradle
+++ b/symphony-bdk-examples/bdk-spring-boot-example/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'bdk.java-common-conventions'
-    id 'org.springframework.boot' version "2.4.3"
+    id 'org.springframework.boot' version "2.4.5"
 }
 
 description = 'Symphony Java BDK Examples for the SpringBoot integration'

--- a/symphony-bdk-http/symphony-bdk-http-webclient/build.gradle
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/build.gradle
@@ -29,7 +29,6 @@ dependencies {
 
     implementation 'org.apiguardian:apiguardian-api'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
-    implementation 'org.projectreactor:reactor-spring'
 
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'ch.qos.logback:logback-classic'


### PR DESCRIPTION
reactor-spring does not seem to be required and is introducing a
dependency on json-smart that has a high vulnerability.

Closes #500 #499 #498 #497 
