### PR TITLE
Keep DF loop running for UnknownHostException

### DIFF
--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV1Test.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV1Test.java
@@ -64,6 +64,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -337,6 +338,17 @@ class DatafeedLoopV1Test {
     when(datafeedApi.v4DatafeedCreatePost("1234", "1234")).thenReturn(new Datafeed().id("test-id"));
     when(datafeedApi.v4DatafeedIdReadGet("test-id", "1234", "1234", null))
         .thenThrow(new ProcessingException(new SocketTimeoutException()));
+
+    this.datafeedService.start();
+    verify(datafeedApi, times(2)).v4DatafeedIdReadGet("test-id", "1234", "1234", null);
+    verify(datafeedApiClient, times(2)).rotate();
+  }
+
+  @Test
+  void startTestFailedUnknownHost() throws ApiException, AuthUnauthorizedException {
+    when(datafeedApi.v4DatafeedCreatePost("1234", "1234")).thenReturn(new Datafeed().id("test-id"));
+    when(datafeedApi.v4DatafeedIdReadGet("test-id", "1234", "1234", null))
+        .thenThrow(new ProcessingException(new UnknownHostException()));
 
     this.datafeedService.start();
     verify(datafeedApi, times(2)).v4DatafeedIdReadGet("test-id", "1234", "1234", null);

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2Test.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2Test.java
@@ -44,6 +44,7 @@ import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 
 import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -492,6 +493,24 @@ class DatafeedLoopV2Test {
         Collections.singletonList(new V5Datafeed().id("test-id")));
     when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(
         new ProcessingException(new SocketTimeoutException()));
+
+    ApiClient client = mock(ApiClient.class);
+    when(datafeedApi.getApiClient()).thenReturn(client);
+    when(client.getBasePath()).thenReturn("path/to/the/agent");
+
+    this.datafeedService.start();
+    verify(datafeedApi, times(1)).listDatafeed("1234", "1234", "tibot");
+    verify(datafeedApi, times(2)).readDatafeed("test-id", "1234", "1234", ackId);
+    verify(datafeedApiClient, times(2)).rotate();
+  }
+
+  @Test
+  void testStartUnknownHostReadDatafeed() throws ApiException, AuthUnauthorizedException {
+    AckId ackId = datafeedService.getAckId();
+    when(datafeedApi.listDatafeed("1234", "1234", "tibot")).thenReturn(
+        Collections.singletonList(new V5Datafeed().id("test-id")));
+    when(datafeedApi.readDatafeed("test-id", "1234", "1234", ackId)).thenThrow(
+        new ProcessingException(new UnknownHostException()));
 
     ApiClient client = mock(ApiClient.class);
     when(datafeedApi.getApiClient()).thenReturn(client);


### PR DESCRIPTION
The datafeed loop could stop if DNS related exception were raised (which
could happen because of network glitches or after an outage).

Similar to the timeoutout or connect error we prefer to keep the DF loop
running and to retry.

Note that for DFv2 on startup a DNS error will prevent the DF loop to
start (same as a connect error).
For DFv1 a DNS error will still allow the DF loop to start (if the DF id
already exists) this is consistent with the existing behavior for
connect errors.

Fixes PLAT-11178
