### PR TITLE
#517 List users method does not handle bad path.

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/user/UserService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/user/UserService.java
@@ -110,12 +110,7 @@ public class UserService implements OboUserService, OboService<OboUserService> {
     String uids = uidList.stream().map(String::valueOf).collect(Collectors.joining(","));
     V2UserList v2UserList = executeAndRetry("searchUserByIds",
         () -> usersApi.v3UsersGet(authSession.getSessionToken(), uids, null, null, local, active));
-
-    if (v2UserList == null || v2UserList.getUsers() == null) {
-      return Collections.emptyList();
-    }
-
-    return v2UserList.getUsers();
+    return this.getUsersOrEmpty(v2UserList);
   }
 
   /**
@@ -126,12 +121,7 @@ public class UserService implements OboUserService, OboService<OboUserService> {
     String uids = uidList.stream().map(String::valueOf).collect(Collectors.joining(","));
     V2UserList v2UserList = executeAndRetry("searchUserByIds",
         () -> usersApi.v3UsersGet(authSession.getSessionToken(), uids, null, null, false, null));
-
-    if (v2UserList == null || v2UserList.getUsers() == null) {
-      return Collections.emptyList();
-    }
-
-    return v2UserList.getUsers();
+    return this.getUsersOrEmpty(v2UserList);
   }
 
   /**
@@ -143,12 +133,7 @@ public class UserService implements OboUserService, OboService<OboUserService> {
     String emails = String.join(",", emailList);
     V2UserList v2UserList = executeAndRetry("searchUserByEmails",
         () -> usersApi.v3UsersGet(authSession.getSessionToken(), null, emails, null, local, active));
-
-    if (v2UserList == null || v2UserList.getUsers() == null) {
-      return Collections.emptyList();
-    }
-
-    return v2UserList.getUsers();
+    return this.getUsersOrEmpty(v2UserList);
   }
 
   /**
@@ -159,12 +144,7 @@ public class UserService implements OboUserService, OboService<OboUserService> {
     String emails = String.join(",", emailList);
     V2UserList v2UserList = executeAndRetry("searchUserByEmails",
         () -> usersApi.v3UsersGet(authSession.getSessionToken(), null, emails, null, false, null));
-
-    if (v2UserList == null || v2UserList.getUsers() == null) {
-      return Collections.emptyList();
-    }
-
-    return v2UserList.getUsers();
+    return this.getUsersOrEmpty(v2UserList);
   }
 
   /**
@@ -175,12 +155,7 @@ public class UserService implements OboUserService, OboService<OboUserService> {
     String usernames = String.join(",", usernameList);
     V2UserList v2UserList = executeAndRetry("searchUserByUsernames",
         () -> usersApi.v3UsersGet(authSession.getSessionToken(), null, null, usernames, true, active));
-
-    if (v2UserList == null || v2UserList.getUsers() == null) {
-      return Collections.emptyList();
-    }
-
-    return v2UserList.getUsers();
+    return this.getUsersOrEmpty(v2UserList);
   }
 
   /**
@@ -191,7 +166,10 @@ public class UserService implements OboUserService, OboService<OboUserService> {
     String usernames = String.join(",", usernameList);
     V2UserList v2UserList = executeAndRetry("searchUserByUsernames",
         () -> usersApi.v3UsersGet(authSession.getSessionToken(), null, null, usernames, true, null));
+    return this.getUsersOrEmpty(v2UserList);
+  }
 
+  private List<UserV2> getUsersOrEmpty(V2UserList v2UserList) {
     if (v2UserList == null || v2UserList.getUsers() == null) {
       return Collections.emptyList();
     }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/user/UserService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/user/UserService.java
@@ -46,6 +46,7 @@ import org.apiguardian.api.API;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -109,6 +110,11 @@ public class UserService implements OboUserService, OboService<OboUserService> {
     String uids = uidList.stream().map(String::valueOf).collect(Collectors.joining(","));
     V2UserList v2UserList = executeAndRetry("searchUserByIds",
         () -> usersApi.v3UsersGet(authSession.getSessionToken(), uids, null, null, local, active));
+
+    if (v2UserList == null || v2UserList.getUsers() == null) {
+      return Collections.emptyList();
+    }
+
     return v2UserList.getUsers();
   }
 
@@ -120,6 +126,11 @@ public class UserService implements OboUserService, OboService<OboUserService> {
     String uids = uidList.stream().map(String::valueOf).collect(Collectors.joining(","));
     V2UserList v2UserList = executeAndRetry("searchUserByIds",
         () -> usersApi.v3UsersGet(authSession.getSessionToken(), uids, null, null, false, null));
+
+    if (v2UserList == null || v2UserList.getUsers() == null) {
+      return Collections.emptyList();
+    }
+
     return v2UserList.getUsers();
   }
 
@@ -132,6 +143,11 @@ public class UserService implements OboUserService, OboService<OboUserService> {
     String emails = String.join(",", emailList);
     V2UserList v2UserList = executeAndRetry("searchUserByEmails",
         () -> usersApi.v3UsersGet(authSession.getSessionToken(), null, emails, null, local, active));
+
+    if (v2UserList == null || v2UserList.getUsers() == null) {
+      return Collections.emptyList();
+    }
+
     return v2UserList.getUsers();
   }
 
@@ -143,6 +159,11 @@ public class UserService implements OboUserService, OboService<OboUserService> {
     String emails = String.join(",", emailList);
     V2UserList v2UserList = executeAndRetry("searchUserByEmails",
         () -> usersApi.v3UsersGet(authSession.getSessionToken(), null, emails, null, false, null));
+
+    if (v2UserList == null || v2UserList.getUsers() == null) {
+      return Collections.emptyList();
+    }
+
     return v2UserList.getUsers();
   }
 
@@ -154,6 +175,11 @@ public class UserService implements OboUserService, OboService<OboUserService> {
     String usernames = String.join(",", usernameList);
     V2UserList v2UserList = executeAndRetry("searchUserByUsernames",
         () -> usersApi.v3UsersGet(authSession.getSessionToken(), null, null, usernames, true, active));
+
+    if (v2UserList == null || v2UserList.getUsers() == null) {
+      return Collections.emptyList();
+    }
+
     return v2UserList.getUsers();
   }
 
@@ -165,6 +191,11 @@ public class UserService implements OboUserService, OboService<OboUserService> {
     String usernames = String.join(",", usernameList);
     V2UserList v2UserList = executeAndRetry("searchUserByUsernames",
         () -> usersApi.v3UsersGet(authSession.getSessionToken(), null, null, usernames, true, null));
+
+    if (v2UserList == null || v2UserList.getUsers() == null) {
+      return Collections.emptyList();
+    }
+
     return v2UserList.getUsers();
   }
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/user/UserServiceTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/user/UserServiceTest.java
@@ -597,6 +597,48 @@ class UserServiceTest {
   }
 
   @Test
+  void searchUserV3ByIds_withParams_Content() {
+    this.mockApiClient.onGet(SEARCH_USERS_V3, "{}");
+    assertEquals(Collections.emptyList(),
+        this.service.listUsersByIds(Collections.singletonList(1234L), true, true));
+  }
+
+  @Test
+  void searchUserV3ByIds_noParams_noContent() {
+    this.mockApiClient.onGet(SEARCH_USERS_V3, "{}");
+    assertEquals(Collections.emptyList(),
+        this.service.listUsersByIds(Collections.singletonList(1234L)));
+  }
+
+  @Test
+  void searchUserV3ByEmails_withParams_noContent() {
+    this.mockApiClient.onGet(SEARCH_USERS_V3, "{}");
+    assertEquals(Collections.emptyList(),
+        this.service.listUsersByEmails(Collections.singletonList("x@x.com"), true, true));
+  }
+
+  @Test
+  void searchUserV3ByUsernames_noParams_noContent() {
+    this.mockApiClient.onGet(SEARCH_USERS_V3, "{}");
+    assertEquals(Collections.emptyList(),
+        this.service.listUsersByEmails(Collections.singletonList("user-name")));
+  }
+
+  @Test
+  void searchUserV3ByUsernames_withParams_noContent() {
+    this.mockApiClient.onGet(SEARCH_USERS_V3, "{}");
+    assertEquals(Collections.emptyList(),
+        this.service.listUsersByUsernames(Collections.singletonList("user-name"), true));
+  }
+
+  @Test
+  void searchUserV3ByEmails_noParams_noContent() {
+    this.mockApiClient.onGet(SEARCH_USERS_V3, "{}");
+    assertEquals(Collections.emptyList(),
+        this.service.listUsersByUsernames(Collections.singletonList("x@x.com")));
+  }
+
+  @Test
   void searchUserBySearchQueryTest() throws IOException {
     String response = JsonHelper.readFromClasspath("/user/users_by_query.json");
     this.mockApiClient.onPost(SEARCH_USER_BY_QUERY, response);


### PR DESCRIPTION
### Ticket
[#517](https://github.com/finos/symphony-bdk-java/issues/517)

### Description
User service methods to search users cause null pointer when no user is found.
The endpoint /v3/users to search users return null with 204 (no content) http code when no user is found.
This endpoint is used in user service to search users by ids, emails and usernames.

The null pointer was comming from User service methods that call getUsers() on the returned object, which causes NP when no user is found.
There were two options to fix this :
- throw an exception when no user is found
- return an empty list

The second option was chosen to fix this bug. Thus, User service returns an empty list when no user found.