### PR TITLE
Feature-561: Make ApplicationEventMulticaster bean configurable

### DIFF
--- a/docs/spring-boot/core-starter.md
+++ b/docs/spring-boot/core-starter.md
@@ -223,6 +223,15 @@ public class RealTimeEvents {
 }
 ```
 
+By default, the RealTimeEvents are going to be processed asynchronously in the listeners, in case this is not the preferred behavior, one
+can deactivate it by updating the application.yaml file as
+```yaml
+bdk:
+    datafeed:
+        event:
+            async: false
+```
+
 ## Inject Services
 The Core Starter injects services within the Spring application context:
 ```java

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkDatafeedConfig.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkDatafeedConfig.java
@@ -70,6 +70,7 @@ public class BdkDatafeedConfig {
    * Allows to publish application {@link RealTimeEvent} asynchronously from {@link RealTimeEventsDispatcher}.
    */
   @Bean(name = "applicationEventMulticaster")
+  @ConditionalOnProperty(value = "bdk.datafeed.event.async", havingValue = "true", matchIfMissing = true)
   public ApplicationEventMulticaster simpleApplicationEventMulticaster() {
     final SimpleApplicationEventMulticaster eventMulticaster = new SimpleApplicationEventMulticaster();
     eventMulticaster.setTaskExecutor(new SimpleAsyncTaskExecutor());


### PR DESCRIPTION
Running the application event consumer asynchronously is not always preferable,
this feature will give the a better control on that to BDK client.

Example:
bdk:
    datafeed:
        async: false

### Ticket
[561](https://github.com/finos/symphony-bdk-java/issues/561)

### Description
Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced a ticket in the PR title and in the corresponding section
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
