### PR TITLE
PLAT-10920 : Return built-in help command in the list of commands

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/HelpCommand.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/HelpCommand.java
@@ -48,7 +48,6 @@ public class HelpCommand extends PatternCommandActivity<CommandContext> {
   protected void onActivity(CommandContext context) {
     List<String> infos = this.activityRegistry.getActivityList()
         .stream()
-        .filter(act -> !(act instanceof HelpCommand))
         .map(AbstractActivity::getInfo)
         .filter(info -> info.type().equals(ActivityType.COMMAND))
         .map(info -> {

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/command/HelpCommandTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/command/HelpCommandTest.java
@@ -2,6 +2,7 @@ package com.symphony.bdk.core.activity.command;
 
 import static com.symphony.bdk.core.activity.command.SlashCommand.slash;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -20,6 +21,7 @@ import com.symphony.bdk.gen.api.model.V4Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -69,7 +71,13 @@ public class HelpCommandTest {
     V4MessageSent event = createMessageSentEvent();
     provider.trigger(l -> l.onMessageSent(new V4Initiator(), event));
 
-    verify(this.messageService, never()).send(anyString(), any(Message.class));
+    ArgumentCaptor<Message> argumentCaptor = ArgumentCaptor.forClass(Message.class);
+
+    // The build in /help command should be returned
+    verify(this.messageService, times(1)).send(anyString(), argumentCaptor.capture());
+    Message message = argumentCaptor.getValue();
+    assertNotNull(argumentCaptor.getValue());
+    assertEquals("<messageML><ul><li>/help - List available commands</li></ul></messageML>", message.getContent(), "The help command infos should be sent in response");
   }
 
   @Test


### PR DESCRIPTION
This PR is related to [#533](https://github.com/finos/symphony-bdk-java/issues/533)
The build-in help command lists the existing commands. Previously, it was not adding the help command itself in the list. The filter has been changed in this commit to get return it in the list

