### PR TITLE
PLAT-10897 (backport) Upgraded jersey dependency to 2.34 (#522)

### DIFF
--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -59,11 +59,11 @@ dependencies {
         api 'io.swagger:swagger-annotations:1.6.0'
         api 'org.openapitools:jackson-databind-nullable:0.2.1'
 
-        api 'org.glassfish.jersey.core:jersey-client:2.32'
-        api 'org.glassfish.jersey.inject:jersey-hk2:2.32'
-        api 'org.glassfish.jersey.media:jersey-media-multipart:2.32'
-        api 'org.glassfish.jersey.media:jersey-media-json-jackson:2.32'
-        api 'org.glassfish.jersey.connectors:jersey-apache-connector:2.32'
+        api 'org.glassfish.jersey.core:jersey-client:2.34'
+        api 'org.glassfish.jersey.inject:jersey-hk2:2.34'
+        api 'org.glassfish.jersey.media:jersey-media-multipart:2.34'
+        api 'org.glassfish.jersey.media:jersey-media-json-jackson:2.34'
+        api 'org.glassfish.jersey.connectors:jersey-apache-connector:2.34'
 
         api 'org.projectreactor:reactor-spring:1.0.1.RELEASE'
 


### PR DESCRIPTION
Backport of commit #521 : Upgraded jersey dependency to 2.34