### PR TITLE
#515 Unable to create SlashHandler with same value, different @mention

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/ActivityRegistry.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/ActivityRegistry.java
@@ -56,7 +56,8 @@ public class ActivityRegistry {
       Optional<AbstractActivity<?, ?>> act = this.activityList.stream()
           .filter(a -> a.getInfo().type().equals(ActivityType.COMMAND)
               && a.getInfo().name() != null
-              && a.getInfo().name().equals(activity.getInfo().name()))
+              && a.getInfo().name().equals(activity.getInfo().name())
+              && a.getInfo().requiresBotMention() == activity.getInfo().requiresBotMention())
           .findFirst();
 
       act.ifPresent(abstractActivity -> {

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/ActivityRegistry.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/ActivityRegistry.java
@@ -56,12 +56,14 @@ public class ActivityRegistry {
   private void preProcessActivity(AbstractActivity<?, ?> activity) {
 
     Optional<AbstractActivity<?, ?>> act = this.activityList.stream()
-        .filter(a -> a.getInfo().equals(activity.getInfo()))
+        .filter(a -> a.equals(activity))
         .findFirst();
 
     act.ifPresent(abstractActivity -> {
       abstractActivity.bindToRealTimeEventsSource(this.datafeedLoop::unsubscribe);
       this.activityList.remove(abstractActivity);
+      log.debug("One activity '{}' has been removed/unsubscribed in order to be replaced",
+          abstractActivity.getInfo().name());
     });
 
     // a command activity (potentially) needs the bot display name in order to parse the message text content

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/ActivityRegistry.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/ActivityRegistry.java
@@ -1,6 +1,8 @@
 package com.symphony.bdk.core.activity;
 
 import com.symphony.bdk.core.activity.command.CommandActivity;
+import com.symphony.bdk.core.activity.command.SlashCommand;
+import com.symphony.bdk.core.activity.command.HelpCommand;
 import com.symphony.bdk.core.service.datafeed.DatafeedLoop;
 import com.symphony.bdk.gen.api.model.UserV2;
 
@@ -14,6 +16,10 @@ import java.util.Optional;
 /**
  * This class allows to bind an {@link AbstractActivity} to the Real Time Events source, or Datafeed.
  * It also maintains the list of registered activities.
+ * <p>
+ * If an activity to be registered is already existing in the registry, then the old one will be replaced.
+ * In case of an activity of type {@link SlashCommand}, it will replace the old one if this latter has the same name and both require bot mention (or both don't).
+ * If the activity has /help as name, then it will replace {@link HelpCommand} if it is already registered.
  */
 @Slf4j
 @API(status = API.Status.STABLE)

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/HelpCommand.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/HelpCommand.java
@@ -51,7 +51,10 @@ public class HelpCommand extends PatternCommandActivity<CommandContext> {
         .filter(act -> !(act instanceof HelpCommand))
         .map(AbstractActivity::getInfo)
         .filter(info -> info.type().equals(ActivityType.COMMAND))
-        .map(info -> "<li>" + info.name() + " - " + info.description() + "</li>")
+        .map(info -> {
+          String str = "<li>" + info.name() + "%s" + "</li>";
+          return info.description().isEmpty() ? String.format(str, "") : String.format(str, " - " + info.description());
+        })
         .collect(Collectors.toList());
     if (!infos.isEmpty()) {
       String message = "<ul>" + String.join("\n", infos) + "</ul>";

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/HelpCommand.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/HelpCommand.java
@@ -10,6 +10,7 @@ import com.symphony.bdk.core.service.message.model.Message;
 import org.apiguardian.api.API;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -81,4 +82,8 @@ public class HelpCommand extends PatternCommandActivity<CommandContext> {
     return false;
   }
 
+  @Override
+  public int hashCode() {
+    return Objects.hash(activityRegistry, messageService);
+  }
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/HelpCommand.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/HelpCommand.java
@@ -68,4 +68,17 @@ public class HelpCommand extends PatternCommandActivity<CommandContext> {
         .name(HELP_COMMAND)
         .description(DEFAULT_DESCRIPTION);
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) { return true; }
+
+    if (o instanceof SlashCommand) {
+      SlashCommand that = ((SlashCommand) o);
+      return that.getInfo().name() != null && that.getInfo().name().equals(HELP_COMMAND);
+    }
+
+    return false;
+  }
+
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/SlashCommand.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/SlashCommand.java
@@ -105,7 +105,8 @@ public class SlashCommand extends PatternCommandActivity<CommandContext> {
     return new ActivityInfo()
         .type(ActivityType.COMMAND)
         .name(this.slashCommandName)
-        .description(this.description);
+        .description(this.description)
+        .requiresBotMention(this.requiresBotMention);
   }
 
   @Override

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/SlashCommand.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/SlashCommand.java
@@ -51,12 +51,13 @@ public class SlashCommand extends PatternCommandActivity<CommandContext> {
   /**
    * Returns a new {@link SlashCommand} instance.
    *
-   * @param slashCommandName   Identifier of the command (ex: '/gif' or 'gif').
-   * @param callback           Callback to be processed when command is detected.
-   * @param description            The summary of the command.
+   * @param slashCommandName Identifier of the command (ex: '/gif' or 'gif').
+   * @param callback         Callback to be processed when command is detected.
+   * @param description      The summary of the command.
    * @return a {@link SlashCommand} instance.
    */
-  public static SlashCommand slash(@Nonnull String slashCommandName, @Nonnull Consumer<CommandContext> callback, String description) {
+  public static SlashCommand slash(@Nonnull String slashCommandName, @Nonnull Consumer<CommandContext> callback,
+      String description) {
     return slash(slashCommandName, true, callback, description);
   }
 
@@ -66,7 +67,7 @@ public class SlashCommand extends PatternCommandActivity<CommandContext> {
    * @param slashCommandName   Identifier of the command (ex: '/gif' or 'gif').
    * @param requiresBotMention Indicates whether the bot has to be mentioned in order to trigger the command.
    * @param callback           Callback to be processed when command is detected.
-   * @param description            The summary of the command.
+   * @param description        The summary of the command.
    * @return a {@link SlashCommand} instance.
    */
   public static SlashCommand slash(@Nonnull String slashCommandName, boolean requiresBotMention,
@@ -106,12 +107,17 @@ public class SlashCommand extends PatternCommandActivity<CommandContext> {
     return new ActivityInfo()
         .type(ActivityType.COMMAND)
         .name(this.slashCommandName)
-        .description(this.description);
+        .description(this.buildCommandDescription());
   }
 
   @Override
   protected CommandContext createContextInstance(V4Initiator initiator, V4MessageSent event) {
     return new CommandContext(initiator, event);
+  }
+
+  private String buildCommandDescription() {
+    return this.requiresBotMention ? this.description + " (mention required)"
+        : this.description + " (mention not required)";
   }
 
   @Override

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/SlashCommand.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/SlashCommand.java
@@ -8,6 +8,7 @@ import com.symphony.bdk.gen.api.model.V4MessageSent;
 import org.apache.commons.lang3.StringUtils;
 import org.apiguardian.api.API;
 
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
@@ -105,12 +106,24 @@ public class SlashCommand extends PatternCommandActivity<CommandContext> {
     return new ActivityInfo()
         .type(ActivityType.COMMAND)
         .name(this.slashCommandName)
-        .description(this.description)
-        .uniqueObject(this.requiresBotMention);
+        .description(this.description);
   }
 
   @Override
   protected CommandContext createContextInstance(V4Initiator initiator, V4MessageSent event) {
     return new CommandContext(initiator, event);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) { return true; }
+    if (o == null || getClass() != o.getClass()) { return false; }
+    SlashCommand that = (SlashCommand) o;
+    return requiresBotMention == that.requiresBotMention && slashCommandName.equals(that.slashCommandName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(slashCommandName, requiresBotMention);
   }
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/SlashCommand.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/SlashCommand.java
@@ -106,7 +106,7 @@ public class SlashCommand extends PatternCommandActivity<CommandContext> {
         .type(ActivityType.COMMAND)
         .name(this.slashCommandName)
         .description(this.description)
-        .requiresBotMention(this.requiresBotMention);
+        .uniqueObject(this.requiresBotMention);
   }
 
   @Override

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/model/ActivityInfo.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/model/ActivityInfo.java
@@ -27,4 +27,7 @@ public class ActivityInfo {
   /** Description of the activity (can contain multiple lines) */
   private String description;
 
+  /** Whether the bot mention is required or not */
+  private boolean requiresBotMention;
+
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/model/ActivityInfo.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/model/ActivityInfo.java
@@ -5,6 +5,8 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.apiguardian.api.API;
 
+import java.util.Objects;
+
 /**
  * {@link com.symphony.bdk.core.activity.AbstractActivity} information/documentation model.
  * <p>
@@ -28,6 +30,19 @@ public class ActivityInfo {
   private String description;
 
   /** Whether the bot mention is required or not */
-  private boolean requiresBotMention;
+  private Object uniqueObject;
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) { return true; }
+    if (o == null || getClass() != o.getClass()) { return false; }
+    ActivityInfo that = (ActivityInfo) o;
+
+    return this.hashCode() == that.hashCode();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, name, uniqueObject);
+  }
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/model/ActivityInfo.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/model/ActivityInfo.java
@@ -29,8 +29,6 @@ public class ActivityInfo {
   /** Description of the activity (can contain multiple lines) */
   private String description;
 
-  /** Whether the bot mention is required or not */
-  private Object uniqueObject;
 
   @Override
   public boolean equals(Object o) {
@@ -43,6 +41,6 @@ public class ActivityInfo {
 
   @Override
   public int hashCode() {
-    return Objects.hash(type, name, uniqueObject);
+    return Objects.hash(type, name);
   }
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/model/ActivityInfo.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/model/ActivityInfo.java
@@ -5,8 +5,6 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.apiguardian.api.API;
 
-import java.util.Objects;
-
 /**
  * {@link com.symphony.bdk.core.activity.AbstractActivity} information/documentation model.
  * <p>
@@ -28,19 +26,4 @@ public class ActivityInfo {
 
   /** Description of the activity (can contain multiple lines) */
   private String description;
-
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) { return true; }
-    if (o == null || getClass() != o.getClass()) { return false; }
-    ActivityInfo that = (ActivityInfo) o;
-
-    return this.hashCode() == that.hashCode();
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(type, name);
-  }
 }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/ActivityRegistryTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/ActivityRegistryTest.java
@@ -3,11 +3,14 @@ package com.symphony.bdk.core.activity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.symphony.bdk.core.activity.command.CommandActivity;
+import com.symphony.bdk.core.activity.command.CommandContext;
+import com.symphony.bdk.core.activity.command.SlashCommand;
 import com.symphony.bdk.core.service.datafeed.DatafeedLoop;
 import com.symphony.bdk.core.service.datafeed.RealTimeEventListener;
 import com.symphony.bdk.core.service.message.MessageService;
@@ -20,6 +23,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 /**
  * Test class for the {@link ActivityRegistry}.
@@ -45,8 +50,8 @@ class ActivityRegistryTest {
   }
 
   @Test
-  void shouldRegisterActivity() {
-    final CommandActivity<?> act = new TestCommandActivity();
+  void shouldReplaceActivity() {
+    final CommandActivity<?> act = new TestCommandActivity("test");
     assertTrue(this.registry.getActivityList().isEmpty(), "Registry must be empty");
 
     this.registry.register(act);
@@ -54,15 +59,18 @@ class ActivityRegistryTest {
     verify(this.datafeedService, times(1)).subscribe(any(RealTimeEventListener.class));
     assertEquals(this.botSession.getDisplayName(), act.getBotDisplayName());
 
-    this.registry.register(new TestCommandActivity());
+    this.registry.register(new TestCommandActivity("test"));
     assertEquals(1, this.registry.getActivityList().size(), "Registry should still contain only 1 activity");
     verify(this.datafeedService, times(1)).unsubscribe(any(RealTimeEventListener.class));
   }
 
   @Test
   void shouldRegister_sameValue_differentMention(){
-    final CommandActivity<?> actMentionRequired = new TestCommandActivity(true);
-    final CommandActivity<?> actMentionNotRequired = new TestCommandActivity(false);
+    final AtomicBoolean handlerCalled = new AtomicBoolean(false);
+    final Consumer<CommandContext> handler = c -> handlerCalled.set(true);
+
+    final CommandActivity<?> actMentionRequired = SlashCommand.slash("test", true, handler);
+    final CommandActivity<?> actMentionNotRequired = SlashCommand.slash("test", false, handler);
 
     assertTrue(this.registry.getActivityList().isEmpty(), "Registry must be empty");
 
@@ -70,15 +78,18 @@ class ActivityRegistryTest {
     this.registry.register(actMentionNotRequired);
 
     verify(this.datafeedService, times(2)).subscribe(any(RealTimeEventListener.class));
-    verify(this.datafeedService, times(0)).unsubscribe(any(RealTimeEventListener.class));
+    verify(this.datafeedService, never()).unsubscribe(any(RealTimeEventListener.class));
 
     assertEquals(2, this.registry.getActivityList().size(), "Both activities must have been registered");
   }
 
   @Test
   void shouldNotRegister_sameValue_sameMention(){
-    final CommandActivity<?> actMentionRequired = new TestCommandActivity(true);
-    final CommandActivity<?> actMentionNotRequired = new TestCommandActivity(true);
+    final AtomicBoolean handlerCalled = new AtomicBoolean(false);
+    final Consumer<CommandContext> handler = c -> handlerCalled.set(true);
+
+    final CommandActivity<?> actMentionRequired = SlashCommand.slash("test", true, handler);
+    final CommandActivity<?> actMentionNotRequired = SlashCommand.slash("test", true, handler);
 
     assertTrue(this.registry.getActivityList().isEmpty(), "Registry must be empty");
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/ActivityRegistryTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/ActivityRegistryTest.java
@@ -58,4 +58,37 @@ class ActivityRegistryTest {
     assertEquals(1, this.registry.getActivityList().size(), "Registry should still contain only 1 activity");
     verify(this.datafeedService, times(1)).unsubscribe(any(RealTimeEventListener.class));
   }
+
+  @Test
+  void shouldRegister_sameValue_differentMention(){
+    final CommandActivity<?> actMentionRequired = new TestCommandActivity(true);
+    final CommandActivity<?> actMentionNotRequired = new TestCommandActivity(false);
+
+    assertTrue(this.registry.getActivityList().isEmpty(), "Registry must be empty");
+
+    this.registry.register(actMentionRequired);
+    this.registry.register(actMentionNotRequired);
+
+    verify(this.datafeedService, times(2)).subscribe(any(RealTimeEventListener.class));
+    verify(this.datafeedService, times(0)).unsubscribe(any(RealTimeEventListener.class));
+
+    assertEquals(2, this.registry.getActivityList().size(), "Both activities must have been registered");
+  }
+
+  @Test
+  void shouldNotRegister_sameValue_sameMention(){
+    final CommandActivity<?> actMentionRequired = new TestCommandActivity(true);
+    final CommandActivity<?> actMentionNotRequired = new TestCommandActivity(true);
+
+    assertTrue(this.registry.getActivityList().isEmpty(), "Registry must be empty");
+
+    this.registry.register(actMentionRequired);
+    this.registry.register(actMentionNotRequired);
+
+    verify(this.datafeedService, times(2)).subscribe(any(RealTimeEventListener.class));
+    verify(this.datafeedService, times(1)).unsubscribe(any(RealTimeEventListener.class));
+
+    assertEquals(1, this.registry.getActivityList().size(), "Only one activities must have been registered");
+  }
+
 }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/TestCommandActivity.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/TestCommandActivity.java
@@ -19,7 +19,7 @@ public class TestCommandActivity extends CommandActivity<CommandContext> {
 
   public TestCommandActivity(boolean isBotMentionRequired) {
     this.activityInfo =
-        new ActivityInfo().type(ActivityType.COMMAND).name("/test").requiresBotMention(isBotMentionRequired);
+        new ActivityInfo().type(ActivityType.COMMAND).name("/test").uniqueObject(isBotMentionRequired);
   }
 
   public TestCommandActivity() {

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/TestCommandActivity.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/TestCommandActivity.java
@@ -8,6 +8,7 @@ import com.symphony.bdk.core.activity.model.ActivityType;
 
 import lombok.Setter;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 /**
@@ -16,14 +17,15 @@ import java.util.function.Function;
 public class TestCommandActivity extends CommandActivity<CommandContext> {
 
   private final ActivityInfo activityInfo;
+  private final boolean requiresBotMention;
 
-  public TestCommandActivity(boolean isBotMentionRequired) {
-    this.activityInfo =
-        new ActivityInfo().type(ActivityType.COMMAND).name("/test").uniqueObject(isBotMentionRequired);
+  public TestCommandActivity(String name) {
+    this(name, true);
   }
 
-  public TestCommandActivity() {
-    this(false);
+  public TestCommandActivity(String name, boolean requiresBotMention) {
+    this.activityInfo = new ActivityInfo().type(ActivityType.COMMAND).name(name);
+    this.requiresBotMention = requiresBotMention;
   }
 
   @Setter private Function<CommandContext, Boolean> matcher = c -> true;
@@ -41,5 +43,18 @@ public class TestCommandActivity extends CommandActivity<CommandContext> {
   @Override
   public void onActivity(CommandContext context) {
 
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) { return true; }
+    if (o == null || getClass() != o.getClass()) { return false; }
+    TestCommandActivity that = (TestCommandActivity) o;
+    return requiresBotMention == that.requiresBotMention && activityInfo.name().equals(that.activityInfo.name());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(activityInfo.name(), requiresBotMention);
   }
 }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/TestCommandActivity.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/TestCommandActivity.java
@@ -15,11 +15,22 @@ import java.util.function.Function;
  */
 public class TestCommandActivity extends CommandActivity<CommandContext> {
 
+  private final ActivityInfo activityInfo;
+
+  public TestCommandActivity(boolean isBotMentionRequired) {
+    this.activityInfo =
+        new ActivityInfo().type(ActivityType.COMMAND).name("/test").requiresBotMention(isBotMentionRequired);
+  }
+
+  public TestCommandActivity() {
+    this(false);
+  }
+
   @Setter private Function<CommandContext, Boolean> matcher = c -> true;
 
   @Override
   protected ActivityInfo info() {
-    return new ActivityInfo().type(ActivityType.COMMAND).name("/test");
+    return this.activityInfo;
   }
 
   @Override

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/command/CommandActivityTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/command/CommandActivityTest.java
@@ -33,7 +33,7 @@ class CommandActivityTest {
 
   @BeforeEach
   void setUp() {
-    act = new TestCommandActivity();
+    act = new TestCommandActivity("test");
     act.bindToRealTimeEventsSource(datafeedService::subscribe);
   }
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/command/SlashCommandTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/command/SlashCommandTest.java
@@ -79,6 +79,7 @@ class SlashCommandTest {
     final SlashCommand cmd = SlashCommand.slash("/test", c -> {});
     final ActivityInfo info = cmd.getInfo();
     assertEquals(ActivityType.COMMAND, info.type());
+    assertTrue(info.requiresBotMention(), "requiredBotMention is true by default in SlashCommand");
     assertEquals("/test", info.name());
   }
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/command/SlashCommandTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/command/SlashCommandTest.java
@@ -79,7 +79,6 @@ class SlashCommandTest {
     final SlashCommand cmd = SlashCommand.slash("/test", c -> {});
     final ActivityInfo info = cmd.getInfo();
     assertEquals(ActivityType.COMMAND, info.type());
-    assertTrue((Boolean) info.uniqueObject(), "Unique object is a boolean and true by default in SlashCommand");
     assertEquals("/test", info.name());
   }
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/command/SlashCommandTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/command/SlashCommandTest.java
@@ -79,7 +79,7 @@ class SlashCommandTest {
     final SlashCommand cmd = SlashCommand.slash("/test", c -> {});
     final ActivityInfo info = cmd.getInfo();
     assertEquals(ActivityType.COMMAND, info.type());
-    assertTrue(info.requiresBotMention(), "requiredBotMention is true by default in SlashCommand");
+    assertTrue((Boolean) info.uniqueObject(), "Unique object is a boolean and true by default in SlashCommand");
     assertEquals("/test", info.name());
   }
 


### PR DESCRIPTION
### Ticket
[#515 ](https://github.com/finos/symphony-bdk-java/issues/515)

### Description
Previously, we were not able to register two slash commands having the same name. This was done in order to avoid registering duplicates. However, two slash commands having the same name are not necessarily duplicates as they can differ in bot's mention required property : In fact, we can have one command requiring bot's mention while the second one is not requiring it. In this case, both of them should be registered. 

The issue was coming from the fact that we only relied on command's name to check if it is not already present in the registry. The fix was to check the bot's mention required property as well.