### PR TITLE
Support client/response filters for HTTP clients

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/client/ApiClientFactory.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/client/ApiClientFactory.java
@@ -32,12 +32,12 @@ import javax.annotation.Nonnull;
 @API(status = API.Status.EXPERIMENTAL)
 public class ApiClientFactory {
 
-  private final static String LOGIN_CONTEXT_PATH = "/login";
-  private final static String POD_CONTEXT_PATH = "/pod";
-  private final static String AGENT_CONTEXT_PATH = "/agent";
-  private final static String KEYMANAGER_CONTEXT_PATH = "/relay";
-  private final static String SESSIONAUTH_CONTEXT_PATH = "/sessionauth";
-  private final static String KEYAUTH_CONTEXT_PATH = "/keyauth";
+  private static final String LOGIN_CONTEXT_PATH = "/login";
+  private static final String POD_CONTEXT_PATH = "/pod";
+  private static final String AGENT_CONTEXT_PATH = "/agent";
+  private static final String KEYMANAGER_CONTEXT_PATH = "/relay";
+  private static final String SESSIONAUTH_CONTEXT_PATH = "/sessionauth";
+  private static final String KEYAUTH_CONTEXT_PATH = "/keyauth";
 
   private final BdkConfig config;
   private final ApiClientBuilderProvider apiClientBuilderProvider;
@@ -168,9 +168,8 @@ public class ApiClientFactory {
     }
 
     final BdkCertificateConfig certificateConfig = config.getCertificateConfig();
-    ApiClient apiClient = null;
     try {
-      apiClient = getApiClientBuilder(clientConfig.getBasePath() + contextPath, clientConfig)
+      return getApiClientBuilder(clientConfig.getBasePath() + contextPath, clientConfig)
           .withKeyStore(certificateConfig.getCertificateBytes(), certificateConfig.getPassword())
           .build();
     }
@@ -180,7 +179,6 @@ public class ApiClientFactory {
       log.error(failedCertificateMessage);
       throw new IllegalStateException(failedCertificateMessage, e);
     }
-    return apiClient;
   }
 
   protected ApiClientBuilder getApiClientBuilder(String basePath, BdkClientConfig clientConfig) {

--- a/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/ApiClientBuilder.java
+++ b/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/ApiClientBuilder.java
@@ -81,9 +81,8 @@ public interface ApiClientBuilder {
    *
    * @param connectionPoolMax maximum connections in the pool
    * @return the updated instance of {@link ApiClientBuilder}
-   *
    */
-  default ApiClientBuilder withConnectionPoolMax(Integer connectionPoolMax){
+  default ApiClientBuilder withConnectionPoolMax(Integer connectionPoolMax) {
     // Only ApiClientBuilderJersey2 override default method, otherwise it does nothing
     return this;
   }
@@ -95,9 +94,8 @@ public interface ApiClientBuilder {
    *
    * @param connectionPoolPerRoute maximum connections per each route
    * @return the updated instance of {@link ApiClientBuilder}
-   *
    */
-  default ApiClientBuilder withConnectionPoolPerRoute(Integer connectionPoolPerRoute){
+  default ApiClientBuilder withConnectionPoolPerRoute(Integer connectionPoolPerRoute) {
     // Only ApiClientBuilderJersey2 override default method, otherwise it does nothing
     return this;
   }
@@ -119,4 +117,14 @@ public interface ApiClientBuilder {
    * @return the updated instance of {@link ApiClientBuilder}
    */
   ApiClientBuilder withProxyCredentials(String proxyUser, String proxyPassword);
+
+  /**
+   * Add a request/response interceptor/filter for the HTTP client.
+   *
+   * @param filter Concrete implementation depends on the underlying HTTP client implementation.
+   *                    For Jersey ClientRequestFilter and/or ClientResponseFilter are expected.
+   *                    For Spring WebClient, an ExchangeFilterFunction implementation is expected.
+   */
+  @API(status = API.Status.EXPERIMENTAL)
+  ApiClientBuilder addFilter(Object filter);
 }

--- a/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientBuilderJersey2.java
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientBuilderJersey2.java
@@ -28,7 +28,9 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.net.ssl.SSLContext;
@@ -61,6 +63,7 @@ public class ApiClientBuilderJersey2 implements ApiClientBuilder {
   protected String proxyUrl;
   protected String proxyUser;
   protected String proxyPassword;
+  protected List<Object> filters;
 
   public ApiClientBuilderJersey2() {
     this.basePath = "https://acme.symphony.com";
@@ -77,6 +80,7 @@ public class ApiClientBuilderJersey2 implements ApiClientBuilder {
     this.proxyUrl = null;
     this.proxyUser = null;
     this.proxyPassword = null;
+    this.filters = new ArrayList<>();
     this.withUserAgent(ApiUtils.getUserAgent());
   }
 
@@ -95,6 +99,8 @@ public class ApiClientBuilderJersey2 implements ApiClientBuilder {
 
     httpClient.property(ClientProperties.CONNECT_TIMEOUT, this.connectionTimeout);
     httpClient.property(ClientProperties.READ_TIMEOUT, this.readTimeout);
+
+    filters.forEach(httpClient::register);
 
     return new ApiClientJersey2(httpClient, this.basePath, this.defaultHeaders, this.temporaryFolderPath);
   }
@@ -207,6 +213,12 @@ public class ApiClientBuilderJersey2 implements ApiClientBuilder {
   public ApiClientBuilder withProxyCredentials(String proxyUser, String proxyPassword) {
     this.proxyUser = proxyUser;
     this.proxyPassword = proxyPassword;
+    return this;
+  }
+
+  @Override
+  public ApiClientBuilder addFilter(Object filter) {
+    this.filters.add(filter);
     return this;
   }
 

--- a/symphony-bdk-http/symphony-bdk-http-jersey2/src/test/java/com/symphony/bdk/http/jersey2/ApiClientBuilderJersey2Test.java
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/src/test/java/com/symphony/bdk/http/jersey2/ApiClientBuilderJersey2Test.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.http.jersey2;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.symphony.bdk.http.api.ApiClient;
 import com.symphony.bdk.http.api.ApiException;
@@ -23,6 +24,9 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.ws.rs.client.ClientRequestFilter;
 
 class ApiClientBuilderJersey2Test {
 
@@ -61,6 +65,24 @@ class ApiClientBuilderJersey2Test {
             null, "application/json", "", null, null);
 
     assertEquals(200, response.getStatusCode());
+  }
+
+  @Test
+  void addFilter() {
+    AtomicBoolean filterHasBeenCalled = new AtomicBoolean(false);
+    ApiClient client = new ApiClientBuilderJersey2()
+        .withBasePath("http://localhost:" + mockServer.getPort())
+        .addFilter((ClientRequestFilter) requestContext -> filterHasBeenCalled.set(true))
+        .build();
+
+    try {
+      client.invokeAPI("/test", "GET", Collections.emptyList(), null, Collections.emptyMap(), Collections.emptyMap(),
+          null, "application/json", "", null, null);
+    } catch (ApiException e) {
+      // nothing implemented, calls fail but filter should be called before
+    }
+
+    assertTrue(filterHasBeenCalled.get());
   }
 
   private ByteArrayOutputStream getMockServerKeyStore()

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClient.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClient.java
@@ -12,6 +12,7 @@ import org.apiguardian.api.API;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.transport.ProxyProvider;
@@ -23,7 +24,9 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -54,6 +57,7 @@ public class ApiClientBuilderWebClient implements ApiClientBuilder {
   protected int proxyPort;
   protected String proxyUser;
   protected String proxyPassword;
+  protected List<ExchangeFilterFunction> filters;
 
   public ApiClientBuilderWebClient() {
     this.basePath = "";
@@ -64,6 +68,7 @@ public class ApiClientBuilderWebClient implements ApiClientBuilder {
     this.proxyPort = -1;
     this.proxyUser = null;
     this.proxyPassword = null;
+    this.filters = new ArrayList<>();
     this.withUserAgent(ApiUtils.getUserAgent());
   }
 
@@ -72,9 +77,11 @@ public class ApiClientBuilderWebClient implements ApiClientBuilder {
    */
   @Override
   public ApiClient build() {
-    final WebClient webClient = WebClient.builder()
+    WebClient.Builder builder = WebClient.builder()
         .clientConnector(new ReactorClientHttpConnector(this.createHttpClient()))
-        .baseUrl(this.basePath)
+        .baseUrl(this.basePath);
+    this.filters.forEach(builder::filter);
+    final WebClient webClient = builder
         .build();
 
     return new ApiClientWebClient(webClient, this.basePath, this.defaultHeaders);
@@ -171,6 +178,18 @@ public class ApiClientBuilderWebClient implements ApiClientBuilder {
   public ApiClientBuilder withProxyCredentials(String proxyUser, String proxyPassword) {
     this.proxyUser = proxyUser;
     this.proxyPassword = proxyPassword;
+    return this;
+  }
+
+  @Override
+  public ApiClientBuilder addFilter(Object filter) {
+    if (!(filter instanceof ExchangeFilterFunction)) {
+      throw new IllegalArgumentException(
+          "The filter " + filter.getClass().getName()
+              + " must be an instance of " + ExchangeFilterFunction.class.getName()
+              + " to be used with WebClient HTTP client");
+    }
+    this.filters.add((ExchangeFilterFunction) filter);
     return this;
   }
 

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/test/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClientTest.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/test/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClientTest.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.http.webclient;
 
 import static org.apache.commons.io.IOUtils.toByteArray;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -9,18 +10,18 @@ import com.symphony.bdk.http.api.ApiClient;
 import com.symphony.bdk.http.api.util.ApiUtils;
 
 import ch.qos.logback.classic.Level;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import org.slf4j.LoggerFactory;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 
 import java.io.IOException;
 import java.util.List;
 
-public class ApiClientBuilderWebClientTest {
+class ApiClientBuilderWebClientTest {
 
   private ApiClientBuilderWebClient builder;
   private byte[] truststore;
@@ -73,5 +74,17 @@ public class ApiClientBuilderWebClientTest {
     builder.withKeyStore(keystore, "wrongPassword");
 
     assertThrows(RuntimeException.class, this.builder::build);
+  }
+
+  @Test
+  void addFilterWrongImplementation() {
+    assertThrows(IllegalArgumentException.class, () -> builder.addFilter(new Object()));
+  }
+
+  @Test
+  void addFilterCorrectImplementation() {
+    builder.addFilter((ExchangeFilterFunction) (request, next) -> next.exchange(request));
+
+    assertDoesNotThrow(this.builder::build);
   }
 }

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/test/java/com/symphony/bdk/http/webclient/ApiClientWebClientTest.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/test/java/com/symphony/bdk/http/webclient/ApiClientWebClientTest.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @ExtendWith(BdkMockServerExtension.class)
 class ApiClientWebClientTest {
@@ -53,6 +54,21 @@ class ApiClientWebClientTest {
     assertThrows(ApiException.class, () -> this.apiClient.invokeAPI("/test-api", null, null, null,
         Collections.singletonMap("sessionToken", "test-token"),
         null, null, null, null, new String[] {}, new TypeReference<Response>() {}));
+  }
+
+  @Test
+  void testInvokeApiWithFilter(final BdkMockServer mockServer) throws ApiException {
+    AtomicBoolean filterHasBeenCalled = new AtomicBoolean(false);
+    this.apiClient = mockServer.newApiClient("", (request, next) -> {
+      filterHasBeenCalled.set(true);
+      return next.exchange(request);
+    });
+
+    this.apiClient.invokeAPI("/test-api", "GET", null, null,
+        Collections.singletonMap("sessionToken", "test-token"),
+        null, null, null, "application/json", new String[] {}, new TypeReference<Response>() {});
+
+    assertTrue(filterHasBeenCalled.get());
   }
 
   @Test

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/test/java/com/symphony/bdk/http/webclient/test/BdkMockServer.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/test/java/com/symphony/bdk/http/webclient/test/BdkMockServer.java
@@ -11,6 +11,7 @@ import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 import org.mockserver.model.MediaType;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 
 import java.util.function.Consumer;
 
@@ -33,6 +34,13 @@ public class BdkMockServer {
   public ApiClient newApiClient(String contextPath) {
     return new ApiClientBuilderWebClient()
         .withBasePath("http://localhost:" + this.mockServer.getPort() + contextPath)
+        .build();
+  }
+
+  public ApiClient newApiClient(String contextPath, ExchangeFilterFunction filter) {
+    return new ApiClientBuilderWebClient()
+        .withBasePath("http://localhost:" + this.mockServer.getPort() + contextPath)
+        .addFilter(filter)
         .build();
   }
 


### PR DESCRIPTION
The HTTP clients implementations supported by the BDK both support
registering custom filters to intercept requests and responses. This can
be useful to add custom logic, trace requests, provide metrics or
support use cases such as Agentless.

Using the SymphonyBdkBuilder it is now possible to register such
filters.

For instance:

```java
final SymphonyBdk bdk = new SymphonyBdkBuilder()
        .apiClientFactory(new ApiClientFactory(config){
          @Override
          protected ApiClientBuilder getApiClientBuilder(String basePath, BdkClientConfig clientConfig) {
            ApiClientBuilder apiClientBuilder = super.getApiClientBuilder(basePath, clientConfig);
            apiClientBuilder.addFilter(new JerseyCryptoFilter(config));
            return apiClientBuilder;
          }
        })
        .config(config)
        .build();
```

The concrete implementation is specifc to each HTTP client, this is why
the API takes a generic object.
