### PR TITLE
ApiClientJersey2 initialize random traceId if not already set

### DIFF
--- a/symphony-bdk-http/symphony-bdk-http-jersey2/build.gradle
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/build.gradle
@@ -37,5 +37,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'ch.qos.logback:logback-classic'
     testImplementation 'org.mock-server:mockserver-netty'
+    testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
 }
 

--- a/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientJersey2.java
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientJersey2.java
@@ -96,10 +96,12 @@ public class ApiClientJersey2 implements ApiClient {
 
     Invocation.Builder invocationBuilder = target.request().accept(accept);
 
-    if (DistributedTracingContext.hasTraceId()) {
-      invocationBuilder =
-          invocationBuilder.header(DistributedTracingContext.TRACE_ID, DistributedTracingContext.getTraceId());
+    if (!DistributedTracingContext.hasTraceId()) {
+      DistributedTracingContext.setTraceId();
     }
+
+    invocationBuilder =
+        invocationBuilder.header(DistributedTracingContext.TRACE_ID, DistributedTracingContext.getTraceId());
 
     if (headerParams != null) {
       for (Entry<String, String> entry : headerParams.entrySet()) {
@@ -175,6 +177,8 @@ public class ApiClientJersey2 implements ApiClient {
             buildResponseHeaders(response),
             respBody);
       }
+    } finally {
+      DistributedTracingContext.clear();
     }
   }
 

--- a/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientJersey2.java
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientJersey2.java
@@ -95,9 +95,11 @@ public class ApiClientJersey2 implements ApiClient {
     }
 
     Invocation.Builder invocationBuilder = target.request().accept(accept);
+    boolean clearTraceId = false;
 
     if (!DistributedTracingContext.hasTraceId()) {
       DistributedTracingContext.setTraceId();
+      clearTraceId = true;
     }
 
     invocationBuilder =
@@ -178,7 +180,9 @@ public class ApiClientJersey2 implements ApiClient {
             respBody);
       }
     } finally {
-      DistributedTracingContext.clear();
+      if (clearTraceId) {
+        DistributedTracingContext.clear();
+      }
     }
   }
 

--- a/symphony-bdk-http/symphony-bdk-http-jersey2/src/test/java/com/symphony/bdk/http/jersey2/ApiClientJersey2Test.java
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/src/test/java/com/symphony/bdk/http/jersey2/ApiClientJersey2Test.java
@@ -1,0 +1,86 @@
+package com.symphony.bdk.http.jersey2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.symphony.bdk.http.api.ApiException;
+import com.symphony.bdk.http.api.tracing.DistributedTracingContext;
+
+import com.symphony.bdk.http.api.util.TypeReference;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.Response;
+
+@ExtendWith(MockitoExtension.class)
+class ApiClientJersey2Test {
+
+  private ApiClientJersey2 apiClient;
+
+  @BeforeEach
+  void init(
+      @Mock Client client,
+      @Mock WebTarget target,
+      @Mock Invocation.Builder builder,
+      @Mock Response response,
+      @Mock Response.StatusType statusInfo
+  ) {
+    when(client.target(anyString())).thenReturn(target);
+    when(target.request()).thenReturn(builder);
+    when(builder.accept(anyString())).thenReturn(builder);
+    when(builder.header(anyString(), any())).thenReturn(builder);
+    when(builder.post(any(Entity.class))).thenReturn(response);
+    when(response.getStatusInfo()).thenReturn(statusInfo);
+    when(statusInfo.getStatusCode()).thenReturn(200);
+    when(statusInfo.getFamily()).thenReturn(Response.Status.Family.SUCCESSFUL);
+    when(response.getHeaders()).thenReturn(new MultivaluedHashMap<>());
+    this.apiClient = new ApiClientJersey2(client, "", Collections.emptyMap(), "");
+  }
+
+  @Test
+  void shouldClearTraceIdIfNotSet() throws ApiException {
+    assertTrue(DistributedTracingContext.getTraceId().isEmpty());
+    this.doInvokeAPI();
+    assertTrue(DistributedTracingContext.getTraceId().isEmpty());
+  }
+
+  @Test
+  void shouldPreserveExistingTraceId() throws ApiException {
+    String traceId = UUID.randomUUID().toString();
+    DistributedTracingContext.setTraceId(traceId);
+    this.doInvokeAPI();
+    assertEquals(traceId, DistributedTracingContext.getTraceId());
+  }
+
+  private void doInvokeAPI() throws ApiException {
+    this.apiClient.invokeAPI(
+        "/hello",
+        HttpMethod.POST,
+        Collections.emptyList(),
+        null,
+        Collections.emptyMap(),
+        Collections.emptyMap(),
+        Collections.emptyMap(),
+        "application/json",
+        "application/json",
+        new String[0],
+        new TypeReference<String>() {}
+    );
+  }
+}

