### PR TITLE
Prevent invalid signed JWT expiration upon login

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/jwt/JwtHelper.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/jwt/JwtHelper.java
@@ -42,7 +42,7 @@ import java.util.Date;
 @API(status = API.Status.INTERNAL)
 public class JwtHelper {
 
-  // Expiration of the jwt, 5 minutes maximum, use a little less than that in case of clock differents
+  // Expiration of the jwt, 5 minutes maximum, use a little less than that in case of different clock skews
   public static final Long JWT_EXPIRATION_MILLIS = 240_000L;
 
 	// PKCS#8 format

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/jwt/JwtHelper.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/jwt/JwtHelper.java
@@ -42,8 +42,8 @@ import java.util.Date;
 @API(status = API.Status.INTERNAL)
 public class JwtHelper {
 
-  // Expiration of the jwt
-  public static final Long JWT_EXPIRATION_MILLIS = 300_000L;
+  // Expiration of the jwt, 5 minutes maximum, use a little less than that in case of clock differents
+  public static final Long JWT_EXPIRATION_MILLIS = 240_000L;
 
 	// PKCS#8 format
 	private static final String PEM_PRIVATE_START = "-----BEGIN PRIVATE KEY-----";


### PR DESCRIPTION
If the backend and the bot/BDK do not have their clocks synced, the
signed JWT generated to authenticate could be considered as invalid
because the expiration is considered to be more then 5 minutes by the
backend.

We use 4 minutes instead to accommodate that.

Given we create a new token for each authentication attempt this should
be fine to use less than 5 minutes (we expect the signed JWT to be used
quickly).
