### PR TITLE
PLAT-11065: Failing healthcheck could prevent bot's startup

### DIFF
--- a/symphony-bdk-bot-sdk-java/src/main/java/com/symphony/bdk/bot/sdk/monitoring/SymphonyHealthMeterBinder.java
+++ b/symphony-bdk-bot-sdk-java/src/main/java/com/symphony/bdk/bot/sdk/monitoring/SymphonyHealthMeterBinder.java
@@ -1,8 +1,5 @@
 package com.symphony.bdk.bot.sdk.monitoring;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.symphony.bdk.bot.sdk.symphony.HealthcheckClient;
 import com.symphony.bdk.bot.sdk.symphony.model.HealthCheckInfo;
 
@@ -11,13 +8,16 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
 
 /**
  * Retrieves health details for Symphony components (e.g. POD, agent) to be
  * exposed by prometheus endpoint.
  *
  * @author Marcus Secato
- *
  */
 public class SymphonyHealthMeterBinder implements MeterBinder {
   private static final Logger LOGGER = LoggerFactory.getLogger(SymphonyHealthMeterBinder.class);
@@ -48,9 +48,9 @@ public class SymphonyHealthMeterBinder implements MeterBinder {
     Gauge.builder(METRIC_NAME, this, value -> value.status().checkOverallStatus() ? 1.0 : 0.0)
         .description(METRIC_DESCRIPTION)
         .tags(Tags.of(
-            Tag.of(TAG_POD_VERSION, healthStatus.getPodVersion()),
-            Tag.of(TAG_AGENT_VERSION, healthStatus.getAgentVersion()),
-            Tag.of(TAG_API_VERSION, healthStatus.getSymphonyApiClientVersion())))
+            Tag.of(TAG_POD_VERSION, Objects.toString(healthStatus.getPodVersion(), "")),
+            Tag.of(TAG_AGENT_VERSION, Objects.toString(healthStatus.getAgentVersion())),
+            Tag.of(TAG_API_VERSION, Objects.toString(healthStatus.getSymphonyApiClientVersion()))))
         .baseUnit(BASE_UNIT)
         .register(registry);
   }

--- a/symphony-bdk-bot-sdk-java/src/test/java/com/symphony/bdk/bot/sdk/monitoring/SymphonyHealthMeterBinderTest.java
+++ b/symphony-bdk-bot-sdk-java/src/test/java/com/symphony/bdk/bot/sdk/monitoring/SymphonyHealthMeterBinderTest.java
@@ -1,0 +1,38 @@
+package com.symphony.bdk.bot.sdk.monitoring;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.symphony.bdk.bot.sdk.symphony.model.HealthCheckInfo;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import model.HealthcheckResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class SymphonyHealthMeterBinderTest {
+
+  @Test
+  void bindTo_failedHealthCheck() {
+    assertDoesNotThrow(() ->
+        // failing healthcheck returns null
+        new SymphonyHealthMeterBinder(() -> new HealthCheckInfo(null, false, ""))
+            .bindTo(new SimpleMeterRegistry()));
+  }
+
+  @Test
+  void bindTo_workingHealthCheck() {
+    assertDoesNotThrow(() ->
+        new SymphonyHealthMeterBinder(() -> new HealthCheckInfo(healthyResponse(), false, ""))
+            .bindTo(new SimpleMeterRegistry()));
+  }
+
+  private HealthcheckResponse healthyResponse() {
+    HealthcheckResponse response = new HealthcheckResponse();
+    response.setAgentServiceUser(true);
+    response.setPodConnectivity(true);
+    response.setKeyManagerConnectivity(true);
+    response.setPodVersion("123");
+    response.setAgentVersion("123");
+    return response;
+  }
+}


### PR DESCRIPTION
Startup would fail with this error:

Caused by: java.lang.NullPointerException
	at java.util.Objects.requireNonNull(Objects.java:203) ~[?:1.8.0_265]
	at io.micrometer.core.instrument.ImmutableTag.<init>(ImmutableTag.java:35) ~[micrometer-core-1.5.1.jar!/:1.5.1]
	at io.micrometer.core.instrument.Tag.of(Tag.java:29) ~[micrometer-core-1.5.1.jar!/:1.5.1]
	at com.symphony.bdk.bot.sdk.monitoring.SymphonyHealthMeterBinder.bindTo(SymphonyHealthMeterBinder.java:51) ~[symphony-bdk-bot-sdk-java-1.3.4.jar!/:1.3.4]
	at org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryConfigurer.lambda$addBinders$1(MeterRegistryConfigurer.java:84) ~[spring-boot-actuator-autoconfigure-2.3.7.RELEASE.jar!/:2.3.7.RELEASE]
	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183) ~[?:1.8.0_265]
	at java.util.ArrayList.forEach(ArrayList.java:1259) ~[?:1.8.0_265]
	at java.util.stream.SortedOps$RefSortingSink.end(SortedOps.java:395) ~[?:1.8.0_265]
	at java.util.stream.Sink$ChainedReference.end(Sink.java:258) ~[?:1.8.0_265]
	at java.util.stream.Sink$ChainedReference.end(Sink.java:258) ~[?:1.8.0_265]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:483) ~[?:1.8.0_265]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_265]
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) ~[?:1.8.0_265]
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173) ~[?:1.8.0_265]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_265]
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:485) ~[?:1.8.0_265]
	at org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryConfigurer.addBinders(MeterRegistryConfigurer.java:84) ~[spring-boot-actuator-autoconfigure-2.3.7.RELEASE.jar!/:2.3.7.RELEASE]
	at org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryConfigurer.configure(MeterRegistryConfigurer.java:66) ~[spring-boot-actuator-autoconfigure-2.3.7.RELEASE.jar!/:2.3.7.RELEASE]
	at org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryPostProcessor.postProcessAfterInitialization(MeterRegistryPostProcessor.java:64) ~[spring-boot-actuator-autoconfigure-2.3.7.RELEASE.jar!/:2.3.7.RELEASE]

This is caused because if it fails the returned healthcheck's response
is set to null and it is not permitted to register a null micrometer
tag.

Handle this case with a default empty value (I avoided changing the
healthcheck behavior, not sure about other potential impacts).

### Ticket
[PLAT-11065](https://perzoinc.atlassian.net/browse/PLAT-11065)