### PR TITLE
#566 Support of Search Messages endpoint (using POST)

### DIFF
--- a/docs/message.md
+++ b/docs/message.md
@@ -4,6 +4,7 @@ The Message API aims to cover the Messages part of the [REST API documentation](
 More precisely:
 * [Get a message](https://developers.symphony.com/restapi/reference#get-message-v1)
 * [Get messages](https://developers.symphony.com/restapi/reference#messages-v4)
+* [Search messages](https://developers.symphony.com/restapi/reference#message-search-post)
 * [Get message IDs by timestamp](https://developers.symphony.com/restapi/reference#get-message-ids-by-timestamp)
 * [Send message](https://developers.symphony.com/restapi/reference#create-message-v4)
 * [Import messages](https://developers.symphony.com/restapi/reference#import-message-v4)

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/model/SortDir.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/model/SortDir.java
@@ -1,8 +1,11 @@
 package com.symphony.bdk.core.service.message.model;
 
+import org.apiguardian.api.API;
+
 /**
  * Sorting direction for response. Possible values are desc (default) and asc.
  */
+@API(status = API.Status.STABLE)
 public enum SortDir {
   DESC, ASC
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/model/SortDir.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/model/SortDir.java
@@ -1,0 +1,8 @@
+package com.symphony.bdk.core.service.message.model;
+
+/**
+ * Sorting direction for response. Possible values are desc (default) and asc.
+ */
+public enum SortDir {
+  DESC, ASC
+}

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/MessageServiceTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/MessageServiceTest.java
@@ -35,6 +35,7 @@ import com.symphony.bdk.gen.api.StreamsApi;
 import com.symphony.bdk.gen.api.model.MessageMetadataResponse;
 import com.symphony.bdk.gen.api.model.MessageMetadataResponseParent;
 import com.symphony.bdk.gen.api.model.MessageReceiptDetailResponse;
+import com.symphony.bdk.gen.api.model.MessageSearchQuery;
 import com.symphony.bdk.gen.api.model.MessageStatus;
 import com.symphony.bdk.gen.api.model.MessageSuppressionResponse;
 import com.symphony.bdk.gen.api.model.StreamAttachmentItem;
@@ -73,6 +74,7 @@ import java.util.stream.Stream;
 class MessageServiceTest {
 
   private static final String V4_STREAM_MESSAGE = "/agent/v4/stream/{sid}/message";
+  private static final String V4_SEARCH_MESSAGES = "/agent/v1/message/search";
   private static final String V4_STREAM_MESSAGE_CREATE = "/agent/v4/stream/{sid}/message/create";
   private static final String V4_MESSAGE_IMPORT = "/agent/v4/message/import";
   private static final String V4_BLAST_MESSAGE = "/agent/v4/message/blast";
@@ -179,6 +181,34 @@ class MessageServiceTest {
     assertEquals(2, messages.size());
     assertEquals(Arrays.asList("messageId1", "messageId2"),
         messages.stream().map(V4Message::getMessageId).collect(Collectors.toList()));
+  }
+
+
+  @Test
+  void testSearchMessages() throws IOException {
+    mockApiClient.onPost(V4_SEARCH_MESSAGES,
+        JsonHelper.readFromClasspath("/message/get_message_stream_id.json"));
+
+    final List<V4Message> messages = messageService.searchMessages(new MessageSearchQuery());
+
+    assertEquals(2, messages.size());
+    assertEquals(Arrays.asList("messageId1", "messageId2"),
+        messages.stream().map(V4Message::getMessageId).collect(Collectors.toList()));
+  }
+
+  @Test
+  void testSearchMessagesQueryValidation() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> messageService.searchMessages(new MessageSearchQuery().streamType("FOO")),
+        "checks if streamType value is a valid one"
+    );
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> messageService.searchMessages(new MessageSearchQuery().text("foo")),
+        "text require streamId arg to be provided"
+    );
   }
 
   @Test

--- a/symphony-bdk-examples/bdk-core-examples/src/main/java/com/symphony/bdk/examples/SearchMessageExampleMain.java
+++ b/symphony-bdk-examples/bdk-core-examples/src/main/java/com/symphony/bdk/examples/SearchMessageExampleMain.java
@@ -1,0 +1,37 @@
+package com.symphony.bdk.examples;
+
+import static com.symphony.bdk.core.config.BdkConfigLoader.loadFromSymphonyDir;
+
+import com.symphony.bdk.core.SymphonyBdk;
+import com.symphony.bdk.core.service.message.model.SortDir;
+import com.symphony.bdk.core.service.pagination.model.PaginationAttribute;
+import com.symphony.bdk.gen.api.model.MessageSearchQuery;
+import com.symphony.bdk.gen.api.model.V4Message;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+
+/**
+ * This demonstrates a basic usage of the message service.
+ */
+@Slf4j
+public class SearchMessageExampleMain {
+
+  public static void main(String[] args) throws Exception {
+    final SymphonyBdk bdk = new SymphonyBdk(loadFromSymphonyDir("config.yaml"));
+
+    final List<V4Message> results = bdk.messages().searchMessages(
+        new MessageSearchQuery()
+            .fromDate(0L)
+            .streamType("IM"),
+        new PaginationAttribute(0, 1000),
+        SortDir.ASC
+    );
+
+    log.info("Found {} messages:", results.size());
+    for (V4Message result : results) {
+       log.info("- {} -> {}", result.getMessageId(), result.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
### Ticket
Closes #566

### Description
Support of [Search Messages endpoint](https://developers.symphony.com/restapi/reference#message-search-post).
Also added so pre-validation checks following [public documentation](https://developers.symphony.com/restapi/reference#message-search-post).
Decided to implement the `POST` version only, as it allows to use the generated `MessageSearchQuery` class. The `POST` endpoint is completely similar to the `GET` one. 

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Unit tests updated or added
- [x] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
