### PR TITLE
Jersey HTTP client SSL/TLS broken configuration

### DIFF
--- a/symphony-bdk-http/symphony-bdk-http-jersey2/src/test/java/com/symphony/bdk/http/jersey2/ApiClientBuilderJersey2Test.java
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/src/test/java/com/symphony/bdk/http/jersey2/ApiClientBuilderJersey2Test.java
@@ -1,0 +1,73 @@
+package com.symphony.bdk.http.jersey2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.symphony.bdk.http.api.ApiClient;
+import com.symphony.bdk.http.api.ApiException;
+import com.symphony.bdk.http.api.ApiResponse;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockserver.configuration.ConfigurationProperties;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.logging.MockServerLogger;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.mockserver.socket.tls.KeyStoreFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.Collections;
+
+class ApiClientBuilderJersey2Test {
+
+  private static final String KEY_STORE_PWD = "changeit";
+
+  private ClientAndServer mockServer;
+
+  @BeforeEach
+  void setUp() {
+    // enforce client certificates usage
+    ConfigurationProperties.tlsMutualAuthenticationRequired(true);
+    mockServer = ClientAndServer.startClientAndServer();
+  }
+
+  @AfterEach
+  void tearDown() {
+    mockServer.stop();
+  }
+
+  @Test
+  void sslContextIsUsed()
+      throws ApiException, CertificateException, KeyStoreException, IOException, NoSuchAlgorithmException {
+    ByteArrayOutputStream keyStoreData = getMockServerKeyStore();
+    ApiClient client = new ApiClientBuilderJersey2()
+        .withBasePath("https://localhost:" + mockServer.getPort())
+        .withKeyStore(keyStoreData.toByteArray(), "changeit")
+        .withTrustStore(keyStoreData.toByteArray(), "changeit")
+        .build();
+
+    mockServer.withSecure(true)
+        .when(HttpRequest.request().withMethod("GET").withPath("/test"))
+        .respond(HttpResponse.response().withStatusCode(200));
+
+    ApiResponse<Object> response =
+        client.invokeAPI("/test", "GET", Collections.emptyList(), null, Collections.emptyMap(), Collections.emptyMap(),
+            null, "application/json", "", null, null);
+
+    assertEquals(200, response.getStatusCode());
+  }
+
+  private ByteArrayOutputStream getMockServerKeyStore()
+      throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException {
+    KeyStore mockServerKeyStore = new KeyStoreFactory(new MockServerLogger()).loadOrCreateKeyStore();
+    ByteArrayOutputStream keyStoreData = new ByteArrayOutputStream();
+    mockServerKeyStore.store(keyStoreData, KEY_STORE_PWD.toCharArray());
+    return keyStoreData;
+  }
+}


### PR DESCRIPTION
When a proxy is used, the Jersey client was switch to the Apache HTTP
connection pool which was not properly configured to use custom
key/trust stores.

The connector has to be set all the time to make the Apache pool is
used. Then the SSL context must be set directly in the pool as well.

Added a unit test to check this using Mock Server.

Closes #519
