### PR TITLE
PLAT-10923 Usage of userId instead of username to accept incoming events (2.1-rc manual backport)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "io.codearte.nexus-staging" version "0.22.0"
 }
 
-ext.projectVersion = '2.1.6'
+ext.projectVersion = '2.1.7'
 ext.isReleaseVersion = !ext.projectVersion.endsWith('SNAPSHOT')
 
 ext.mavenRepoUrl = project.properties['mavenRepoUrl'] ?: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/ServiceFactory.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/ServiceFactory.java
@@ -39,6 +39,7 @@ import com.symphony.bdk.gen.api.StreamsApi;
 import com.symphony.bdk.gen.api.SystemApi;
 import com.symphony.bdk.gen.api.UserApi;
 import com.symphony.bdk.gen.api.UsersApi;
+import com.symphony.bdk.gen.api.model.UserV2;
 import com.symphony.bdk.http.api.ApiClient;
 import com.symphony.bdk.template.api.TemplateEngine;
 
@@ -113,12 +114,13 @@ class ServiceFactory {
    * Returns a fully initialized {@link DatafeedLoop}.
    *
    * @return a new {@link DatafeedLoop} instance.
+   * @param botInfo
    */
-  public DatafeedLoop getDatafeedLoop() {
+  public DatafeedLoop getDatafeedLoop(UserV2 botInfo) {
     if (DatafeedVersion.of(config.getDatafeed().getVersion()) == DatafeedVersion.V2) {
-      return new DatafeedLoopV2(new DatafeedApi(datafeedAgentClient), authSession, config);
+      return new DatafeedLoopV2(new DatafeedApi(datafeedAgentClient), authSession, config, botInfo);
     }
-    return new DatafeedLoopV1(new DatafeedApi(datafeedAgentClient), authSession, config);
+    return new DatafeedLoopV1(new DatafeedApi(datafeedAgentClient), authSession, config, botInfo);
   }
 
   /**

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/SymphonyBdk.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/SymphonyBdk.java
@@ -125,10 +125,12 @@ public class SymphonyBdk {
     this.healthService = serviceFactory != null ? serviceFactory.getHealthService() : null;
     this.messageService = serviceFactory != null ? serviceFactory.getMessageService() : null;
     this.disclaimerService = serviceFactory != null ? serviceFactory.getDisclaimerService() : null;
-    this.datafeedLoop = serviceFactory != null ? serviceFactory.getDatafeedLoop() : null;
 
     // retrieve bot session info
     this.botInfo = sessionService != null ? sessionService.getSession() : null;
+
+    // create datafeed loop
+    this.datafeedLoop = serviceFactory != null && this.botInfo !=null ? serviceFactory.getDatafeedLoop(this.botInfo) : null;
 
     // setup activities
     this.activityRegistry = this.datafeedLoop != null ? new ActivityRegistry(this.botInfo, this.datafeedLoop) : null;

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/RealTimeEventListener.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/RealTimeEventListener.java
@@ -16,15 +16,19 @@ public interface RealTimeEventListener {
      * By default, all the event that is created by the bot itself will not be accepted to be handled by the listener.
      * If you want to handle the self-created events or you want to apply your own filters for the events, you should override this method.
      *
-     * @param event     Event to be verified.
-     * @param username  Username of the bot itself.
+     * <p>
+     * Account user ID is used to determine if the event has been sent by the bot itself.
+     *
+     * @param event   Event to be verified.
+     * @param botInfo Bot information retrieved from the {@link com.symphony.bdk.core.service.session.SessionService}.
      * @return the event is accepted or not
      */
     @API(status = API.Status.EXPERIMENTAL)
-    default boolean isAcceptingEvent(V4Event event, String username) {
-      return event.getInitiator() != null && event.getInitiator().getUser() != null
-          && event.getInitiator().getUser().getUsername() != null
-          && !event.getInitiator().getUser().getUsername().equals(username);
+    default boolean isAcceptingEvent(V4Event event, UserV2 botInfo) {
+      return event.getInitiator() != null
+          && event.getInitiator().getUser() != null
+          && event.getInitiator().getUser().getUserId() != null
+          && !event.getInitiator().getUser().getUserId().equals(botInfo.getId());
     }
 
     /**

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV1.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV1.java
@@ -11,6 +11,7 @@ import com.symphony.bdk.core.retry.RetryWithRecoveryBuilder;
 import com.symphony.bdk.core.service.datafeed.DatafeedIdRepository;
 import com.symphony.bdk.core.service.datafeed.exception.NestedRetryException;
 import com.symphony.bdk.gen.api.DatafeedApi;
+import com.symphony.bdk.gen.api.model.UserV2;
 import com.symphony.bdk.gen.api.model.V4Event;
 import com.symphony.bdk.http.api.ApiException;
 
@@ -51,13 +52,13 @@ public class DatafeedLoopV1 extends AbstractDatafeedLoop {
   private final DatafeedIdRepository datafeedRepository;
   private String datafeedId;
 
-  public DatafeedLoopV1(DatafeedApi datafeedApi, AuthSession authSession, BdkConfig config) {
-    this(datafeedApi, authSession, config, new OnDiskDatafeedIdRepository(config));
+  public DatafeedLoopV1(DatafeedApi datafeedApi, AuthSession authSession, BdkConfig config, UserV2 botInfo) {
+    this(datafeedApi, authSession, config, new OnDiskDatafeedIdRepository(config), botInfo);
   }
 
   public DatafeedLoopV1(DatafeedApi datafeedApi, AuthSession authSession, BdkConfig config,
-      DatafeedIdRepository repository) {
-    super(datafeedApi, authSession, config);
+      DatafeedIdRepository repository, UserV2 botInfo) {
+    super(datafeedApi, authSession, config, botInfo);
 
     this.started.set(false);
     this.datafeedRepository = repository;

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2.java
@@ -10,6 +10,7 @@ import com.symphony.bdk.core.retry.RetryWithRecoveryBuilder;
 import com.symphony.bdk.core.service.datafeed.exception.NestedRetryException;
 import com.symphony.bdk.gen.api.DatafeedApi;
 import com.symphony.bdk.gen.api.model.AckId;
+import com.symphony.bdk.gen.api.model.UserV2;
 import com.symphony.bdk.gen.api.model.V4Event;
 import com.symphony.bdk.gen.api.model.V5Datafeed;
 import com.symphony.bdk.gen.api.model.V5EventList;
@@ -49,8 +50,9 @@ public class DatafeedLoopV2 extends AbstractDatafeedLoop {
   private final AckId ackId;
   private V5Datafeed datafeed;
 
-  public DatafeedLoopV2(DatafeedApi datafeedApi, AuthSession authSession, BdkConfig config) {
-    super(datafeedApi, authSession, config);
+  public DatafeedLoopV2(DatafeedApi datafeedApi, AuthSession authSession, BdkConfig config,
+      UserV2 botInfo) {
+    super(datafeedApi, authSession, config, botInfo);
     this.ackId = new AckId().ackId("");
   }
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/ServiceFactoryTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/ServiceFactoryTest.java
@@ -23,6 +23,7 @@ import com.symphony.bdk.core.service.presence.PresenceService;
 import com.symphony.bdk.core.service.signal.SignalService;
 import com.symphony.bdk.core.service.stream.StreamService;
 import com.symphony.bdk.core.service.user.UserService;
+import com.symphony.bdk.gen.api.model.UserV2;
 import com.symphony.bdk.http.api.ApiClient;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -34,6 +35,7 @@ public class ServiceFactoryTest {
   private ApiClientFactory apiClientFactory;
   private AuthSession mAuthSession;
   private BdkConfig config;
+  private final UserV2 botInfo = new UserV2().id(1234L);
 
   @BeforeEach
   void setUp() throws BdkConfigException {
@@ -109,13 +111,13 @@ public class ServiceFactoryTest {
     datafeedConfig.setVersion("v1");
 
     this.serviceFactory = new ServiceFactory(this.apiClientFactory, mAuthSession, config);
-    DatafeedLoop datafeedServiceV1 = this.serviceFactory.getDatafeedLoop();
+    DatafeedLoop datafeedServiceV1 = this.serviceFactory.getDatafeedLoop(this.botInfo);
     assertNotNull(datafeedServiceV1);
     assertEquals(datafeedServiceV1.getClass(), DatafeedLoopV1.class);
 
     datafeedConfig.setVersion("v2");
     this.serviceFactory = new ServiceFactory(this.apiClientFactory, mAuthSession, config);
-    DatafeedLoop datafeedServiceV2 = this.serviceFactory.getDatafeedLoop();
+    DatafeedLoop datafeedServiceV2 = this.serviceFactory.getDatafeedLoop(this.botInfo);
     assertNotNull(datafeedServiceV2);
     assertEquals(datafeedServiceV2.getClass(), DatafeedLoopV2.class);
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV1Test.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV1Test.java
@@ -28,6 +28,7 @@ import com.symphony.bdk.core.service.datafeed.exception.NestedRetryException;
 import com.symphony.bdk.core.test.InMemoryDatafeedIdRepository;
 import com.symphony.bdk.gen.api.DatafeedApi;
 import com.symphony.bdk.gen.api.model.Datafeed;
+import com.symphony.bdk.gen.api.model.UserV2;
 import com.symphony.bdk.gen.api.model.V4ConnectionAccepted;
 import com.symphony.bdk.gen.api.model.V4ConnectionRequested;
 import com.symphony.bdk.gen.api.model.V4Event;
@@ -86,6 +87,7 @@ class DatafeedLoopV1Test {
   private DatafeedApi datafeedApi;
   private AuthSession authSession;
   private RealTimeEventListener listener;
+  private final UserV2 botInfo = new UserV2().id(1234L);
 
   @BeforeEach
   void init() throws BdkConfigException {
@@ -129,7 +131,8 @@ class DatafeedLoopV1Test {
         this.datafeedApi,
         this.authSession,
         this.bdkConfig,
-        this.datafeedIdRepository
+        this.datafeedIdRepository,
+        this.botInfo
     );
 
     this.listener = new RealTimeEventListener() {
@@ -143,7 +146,7 @@ class DatafeedLoopV1Test {
 
   private List<V4Event> getMessageSentEvent() {
     final V4Event event = new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())
-        .initiator(new V4Initiator().user(new V4User().username("username")));
+        .initiator(new V4Initiator().user(new V4User().userId(4321L).username("username")));
     return Collections.singletonList(event);
   }
 
@@ -370,7 +373,7 @@ class DatafeedLoopV1Test {
     datafeedConfig.setIdFilePath(tempDir.toString());
     bdkConfig.setDatafeed(datafeedConfig);
 
-    Optional<String> datafeedId = new DatafeedLoopV1(this.datafeedApi, this.authSession, this.bdkConfig)
+    Optional<String> datafeedId = new DatafeedLoopV1(this.datafeedApi, this.authSession, this.bdkConfig, this.botInfo)
         .retrieveDatafeed();
 
     assertTrue(datafeedId.isPresent());
@@ -388,7 +391,7 @@ class DatafeedLoopV1Test {
     bdkConfig.setDatafeed(datafeedConfig);
 
     Optional<String> datafeedId =
-        new DatafeedLoopV1(this.datafeedApi, this.authSession, this.bdkConfig).retrieveDatafeed();
+        new DatafeedLoopV1(this.datafeedApi, this.authSession, this.bdkConfig, this.botInfo).retrieveDatafeed();
     assertTrue(datafeedId.isPresent());
     assertEquals(datafeedId.get(), "8e7c8672-220");
   }
@@ -452,7 +455,7 @@ class DatafeedLoopV1Test {
         .userJoinedRoom(new V4UserJoinedRoom())
         .userRequestedToJoinRoom(new V4UserRequestedToJoinRoom());
 
-    final V4Initiator initiator = new V4Initiator().user(new V4User().username("username"));
+    final V4Initiator initiator = new V4Initiator().user(new V4User().username("username").userId(4321L));
     for (RealTimeEventType type : types) {
       final V4Event event = new V4Event().type(type.name());
       event.id(traceId).payload(payload).initiator(initiator);
@@ -462,7 +465,7 @@ class DatafeedLoopV1Test {
     events.add(new V4Event().type(null));
     events.add(new V4Event().type(types[0].name()).initiator(
         new V4Initiator().user(
-            new V4User().username(this.bdkConfig.getBot().getUsername()))
+            new V4User().username(this.bdkConfig.getBot().getUsername()).userId(1234L))
         )
     );
 

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkDatafeedConfig.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkDatafeedConfig.java
@@ -46,7 +46,7 @@ public class BdkDatafeedConfig {
   ) {
 
     if (datafeedVersion == DatafeedVersion.V2) {
-      return new DatafeedLoopV2(datafeedApi, botSession, properties);
+      return new DatafeedLoopV2(datafeedApi, botSession, properties, botInfo);
     }
 
     return new DatafeedLoopV1(datafeedApi, botSession, properties);

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkDatafeedConfig.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkDatafeedConfig.java
@@ -6,7 +6,9 @@ import com.symphony.bdk.core.service.datafeed.DatafeedVersion;
 import com.symphony.bdk.core.service.datafeed.RealTimeEventListener;
 import com.symphony.bdk.core.service.datafeed.impl.DatafeedLoopV1;
 import com.symphony.bdk.core.service.datafeed.impl.DatafeedLoopV2;
+import com.symphony.bdk.core.service.session.SessionService;
 import com.symphony.bdk.gen.api.DatafeedApi;
+import com.symphony.bdk.gen.api.model.UserV2;
 import com.symphony.bdk.spring.SymphonyBdkCoreProperties;
 import com.symphony.bdk.spring.events.RealTimeEvent;
 import com.symphony.bdk.spring.events.RealTimeEventsDispatcher;
@@ -42,14 +44,17 @@ public class BdkDatafeedConfig {
       SymphonyBdkCoreProperties properties,
       DatafeedApi datafeedApi,
       AuthSession botSession,
-      DatafeedVersion datafeedVersion
+      DatafeedVersion datafeedVersion,
+      SessionService sessionService
   ) {
+
+    final UserV2 botInfo = sessionService.getSession();
 
     if (datafeedVersion == DatafeedVersion.V2) {
       return new DatafeedLoopV2(datafeedApi, botSession, properties, botInfo);
     }
 
-    return new DatafeedLoopV1(datafeedApi, botSession, properties);
+    return new DatafeedLoopV1(datafeedApi, botSession, properties, botInfo);
   }
 
   @Bean


### PR DESCRIPTION
### Ticket
[PLAT-10923](https://perzoinc.atlassian.net/browse/PLAT-10923)

### Description
To be able to handle external messages we want to use userId instead of username to accept incoming events.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
