### PR TITLE
#544 Remove html entities before xml parsing messages

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/util/PresentationMLParser.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/util/PresentationMLParser.java
@@ -4,6 +4,7 @@ import com.symphony.bdk.core.service.message.exception.PresentationMLParserExcep
 
 import lombok.Generated;
 import lombok.SneakyThrows;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apiguardian.api.API;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
@@ -33,7 +34,9 @@ public class PresentationMLParser {
    */
   public static String getTextContent(String presentationML, Boolean trim) throws PresentationMLParserException {
     try {
-      final Document doc = LOCAL_BUILDER.get().parse(new ByteArrayInputStream(presentationML.getBytes(StandardCharsets.UTF_8)));
+      String escapedPresentationML = StringEscapeUtils.unescapeHtml4(presentationML);
+      final Document doc = LOCAL_BUILDER.get().parse(
+          new ByteArrayInputStream(escapedPresentationML.getBytes(StandardCharsets.UTF_8)));
       String textContent = doc.getChildNodes().item(0).getTextContent();
       return trim ? textContent.trim() : textContent;
     } catch (SAXException | IOException e) {

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/util/PresentationMLParserTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/util/PresentationMLParserTest.java
@@ -36,10 +36,10 @@ public class PresentationMLParserTest {
 
   @Test
   void getMessageFromPresentationMLWithEscapedContentTest() throws PresentationMLParserException {
-    String presentationML = "<div data-format=\"PresentationML\" data-version=\"2.0\">&nbsp;</div>";
+    String presentationML = "<div data-format=\"PresentationML\" data-version=\"2.0\">Hello&nbsp;World</div>";
     String content = PresentationMLParser.getTextContent(presentationML, false);
 
-    assertNotEquals(content, "&#160;");
+    assertEquals("Hello World", content);
   }
 
   @Test

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/util/PresentationMLParserTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/util/PresentationMLParserTest.java
@@ -35,6 +35,14 @@ public class PresentationMLParserTest {
   }
 
   @Test
+  void getMessageFromPresentationMLWithEscapedContentTest() throws PresentationMLParserException {
+    String presentationML = "<div data-format=\"PresentationML\" data-version=\"2.0\">&nbsp;</div>";
+    String content = PresentationMLParser.getTextContent(presentationML, false);
+
+    assertNotEquals(content, "&#160;");
+  }
+
+  @Test
   void getMessageFromPresentationMLFailedToParse() {
     String presentationML = "<div data-format=\"PresentationML\" data-version=\"2.0\"> \n"
         + "  <a href=\"http://www.symphony.com\">This is a link to Symphony's Website<a> \n"


### PR DESCRIPTION
### Ticket
closes #544 

### Description
Goal of this PR is to enable the BDK to extract content from a presentationML which contains HTML specific tags.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
