### PR TITLE
Fixed characters escape in PresentationMLParser

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/util/PresentationMLParser.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/util/PresentationMLParser.java
@@ -32,13 +32,13 @@ public class PresentationMLParser {
    * @param trim            flag if we want to trim the text result
    * @return the message text content extracted from the given PresentationML
    */
-  public static String getTextContent(String presentationML, Boolean trim) throws PresentationMLParserException {
+  public static String getTextContent(String presentationML, boolean trim) throws PresentationMLParserException {
     try {
-      String escapedPresentationML = StringEscapeUtils.unescapeHtml4(presentationML);
       final Document doc = LOCAL_BUILDER.get().parse(
-          new ByteArrayInputStream(escapedPresentationML.getBytes(StandardCharsets.UTF_8)));
+          new ByteArrayInputStream(presentationML.getBytes(StandardCharsets.UTF_8)));
       String textContent = doc.getChildNodes().item(0).getTextContent();
-      return trim ? textContent.trim() : textContent;
+      String escapedPresentationML = StringEscapeUtils.unescapeHtml4(textContent);
+      return trim ? escapedPresentationML.trim() : escapedPresentationML;
     } catch (SAXException | IOException e) {
       throw new PresentationMLParserException(presentationML, "Failed to parse the PresentationML", e);
     }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/util/PresentationMLParserTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/util/PresentationMLParserTest.java
@@ -3,23 +3,36 @@ package com.symphony.bdk.core.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.symphony.bdk.core.service.message.exception.PresentationMLParserException;
 import com.symphony.bdk.core.service.message.util.PresentationMLParser;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-public class PresentationMLParserTest {
+import java.util.stream.Stream;
 
-  @Test
-  void getMessageFromPresentationMLTest() throws PresentationMLParserException {
-    String presentationML = "<div data-format=\"PresentationML\" data-version=\"2.0\"> \n"
-        + "  <a href=\"http://www.symphony.com\">This is a link to Symphony's Website</a> \n"
-        + "</div>";
+class PresentationMLParserTest {
 
-    String content = PresentationMLParser.getTextContent(presentationML);
+  static Stream<Arguments> validPresentationMLs() {
+    return Stream.of(
+        arguments(
+            "<div data-format=\"PresentationML\" data-version=\"2.0\">\n<a href=\"http://www.symphony.com\">This is a link to Symphony's Website</a>\n</div>",
+            "This is a link to Symphony's Website"),
+        arguments("<div data-format=\"PresentationML\" data-version=\"2.0\"> <p>/test &lt;/messageML&gt;</p> </div>",
+            "/test </messageML>"),
+        arguments("<div data-format=\"PresentationML\" data-version=\"2.0\">Hello&#xA0;World</div>", "Hello World"));
+  }
 
-    assertEquals(content, "This is a link to Symphony's Website");
+
+  @ParameterizedTest
+  @MethodSource("validPresentationMLs")
+  void getMessageFromPresentationMLTest(String presentationML, String expectedContent)
+      throws PresentationMLParserException {
+    assertEquals(expectedContent, PresentationMLParser.getTextContent(presentationML));
   }
 
   @Test
@@ -30,16 +43,8 @@ public class PresentationMLParserTest {
 
     String content = PresentationMLParser.getTextContent(presentationML, false);
 
-    assertNotEquals(content, "This is a link to Symphony's Website");
-    assertEquals(content.trim(), "This is a link to Symphony's Website");
-  }
-
-  @Test
-  void getMessageFromPresentationMLWithEscapedContentTest() throws PresentationMLParserException {
-    String presentationML = "<div data-format=\"PresentationML\" data-version=\"2.0\">Hello&nbsp;World</div>";
-    String content = PresentationMLParser.getTextContent(presentationML, false);
-
-    assertEquals("Hello World", content);
+    assertNotEquals("This is a link to Symphony's Website", content);
+    assertEquals("This is a link to Symphony's Website", content.trim());
   }
 
   @Test


### PR DESCRIPTION
PresentationMLParser getTextContent method was unescaping content characters before parsing it which fails when the message contains messageML tags for instance. In this commit, we changed operations order to parse the message first with the escaped characters, then unescape it in a second time