### PR TITLE
PLAT-10897 fixed jersey common dependency issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "io.codearte.nexus-staging" version "0.22.0"
 }
 
-ext.projectVersion = '2.1.7'
+ext.projectVersion = '2.1.8'
 ext.isReleaseVersion = !ext.projectVersion.endsWith('SNAPSHOT')
 
 ext.mavenRepoUrl = project.properties['mavenRepoUrl'] ?: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'

--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -59,6 +59,7 @@ dependencies {
         api 'io.swagger:swagger-annotations:1.6.0'
         api 'org.openapitools:jackson-databind-nullable:0.2.1'
 
+        api 'org.glassfish.jersey.core:jersey-common:2.34'
         api 'org.glassfish.jersey.core:jersey-client:2.34'
         api 'org.glassfish.jersey.inject:jersey-hk2:2.34'
         api 'org.glassfish.jersey.media:jersey-media-multipart:2.34'

--- a/symphony-bdk-http/symphony-bdk-http-jersey2/build.gradle
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/build.gradle
@@ -25,7 +25,10 @@ dependencies {
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'org.openapitools:jackson-databind-nullable'
-    implementation 'org.glassfish.jersey.media:jersey-media-json-jackson'
+    implementation ('org.glassfish.jersey.media:jersey-media-json-jackson') {
+        exclude group: 'org.glassfish.jersey.core', module: 'jersey-common'
+    }
+    implementation 'org.glassfish.jersey.core:jersey-common'
     implementation 'org.glassfish.jersey.core:jersey-client'
     implementation 'org.glassfish.jersey.inject:jersey-hk2'
     implementation 'org.glassfish.jersey.media:jersey-media-multipart'


### PR DESCRIPTION
Dependency `org.glassfish.jersey.media:jersey-media-json-jackson` was importing transitive `org.glassfish.jersey.core:jersey-common:2.32` instead of `org.glassfish.jersey.core:jersey-common:2.34` which seems to be an issue in Jersey side.

We might have to open a ticket on their repo. 