### PR TITLE
PLAT-10923: Usage of userId instead of username to accept incoming events

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/ServiceFactory.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/ServiceFactory.java
@@ -39,6 +39,7 @@ import com.symphony.bdk.gen.api.StreamsApi;
 import com.symphony.bdk.gen.api.SystemApi;
 import com.symphony.bdk.gen.api.UserApi;
 import com.symphony.bdk.gen.api.UsersApi;
+import com.symphony.bdk.gen.api.model.UserV2;
 import com.symphony.bdk.http.api.ApiClient;
 import com.symphony.bdk.template.api.TemplateEngine;
 
@@ -114,11 +115,11 @@ class ServiceFactory {
    *
    * @return a new {@link DatafeedLoop} instance.
    */
-  public DatafeedLoop getDatafeedLoop() {
+  public DatafeedLoop getDatafeedLoop(UserV2 botInfo) {
     if (DatafeedVersion.of(config.getDatafeed().getVersion()) == DatafeedVersion.V2) {
-      return new DatafeedLoopV2(new DatafeedApi(datafeedAgentClient), authSession, config);
+      return new DatafeedLoopV2(new DatafeedApi(datafeedAgentClient), authSession, config, botInfo);
     }
-    return new DatafeedLoopV1(new DatafeedApi(datafeedAgentClient), authSession, config);
+    return new DatafeedLoopV1(new DatafeedApi(datafeedAgentClient), authSession, config, botInfo);
   }
 
   /**

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/SymphonyBdk.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/SymphonyBdk.java
@@ -125,10 +125,11 @@ public class SymphonyBdk {
     this.healthService = serviceFactory != null ? serviceFactory.getHealthService() : null;
     this.messageService = serviceFactory != null ? serviceFactory.getMessageService() : null;
     this.disclaimerService = serviceFactory != null ? serviceFactory.getDisclaimerService() : null;
-    this.datafeedLoop = serviceFactory != null ? serviceFactory.getDatafeedLoop() : null;
 
     // retrieve bot session info
     this.botInfo = sessionService != null ? sessionService.getSession() : null;
+
+    this.datafeedLoop = serviceFactory != null ? serviceFactory.getDatafeedLoop(this.botInfo) : null;
 
     // setup activities
     this.activityRegistry = this.datafeedLoop != null ? new ActivityRegistry(this.botInfo, this.datafeedLoop) : null;

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/RealTimeEventListener.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/RealTimeEventListener.java
@@ -18,16 +18,16 @@ public interface RealTimeEventListener {
    * If you want to handle the self-created events or you want to apply your own filters for the events, you should override this method.
    *
    * @param event    Event to be verified.
-   * @param username Username of the bot itself.
+   * @param botInfo  General bot info object.
    * @return The event is accepted or not.
    * @throws EventException Throw this exception if this method should fail the current events processing
    *                        and re-queue the events in datafeed. Other exceptions will be caught silently.
    */
   @API(status = API.Status.EXPERIMENTAL)
-  default boolean isAcceptingEvent(V4Event event, String username) throws EventException {
+  default boolean isAcceptingEvent(V4Event event, UserV2 botInfo) throws EventException {
     return event.getInitiator() != null && event.getInitiator().getUser() != null
-        && event.getInitiator().getUser().getUsername() != null
-        && !event.getInitiator().getUser().getUsername().equals(username);
+        && event.getInitiator().getUser().getUserId() != null
+        && !event.getInitiator().getUser().getUserId().equals(botInfo.getId());
   }
 
   /**

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/AbstractDatafeedLoop.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/AbstractDatafeedLoop.java
@@ -9,6 +9,7 @@ import com.symphony.bdk.core.service.datafeed.DatafeedLoop;
 import com.symphony.bdk.core.service.datafeed.EventException;
 import com.symphony.bdk.core.service.datafeed.RealTimeEventListener;
 import com.symphony.bdk.gen.api.DatafeedApi;
+import com.symphony.bdk.gen.api.model.UserV2;
 import com.symphony.bdk.gen.api.model.V4Event;
 import com.symphony.bdk.http.api.ApiClient;
 import com.symphony.bdk.http.api.ApiException;
@@ -33,6 +34,7 @@ abstract class AbstractDatafeedLoop implements DatafeedLoop {
 
   protected final AuthSession authSession;
   protected final BdkConfig bdkConfig;
+  protected final UserV2 botInfo;
   protected final RetryWithRecoveryBuilder retryWithRecoveryBuilder;
   @Setter
   protected DatafeedApi datafeedApi;
@@ -41,11 +43,12 @@ abstract class AbstractDatafeedLoop implements DatafeedLoop {
   // access needs to be thread safe (DF loop is usually running on its own thread)
   private final List<RealTimeEventListener> listeners;
 
-  public AbstractDatafeedLoop(DatafeedApi datafeedApi, AuthSession authSession, BdkConfig config) {
+  public AbstractDatafeedLoop(DatafeedApi datafeedApi, AuthSession authSession, BdkConfig config, UserV2 botInfo) {
     this.datafeedApi = datafeedApi;
     this.listeners = new ArrayList<>();
     this.authSession = authSession;
     this.bdkConfig = config;
+    this.botInfo = botInfo;
     this.apiClient = datafeedApi.getApiClient();
     this.retryWithRecoveryBuilder = new RetryWithRecoveryBuilder<>()
         .retryConfig(config.getDatafeedRetryConfig())
@@ -100,7 +103,7 @@ abstract class AbstractDatafeedLoop implements DatafeedLoop {
         synchronized (this.listeners) {
           for (RealTimeEventListener listener : this.listeners) {
 
-            if (listener.isAcceptingEvent(event, this.bdkConfig.getBot().getUsername())) {
+            if (listener.isAcceptingEvent(event, this.botInfo)) {
               try {
                 log.debug("Before dispatching '{}' event to listener {}", event.getType(), listener);
                 eventType.get().dispatch(listener, event);

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV1.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV1.java
@@ -11,6 +11,7 @@ import com.symphony.bdk.core.retry.RetryWithRecoveryBuilder;
 import com.symphony.bdk.core.service.datafeed.DatafeedIdRepository;
 import com.symphony.bdk.core.service.datafeed.exception.NestedRetryException;
 import com.symphony.bdk.gen.api.DatafeedApi;
+import com.symphony.bdk.gen.api.model.UserV2;
 import com.symphony.bdk.gen.api.model.V4Event;
 import com.symphony.bdk.http.api.ApiException;
 
@@ -51,13 +52,13 @@ public class DatafeedLoopV1 extends AbstractDatafeedLoop {
   private final DatafeedIdRepository datafeedRepository;
   private String datafeedId;
 
-  public DatafeedLoopV1(DatafeedApi datafeedApi, AuthSession authSession, BdkConfig config) {
-    this(datafeedApi, authSession, config, new OnDiskDatafeedIdRepository(config));
+  public DatafeedLoopV1(DatafeedApi datafeedApi, AuthSession authSession, BdkConfig config, UserV2 botInfo) {
+    this(datafeedApi, authSession, config, botInfo, new OnDiskDatafeedIdRepository(config));
   }
 
-  public DatafeedLoopV1(DatafeedApi datafeedApi, AuthSession authSession, BdkConfig config,
+  public DatafeedLoopV1(DatafeedApi datafeedApi, AuthSession authSession, BdkConfig config, UserV2 botInfo,
       DatafeedIdRepository repository) {
-    super(datafeedApi, authSession, config);
+    super(datafeedApi, authSession, config, botInfo);
 
     this.started.set(false);
     this.datafeedRepository = repository;

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2.java
@@ -10,6 +10,7 @@ import com.symphony.bdk.core.retry.RetryWithRecoveryBuilder;
 import com.symphony.bdk.core.service.datafeed.exception.NestedRetryException;
 import com.symphony.bdk.gen.api.DatafeedApi;
 import com.symphony.bdk.gen.api.model.AckId;
+import com.symphony.bdk.gen.api.model.UserV2;
 import com.symphony.bdk.gen.api.model.V4Event;
 import com.symphony.bdk.gen.api.model.V5Datafeed;
 import com.symphony.bdk.gen.api.model.V5DatafeedCreateBody;
@@ -64,8 +65,8 @@ public class DatafeedLoopV2 extends AbstractDatafeedLoop {
 
   private V5Datafeed datafeed;
 
-  public DatafeedLoopV2(DatafeedApi datafeedApi, AuthSession authSession, BdkConfig config) {
-    super(datafeedApi, authSession, config);
+  public DatafeedLoopV2(DatafeedApi datafeedApi, AuthSession authSession, BdkConfig config, UserV2 botInfo) {
+    super(datafeedApi, authSession, config, botInfo);
     this.ackId = new AckId().ackId("");
     this.tag = StringUtils.truncate(bdkConfig.getBot().getUsername(), DATAFEED_TAG_MAX_LENGTH);
   }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/ServiceFactoryTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/ServiceFactoryTest.java
@@ -23,6 +23,7 @@ import com.symphony.bdk.core.service.presence.PresenceService;
 import com.symphony.bdk.core.service.signal.SignalService;
 import com.symphony.bdk.core.service.stream.StreamService;
 import com.symphony.bdk.core.service.user.UserService;
+import com.symphony.bdk.gen.api.model.UserV2;
 import com.symphony.bdk.http.api.ApiClient;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -34,10 +35,12 @@ public class ServiceFactoryTest {
   private ApiClientFactory apiClientFactory;
   private AuthSession mAuthSession;
   private BdkConfig config;
+  private UserV2 botInfo;
 
   @BeforeEach
   void setUp() throws BdkConfigException {
     this.config = BdkConfigLoader.loadFromClasspath("/config/config.yaml");
+    this.botInfo = mock(UserV2.class);
     this.mAuthSession = mock(AuthSession.class);
     ApiClient mPodClient = mock(ApiClient.class);
     ApiClient mAgentClient = mock(ApiClient.class);
@@ -109,13 +112,13 @@ public class ServiceFactoryTest {
     datafeedConfig.setVersion("v1");
 
     this.serviceFactory = new ServiceFactory(this.apiClientFactory, mAuthSession, config);
-    DatafeedLoop datafeedServiceV1 = this.serviceFactory.getDatafeedLoop();
+    DatafeedLoop datafeedServiceV1 = this.serviceFactory.getDatafeedLoop(botInfo);
     assertNotNull(datafeedServiceV1);
     assertEquals(datafeedServiceV1.getClass(), DatafeedLoopV1.class);
 
     datafeedConfig.setVersion("v2");
     this.serviceFactory = new ServiceFactory(this.apiClientFactory, mAuthSession, config);
-    DatafeedLoop datafeedServiceV2 = this.serviceFactory.getDatafeedLoop();
+    DatafeedLoop datafeedServiceV2 = this.serviceFactory.getDatafeedLoop(botInfo);
     assertNotNull(datafeedServiceV2);
     assertEquals(datafeedServiceV2.getClass(), DatafeedLoopV2.class);
 

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkDatafeedConfig.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkDatafeedConfig.java
@@ -6,6 +6,7 @@ import com.symphony.bdk.core.service.datafeed.DatafeedVersion;
 import com.symphony.bdk.core.service.datafeed.RealTimeEventListener;
 import com.symphony.bdk.core.service.datafeed.impl.DatafeedLoopV1;
 import com.symphony.bdk.core.service.datafeed.impl.DatafeedLoopV2;
+import com.symphony.bdk.core.service.session.SessionService;
 import com.symphony.bdk.gen.api.DatafeedApi;
 import com.symphony.bdk.spring.SymphonyBdkCoreProperties;
 import com.symphony.bdk.spring.events.RealTimeEvent;
@@ -42,14 +43,15 @@ public class BdkDatafeedConfig {
       SymphonyBdkCoreProperties properties,
       DatafeedApi datafeedApi,
       AuthSession botSession,
-      DatafeedVersion datafeedVersion
+      DatafeedVersion datafeedVersion,
+      SessionService sessionService
   ) {
 
     if (datafeedVersion == DatafeedVersion.V2) {
-      return new DatafeedLoopV2(datafeedApi, botSession, properties);
+      return new DatafeedLoopV2(datafeedApi, botSession, properties, sessionService.getSession());
     }
 
-    return new DatafeedLoopV1(datafeedApi, botSession, properties);
+    return new DatafeedLoopV1(datafeedApi, botSession, properties, sessionService.getSession());
   }
 
   @Bean


### PR DESCRIPTION
### Ticket
[PLAT-10923](https://perzoinc.atlassian.net/browse/PLAT-10923)

### Description
To be able to handle external messages we want to use userId instead of username to accept incoming events.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [] Unit tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