--- a/symphony-bdk-http/symphony-bdk-http-jersey2/src/test/java/com/symphony/bdk/http/jersey2/ApiClientJersey2Test.java
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/src/test/java/com/symphony/bdk/http/jersey2/ApiClientJersey2Test.java
@@ -55,7 +55,7 @@ class ApiClientJersey2Test {
 
   @Test
   void shouldClearTraceIdIfNotSet() throws ApiException {
-    assertTrue(DistributedTracingContext.getTraceId().isEmpty());
+    DistributedTracingContext.clear();
     this.doInvokeAPI();
     assertTrue(DistributedTracingContext.getTraceId().isEmpty());
   }

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientWebClient.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientWebClient.java
@@ -90,9 +90,13 @@ public class ApiClientWebClient implements ApiClient {
       requestBodySpec.accept(MediaType.valueOf(accept));
     }
 
+    boolean clearTraceId = false;
+
     if (!DistributedTracingContext.hasTraceId()) {
       DistributedTracingContext.setTraceId();
+      clearTraceId = true;
     }
+
     requestBodySpec =
         requestBodySpec.header(DistributedTracingContext.TRACE_ID, DistributedTracingContext.getTraceId());
 
@@ -154,6 +158,10 @@ public class ApiClientWebClient implements ApiClient {
             exception.getUri(), exception.getHeaders());
       } else {
         throw e;
+      }
+    } finally {
+      if (clearTraceId) {
+        DistributedTracingContext.clear();
       }
     }
   }

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/test/java/com/symphony/bdk/http/webclient/ApiClientWebClientTest.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/test/java/com/symphony/bdk/http/webclient/ApiClientWebClientTest.java
@@ -10,6 +10,7 @@ import com.symphony.bdk.http.api.ApiClient;
 import com.symphony.bdk.http.api.ApiException;
 import com.symphony.bdk.http.api.ApiResponse;
 import com.symphony.bdk.http.api.Pair;
+import com.symphony.bdk.http.api.tracing.DistributedTracingContext;
 import com.symphony.bdk.http.api.util.TypeReference;
 import com.symphony.bdk.http.webclient.test.BdkMockServer;
 import com.symphony.bdk.http.webclient.test.BdkMockServerExtension;
@@ -36,6 +37,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @ExtendWith(BdkMockServerExtension.class)
 class ApiClientWebClientTest {
@@ -280,6 +282,41 @@ class ApiClientWebClientTest {
 
     assertEquals(200, response.getData().getCode());
     assertEquals("success", response.getData().getMessage());
+  }
+
+  @Test
+  void shouldClearTraceIdIfNotSet(final BdkMockServer mockServer) throws ApiException {
+    mockServer.onRequestModifierWithResponse(200,
+        httpRequest -> httpRequest
+            .withMethod("GET")
+            .withPath("/test-api")
+            .withHeader("sessionToken", "test-token"),
+        httpResponse -> httpResponse.withBody("{\"code\": 200, \"message\": \"success\"}"));
+
+    assertTrue(DistributedTracingContext.getTraceId().isEmpty());
+
+    this.apiClient.invokeAPI("/test-api", "GET", null, null, Collections.singletonMap("sessionToken", "test-token"),
+            null, null, null, "application/json", new String[] {}, new TypeReference<Response>() {});
+
+    assertTrue(DistributedTracingContext.getTraceId().isEmpty());
+  }
+
+  @Test
+  void shouldPreserveExistingTraceId(final BdkMockServer mockServer) throws ApiException {
+    mockServer.onRequestModifierWithResponse(200,
+        httpRequest -> httpRequest
+            .withMethod("GET")
+            .withPath("/test-api")
+            .withHeader("sessionToken", "test-token"),
+        httpResponse -> httpResponse.withBody("{\"code\": 200, \"message\": \"success\"}"));
+
+    String traceId = UUID.randomUUID().toString();
+    DistributedTracingContext.setTraceId(traceId);
+
+    this.apiClient.invokeAPI("/test-api", "GET", null, null, Collections.singletonMap("sessionToken", "test-token"),
+        null, null, null, "application/json", new String[] {}, new TypeReference<Response>() {});
+
+    assertEquals(traceId, DistributedTracingContext.getTraceId());
   }
 
   @Test

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/test/java/com/symphony/bdk/http/webclient/ApiClientWebClientTest.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/test/java/com/symphony/bdk/http/webclient/ApiClientWebClientTest.java
@@ -293,7 +293,7 @@ class ApiClientWebClientTest {
             .withHeader("sessionToken", "test-token"),
         httpResponse -> httpResponse.withBody("{\"code\": 200, \"message\": \"success\"}"));
 
-    assertTrue(DistributedTracingContext.getTraceId().isEmpty());
+    DistributedTracingContext.clear();
 
     this.apiClient.invokeAPI("/test-api", "GET", null, null, Collections.singletonMap("sessionToken", "test-token"),
             null, null, null, "application/json", new String[] {}, new TypeReference<Response>() {});


### PR DESCRIPTION
PR https://github.com/finos/symphony-bdk-java/pull/489 has introduced a regression where the `ApiClientJersey2` stopped initializing the `traceId` value if not already set: 
![Screen Shot 2021-08-27 at 17 12 03](https://user-images.githubusercontent.com/39826516/131149797-ee7b6cd1-0a6b-4da5-af07-dd01272f2ea9.png)

Here we revert this change but we now ensure that the `traceId` is cleared in order to not pollute subsequent logs.