### PR TITLE
Load system truststore in the SSL Context

### DIFF
--- a/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientBuilderJersey2.java
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientBuilderJersey2.java
@@ -13,7 +13,6 @@ import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
-import org.apache.http.ssl.SSLContextBuilder;
 import org.apiguardian.api.API;
 import org.glassfish.jersey.SslConfigurator;
 import org.glassfish.jersey.apache.connector.ApacheClientProperties;
@@ -29,7 +28,6 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -275,6 +273,7 @@ public class ApiClientBuilderJersey2 implements ApiClientBuilder {
         truststore.load(new ByteArrayInputStream(trustStoreBytes), trustStorePassword.toCharArray());
         addDefaultRootCaCertificates(truststore);
         sslConfig.trustStore(truststore);
+        ApiUtils.logTrustStore(truststore);
       }
       if (isNotEmpty(keyStoreBytes) && isNotEmpty(keyStorePassword)) {
         sslConfig

--- a/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientBuilderJersey2.java
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientBuilderJersey2.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientBuilderJersey2.java
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientBuilderJersey2.java
@@ -7,8 +7,8 @@ import com.symphony.bdk.http.api.ApiClientBuilder;
 import com.symphony.bdk.http.api.util.ApiUtils;
 
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.ssl.SSLContextBuilder;
 import org.apiguardian.api.API;
-import org.glassfish.jersey.SslConfigurator;
 import org.glassfish.jersey.apache.connector.ApacheClientProperties;
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
@@ -19,10 +19,8 @@ import org.glassfish.jersey.media.multipart.MultiPartFeature;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -242,32 +240,24 @@ public class ApiClientBuilderJersey2 implements ApiClientBuilder {
 
   @API(status = API.Status.EXPERIMENTAL)
   protected SSLContext createSSLContext() {
-    final SslConfigurator sslConfig = SslConfigurator.newInstance();
-
-    if (isNotEmpty(trustStoreBytes) && isNotEmpty(trustStorePassword)) {
-      sslConfig
-          .trustStoreBytes(trustStoreBytes)
-          .trustStorePassword(trustStorePassword);
-    }
-
-    if (isNotEmpty(keyStoreBytes) && isNotEmpty(keyStorePassword)) {
-      sslConfig
-          .keyStoreBytes(keyStoreBytes)
-          .keyStorePassword(keyStorePassword);
-    }
     try {
-      SSLContext sslContext = sslConfig.createSSLContext();
-
+      SSLContextBuilder builder = new SSLContextBuilder();
+      final KeyStore truststore = KeyStore.getInstance(TRUSTSTORE_FORMAT);
       if (isNotEmpty(trustStoreBytes) && isNotEmpty(trustStorePassword)) {
-        final KeyStore truststore = KeyStore.getInstance(TRUSTSTORE_FORMAT);
         truststore.load(new ByteArrayInputStream(trustStoreBytes), trustStorePassword.toCharArray());
-        ApiUtils.logTrustStore(truststore);
+      } else {
+        truststore.load(null, null);
       }
-
-      return sslContext;
-    } catch (IllegalStateException | KeyStoreException | IOException | NoSuchAlgorithmException | CertificateException e) {
+      if (isNotEmpty(keyStoreBytes) && isNotEmpty(keyStorePassword)) {
+        final KeyStore keystore = KeyStore.getInstance(TRUSTSTORE_FORMAT);
+        keystore.load(new ByteArrayInputStream(keyStoreBytes), keyStorePassword.toCharArray());
+        builder.loadKeyMaterial(keystore, null);
+      }
+      ApiUtils.addDefaultRootCaCertificates(truststore);
+      builder.loadTrustMaterial(truststore, null);
+      return builder.build();
+    }  catch (IOException | GeneralSecurityException e) {
       throw new IllegalStateException(e.getCause().getMessage(), e);
     }
   }
-
 }

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClient.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClient.java
@@ -18,11 +18,8 @@ import reactor.netty.transport.ProxyProvider;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.CertificateException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -198,6 +195,7 @@ public class ApiClientBuilderWebClient implements ApiClientBuilder {
         final KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
         final TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         trustStore.load(new ByteArrayInputStream(this.trustStoreBytes), this.trustStorePassword.toCharArray());
+        ApiUtils.addDefaultRootCaCertificates(trustStore);
         trustManagerFactory.init(trustStore);
         builder.trustManager(trustManagerFactory);
         ApiUtils.logTrustStore(trustStore);
@@ -211,7 +209,7 @@ public class ApiClientBuilderWebClient implements ApiClientBuilder {
         }
       }
       return builder.build();
-    } catch (KeyStoreException | IOException | NoSuchAlgorithmException | CertificateException | UnrecoverableKeyException e) {
+    } catch (GeneralSecurityException | IOException e) {
       throw new RuntimeException(e);
     }
   }

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClient.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClient.java
@@ -21,6 +21,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
### Ticket
#547 

### Description
Goal of this pr is to load both custom and system truststore while creating the SSL context.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
