### PR TITLE
#513 log ssl certs loaded by the bot

### DIFF
--- a/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/util/ApiUtils.java
+++ b/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/util/ApiUtils.java
@@ -4,12 +4,8 @@ import org.apiguardian.api.API;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
 import java.util.Collections;
 
 @API(status = API.Status.INTERNAL)
@@ -26,18 +22,12 @@ public final class ApiUtils {
     return "Symphony-BDK-Java/" + getBdkVersion() + " Java/" + System.getProperty("java.version");
   }
 
-  public static KeyStore createAndLogTrustStore(String keyStoreType, InputStream keyStoreBytes, char[] keyStorePassword)
-      throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {
-    final KeyStore trustStore = KeyStore.getInstance(keyStoreType);
-    trustStore.load(keyStoreBytes, keyStorePassword);
-
+  public static void logTrustStore(KeyStore trustStore) throws KeyStoreException {
     if (log.isDebugEnabled()) {
       for (String alias : Collections.list(trustStore.aliases())) {
         log.debug("Loading {} from truststore", alias);
       }
     }
-
-    return trustStore;
   }
 
   private static String getBdkVersion() {

--- a/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/util/ApiUtils.java
+++ b/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/util/ApiUtils.java
@@ -1,9 +1,21 @@
 package com.symphony.bdk.http.api.util;
 
 import org.apiguardian.api.API;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.Collections;
 
 @API(status = API.Status.INTERNAL)
 public final class ApiUtils {
+
+  private static final Logger log = LoggerFactory.getLogger(ApiUtils.class);
 
   /**
    * Creates a user agent string used for the User-Agent header
@@ -12,6 +24,20 @@ public final class ApiUtils {
    */
   public static String getUserAgent() {
     return "Symphony-BDK-Java/" + getBdkVersion() + " Java/" + System.getProperty("java.version");
+  }
+
+  public static KeyStore createAndLogTrustStore(String keyStoreType, InputStream keyStoreBytes, char[] keyStorePassword)
+      throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {
+    final KeyStore trustStore = KeyStore.getInstance(keyStoreType);
+    trustStore.load(keyStoreBytes, keyStorePassword);
+
+    if (log.isDebugEnabled()) {
+      for (String alias : Collections.list(trustStore.aliases())) {
+        log.debug("Loading {} from truststore", alias);
+      }
+    }
+
+    return trustStore;
   }
 
   private static String getBdkVersion() {

--- a/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientBuilderJersey2.java
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientBuilderJersey2.java
@@ -19,6 +19,7 @@ import org.glassfish.jersey.media.multipart.MultiPartFeature;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
@@ -258,8 +259,9 @@ public class ApiClientBuilderJersey2 implements ApiClientBuilder {
       SSLContext sslContext = sslConfig.createSSLContext();
 
       if (isNotEmpty(trustStoreBytes) && isNotEmpty(trustStorePassword)) {
-        ApiUtils.createAndLogTrustStore(TRUSTSTORE_FORMAT, new ByteArrayInputStream(trustStoreBytes),
-            trustStorePassword.toCharArray());
+        final KeyStore truststore = KeyStore.getInstance(TRUSTSTORE_FORMAT);
+        truststore.load(new ByteArrayInputStream(trustStoreBytes), trustStorePassword.toCharArray());
+        ApiUtils.logTrustStore(truststore);
       }
 
       return sslContext;

--- a/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientBuilderJersey2.java
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientBuilderJersey2.java
@@ -17,12 +17,23 @@ import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.net.ssl.SSLContext;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Specific implementation of {@link ApiClientBuilder} which creates a new instance of an {@link ApiClientJersey2}.
@@ -34,6 +45,8 @@ import javax.ws.rs.client.ClientBuilder;
 @API(status = API.Status.STABLE)
 public class ApiClientBuilderJersey2 implements ApiClientBuilder {
 
+  private static final Logger logger = LoggerFactory.getLogger(ApiClientBuilderJersey2.class);
+  private static final String TRUSTSTORE_FORMAT = "JKS";
   protected String basePath;
   protected byte[] keyStoreBytes;
   protected String keyStorePassword;
@@ -240,6 +253,21 @@ public class ApiClientBuilderJersey2 implements ApiClientBuilder {
       sslConfig
           .trustStoreBytes(trustStoreBytes)
           .trustStorePassword(trustStorePassword);
+      // if logging debug is enabled, we print the truststore entries
+      if (logger.isDebugEnabled()) {
+        final KeyStore truststore;
+        try {
+          truststore = KeyStore.getInstance(TRUSTSTORE_FORMAT);
+          truststore.load(new ByteArrayInputStream(trustStoreBytes), trustStorePassword.toCharArray());
+          final List<String> aliases = Collections.list(truststore.aliases());
+          logger.debug("Your custom truststore contains {} entries :", aliases.size());
+          for (String alias : aliases) {
+            logger.debug("# {}", alias);
+          }
+        } catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException e) {
+          e.printStackTrace();
+        }
+      }
     }
 
     if (isNotEmpty(keyStoreBytes) && isNotEmpty(keyStorePassword)) {

--- a/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientBuilderJersey2.java
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientBuilderJersey2.java
@@ -47,6 +47,7 @@ public class ApiClientBuilderJersey2 implements ApiClientBuilder {
 
   private static final Logger logger = LoggerFactory.getLogger(ApiClientBuilderJersey2.class);
   private static final String TRUSTSTORE_FORMAT = "JKS";
+
   protected String basePath;
   protected byte[] keyStoreBytes;
   protected String keyStorePassword;
@@ -253,20 +254,10 @@ public class ApiClientBuilderJersey2 implements ApiClientBuilder {
       sslConfig
           .trustStoreBytes(trustStoreBytes)
           .trustStorePassword(trustStorePassword);
+
       // if logging debug is enabled, we print the truststore entries
       if (logger.isDebugEnabled()) {
-        final KeyStore truststore;
-        try {
-          truststore = KeyStore.getInstance(TRUSTSTORE_FORMAT);
-          truststore.load(new ByteArrayInputStream(trustStoreBytes), trustStorePassword.toCharArray());
-          final List<String> aliases = Collections.list(truststore.aliases());
-          logger.debug("Your custom truststore contains {} entries :", aliases.size());
-          for (String alias : aliases) {
-            logger.debug("# {}", alias);
-          }
-        } catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException e) {
-          e.printStackTrace();
-        }
+        this.logTrustStore();
       }
     }
 
@@ -278,7 +269,21 @@ public class ApiClientBuilderJersey2 implements ApiClientBuilder {
     try {
       return sslConfig.createSSLContext();
     } catch (IllegalStateException e) {
-        throw new IllegalStateException(e.getCause().getMessage(), e);
+      throw new IllegalStateException(e.getCause().getMessage(), e);
+    }
+  }
+
+  private void logTrustStore() {
+    try {
+      final KeyStore truststore = KeyStore.getInstance(TRUSTSTORE_FORMAT);
+      truststore.load(new ByteArrayInputStream(trustStoreBytes), trustStorePassword.toCharArray());
+      final List<String> aliases = Collections.list(truststore.aliases());
+      logger.debug("Your custom truststore contains {} entries :", aliases.size());
+      for (String alias : aliases) {
+        logger.debug("# {}", alias);
+      }
+    } catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException e) {
+      throw new RuntimeException(e);
     }
   }
 }

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClient.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClient.java
@@ -23,7 +23,9 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -206,6 +208,15 @@ public class ApiClientBuilderWebClient implements ApiClientBuilder {
           keyStore.load(new ByteArrayInputStream(this.keyStoreBytes), this.keyStorePassword.toCharArray());
           keyManagerFactory.init(keyStore, this.keyStorePassword.toCharArray());
           builder.keyManager(keyManagerFactory);
+        }
+
+        // if logging debug is enabled, we print the truststore entries
+        if (log.isDebugEnabled()) {
+          final List<String> aliases = Collections.list(trustStore.aliases());
+          log.debug("Your custom truststore contains {} entries :", aliases.size());
+          for (String alias : aliases) {
+            log.debug("# {}", alias);
+          }
         }
       }
       return builder.build();

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClient.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClient.java
@@ -200,15 +200,15 @@ public class ApiClientBuilderWebClient implements ApiClientBuilder {
         trustStore.load(new ByteArrayInputStream(this.trustStoreBytes), this.trustStorePassword.toCharArray());
         trustManagerFactory.init(trustStore);
         builder.trustManager(trustManagerFactory);
+        ApiUtils.logTrustStore(trustStore);
+
         if (this.keyStoreBytes != null) {
+          final KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
           final KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-          final KeyStore keyStore =
-              ApiUtils.createAndLogTrustStore(KeyStore.getDefaultType(), new ByteArrayInputStream(this.keyStoreBytes),
-                  this.keyStorePassword.toCharArray());
+          keyStore.load(new ByteArrayInputStream(this.keyStoreBytes), this.keyStorePassword.toCharArray());
           keyManagerFactory.init(keyStore, this.keyStorePassword.toCharArray());
           builder.keyManager(keyManagerFactory);
         }
-
       }
       return builder.build();
     } catch (KeyStoreException | IOException | NoSuchAlgorithmException | CertificateException | UnrecoverableKeyException e) {

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClient.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClient.java
@@ -23,9 +23,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -203,21 +201,14 @@ public class ApiClientBuilderWebClient implements ApiClientBuilder {
         trustManagerFactory.init(trustStore);
         builder.trustManager(trustManagerFactory);
         if (this.keyStoreBytes != null) {
-          final KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
           final KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-          keyStore.load(new ByteArrayInputStream(this.keyStoreBytes), this.keyStorePassword.toCharArray());
+          final KeyStore keyStore =
+              ApiUtils.createAndLogTrustStore(KeyStore.getDefaultType(), new ByteArrayInputStream(this.keyStoreBytes),
+                  this.keyStorePassword.toCharArray());
           keyManagerFactory.init(keyStore, this.keyStorePassword.toCharArray());
           builder.keyManager(keyManagerFactory);
         }
 
-        // if logging debug is enabled, we print the truststore entries
-        if (log.isDebugEnabled()) {
-          final List<String> aliases = Collections.list(trustStore.aliases());
-          log.debug("Your custom truststore contains {} entries :", aliases.size());
-          for (String alias : aliases) {
-            log.debug("# {}", alias);
-          }
-        }
       }
       return builder.build();
     } catch (KeyStoreException | IOException | NoSuchAlgorithmException | CertificateException | UnrecoverableKeyException e) {

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/test/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClientTest.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/test/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClientTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.symphony.bdk.http.api.ApiClient;
+import com.symphony.bdk.http.api.util.ApiUtils;
 
 import ch.qos.logback.classic.Level;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,7 +46,7 @@ public class ApiClientBuilderWebClientTest {
 
   @Test
   void buildTest() {
-    Logger logger = (Logger) LoggerFactory.getLogger(ApiClientBuilderWebClient.class);
+    Logger logger = (Logger) LoggerFactory.getLogger(ApiUtils.class);
     ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
     listAppender.start();
     logger.addAppender(listAppender);
@@ -61,8 +62,8 @@ public class ApiClientBuilderWebClientTest {
     // assert logs about truststore entries
     List<ILoggingEvent> logsList = listAppender.list;
     assertFalse(logsList.isEmpty(), "The list of log entries should not be empty");
-    assertEquals("Your custom truststore contains {} entries :", logsList.get(0).getMessage(),
-        "The list of logs should have an entry giving the size of truststore entries");
+    assertEquals("Loading {} from truststore", logsList.get(0).getMessage(),
+        "The list of logs should have at least on entry about one loaded cert");
     assertEquals(Level.DEBUG, logsList.get(0).getLevel(), "The entry level should be DEBUG");
   }
 

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/test/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClientTest.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/test/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClientTest.java
@@ -2,14 +2,23 @@ package com.symphony.bdk.http.webclient;
 
 import static org.apache.commons.io.IOUtils.toByteArray;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.symphony.bdk.http.api.ApiClient;
 
+import ch.qos.logback.classic.Level;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.slf4j.LoggerFactory;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
 import java.io.IOException;
+import java.util.List;
 
 public class ApiClientBuilderWebClientTest {
 
@@ -37,6 +46,11 @@ public class ApiClientBuilderWebClientTest {
 
   @Test
   void buildTest() {
+    Logger logger = (Logger) LoggerFactory.getLogger(ApiClientBuilderWebClient.class);
+    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    listAppender.start();
+    logger.addAppender(listAppender);
+
     builder.withTrustStore(truststore, "changeit");
     builder.withKeyStore(keystore, "password");
 
@@ -44,6 +58,14 @@ public class ApiClientBuilderWebClientTest {
 
     assertEquals(apiClient.getClass(), ApiClientWebClient.class);
     assertEquals(apiClient.getBasePath(), "test-base-path");
+
+    // assert logs about truststore entries
+    List<ILoggingEvent> logsList = listAppender.list;
+    assertFalse(logsList.isEmpty(), "The list of log entries should not be empty");
+    assertNotNull(logsList.get(0), "At least on entry in the list, should not be null");
+    assertEquals("Your custom truststore contains {} entries :", logsList.get(0).getMessage(),
+        "The list of logs should have an entry giving the size of truststore entries");
+    assertEquals(Level.DEBUG, logsList.get(0).getLevel(), "The entry level should be DEBUG");
   }
 
   @Test

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/test/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClientTest.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/test/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClientTest.java
@@ -3,7 +3,6 @@ package com.symphony.bdk.http.webclient;
 import static org.apache.commons.io.IOUtils.toByteArray;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.symphony.bdk.http.api.ApiClient;
@@ -62,7 +61,6 @@ public class ApiClientBuilderWebClientTest {
     // assert logs about truststore entries
     List<ILoggingEvent> logsList = listAppender.list;
     assertFalse(logsList.isEmpty(), "The list of log entries should not be empty");
-    assertNotNull(logsList.get(0), "At least on entry in the list, should not be null");
     assertEquals("Your custom truststore contains {} entries :", logsList.get(0).getMessage(),
         "The list of logs should have an entry giving the size of truststore entries");
     assertEquals(Level.DEBUG, logsList.get(0).getLevel(), "The entry level should be DEBUG");


### PR DESCRIPTION
### Ticket
[#513 ](https://github.com/finos/symphony-bdk-java/issues/513)

### Description
In order to help developers to debug ssl certs issues, a log has been added when the certs are loaded from the trustStore.
