### PR TITLE
#504 DatafeedLoop now retries on 500 server errors

### DIFF
--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV1Test.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV1Test.java
@@ -259,7 +259,7 @@ class DatafeedLoopV1Test {
     when(datafeedApi.v4DatafeedIdReadGet("persisted-id", "1234", "1234", null))
         .thenThrow(new ApiException(400, "expired DF id"));
     when(datafeedApi.v4DatafeedCreatePost("1234", "1234"))
-        .thenThrow(new ApiException(500, "unhandled exception"));
+        .thenThrow(new ApiException(404, "unhandled exception"));
 
     assertThrows(NestedRetryException.class, () -> this.datafeedService.start());
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2Test.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2Test.java
@@ -531,7 +531,7 @@ class DatafeedLoopV2Test {
     AckId ackId = datafeedService.getAckId();
     when(datafeedApi.listDatafeed("1234", "1234", "tibot")).thenReturn(
         Collections.singletonList(new V5Datafeed().id("test-id")));
-    when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(new ApiException(500, "client-error"));
+    when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(new ApiException(404, "client-error"));
 
     assertThrows(ApiException.class, this.datafeedService::start);
     verify(datafeedApi, times(1)).listDatafeed("1234", "1234", "tibot");

--- a/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/ApiException.java
+++ b/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/ApiException.java
@@ -81,7 +81,7 @@ public class ApiException extends Exception {
      * @return true if response status strictly greater than 500, false otherwise
      */
     public boolean isServerError() {
-        return this.code > HttpURLConnection.HTTP_INTERNAL_ERROR;
+        return this.code >= HttpURLConnection.HTTP_INTERNAL_ERROR;
     }
 
     /**

--- a/symphony-bdk-http/symphony-bdk-http-api/src/test/java/com/symphony/bdk/http/api/ApiExceptionTest.java
+++ b/symphony-bdk-http/symphony-bdk-http-api/src/test/java/com/symphony/bdk/http/api/ApiExceptionTest.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.http.api;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -8,9 +9,10 @@ class ApiExceptionTest {
 
   @Test
   void isServerError() {
+    assertFalse(new ApiException(499, "An error").isServerError());
     assertTrue(new ApiException(500, "Internal Server Error").isServerError());
-    assertTrue(new ApiException(502, "Internal Server Error").isServerError());
-    assertTrue(new ApiException(503, "Internal Server Error").isServerError());
+    assertTrue(new ApiException(502, "Bad Gateway").isServerError());
+    assertTrue(new ApiException(503, "Service Unavailable").isServerError());
   }
 
   @Test

--- a/symphony-bdk-http/symphony-bdk-http-api/src/test/java/com/symphony/bdk/http/api/ApiExceptionTest.java
+++ b/symphony-bdk-http/symphony-bdk-http-api/src/test/java/com/symphony/bdk/http/api/ApiExceptionTest.java
@@ -1,0 +1,30 @@
+package com.symphony.bdk.http.api;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ApiExceptionTest {
+
+  @Test
+  void isServerError() {
+    assertTrue(new ApiException(500, "Internal Server Error").isServerError());
+    assertTrue(new ApiException(502, "Internal Server Error").isServerError());
+    assertTrue(new ApiException(503, "Internal Server Error").isServerError());
+  }
+
+  @Test
+  void isUnauthorized() {
+    assertTrue(new ApiException(401, "Unauthorized").isUnauthorized());
+  }
+
+  @Test
+  void isClientError() {
+    assertTrue(new ApiException(400, "Bad Request").isClientError());
+  }
+
+  @Test
+  void isTooManyRequestsError() {
+    assertTrue(new ApiException(429, "Too Many Requests").isTooManyRequestsError());
+  }
+}


### PR DESCRIPTION
### Ticket
Fixes https://github.com/finos/symphony-bdk-java/issues/504

### Description
We recently noticed that the DatafeedLoop was crashing with `500` errors returned from Agent. This is something we initially stated that we did not wanted to retry on this specific status. Now we do :) It has actually been raised by some customers. 

Will have to be backported to `2.1-rc` branch. 