### PR TITLE
Optional ConnectionService#listConnections parameters

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/connection/ConnectionService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/connection/ConnectionService.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Service class for managing connection status.
@@ -72,10 +73,16 @@ public class ConnectionService implements OboConnectionService, OboService<OboCo
    * {@inheritDoc}
    */
   @Override
-  public List<UserConnection> listConnections(@Nonnull ConnectionStatus status, @Nonnull List<Long> userIdList) {
-    String userIds = userIdList.stream().map(String::valueOf).collect(Collectors.joining(","));
+  public List<UserConnection> listConnections(@Nullable ConnectionStatus status, @Nullable List<Long> userIdList) {
+    final String userIds = userIdList != null ?
+        userIdList.stream().map(String::valueOf).collect(Collectors.joining(","))
+        : null;
     return executeAndRetry("listConnection",
-        () -> connectionApi.v1ConnectionListGet(authSession.getSessionToken(), status.name(), userIds));
+        () -> connectionApi.v1ConnectionListGet(authSession.getSessionToken(),
+            status != null ? status.name() : null,
+            userIds
+        )
+    );
   }
 
   /**

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/connection/OboConnectionService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/connection/OboConnectionService.java
@@ -8,6 +8,7 @@ import org.apiguardian.api.API;
 import java.util.List;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Service interface exposing OBO-enabled endpoints to manage user connection status.
@@ -38,7 +39,7 @@ public interface OboConnectionService {
    * @return List of connection statuses with the specified users and status.
    * @see <a href="https://developers.symphony.com/restapi/reference#list-connections">List Connections</a>
    */
-  List<UserConnection> listConnections(@Nonnull ConnectionStatus status, @Nonnull List<Long> userIds);
+  List<UserConnection> listConnections(@Nullable ConnectionStatus status, @Nullable List<Long> userIds);
 
   /**
    * Sends a connection request to another user.

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/connection/ConnectionServiceTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/connection/ConnectionServiceTest.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.core.service.connection;
 
-import static com.symphony.bdk.http.api.Pair.pairs;
+import static com.symphony.bdk.http.api.Pair.pair;
+import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -20,7 +21,7 @@ import com.symphony.bdk.http.api.ApiRuntimeException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class ConnectionServiceTest {
@@ -97,10 +98,10 @@ public class ConnectionServiceTest {
   @Test
   void listConnectionsTest() {
     this.mockApiClient.onGet(V1_LIST_CONNECTION,
-        pairs(
-            "status", "ALL",
-            "userIds", "7078106126503,7078106103809"
-        ),
+          asList(
+              pair("status", "ALL"),
+              pair("userIds", "7078106126503,7078106103809")
+          ),
         "[\n"
             + "  {\n"
             + "    \"userId\": 7078106126503,\n"
@@ -114,7 +115,7 @@ public class ConnectionServiceTest {
             + "  }\n"
             + "]");
 
-    List<UserConnection> connections = this.service.listConnections(ConnectionStatus.ALL, Arrays.asList(7078106126503L, 7078106103809L));
+    List<UserConnection> connections = this.service.listConnections(ConnectionStatus.ALL, asList(7078106126503L, 7078106103809L));
 
     assertEquals(connections.size(), 2);
     assertEquals(connections.get(0).getStatus(), UserConnection.StatusEnum.PENDING_OUTGOING);
@@ -126,9 +127,7 @@ public class ConnectionServiceTest {
   @Test
   void listConnectionsWithNullStatusTest() {
     this.mockApiClient.onGet(V1_LIST_CONNECTION,
-        pairs(
-            "userIds", "7078106126503,7078106103809"
-        ),
+        Collections.singletonList(pair("userIds", "7078106126503,7078106103809")),
         "[\n"
             + "  {\n"
             + "    \"userId\": 7078106126503,\n"
@@ -142,7 +141,7 @@ public class ConnectionServiceTest {
             + "  }\n"
             + "]");
 
-    List<UserConnection> connections = this.service.listConnections(null, Arrays.asList(7078106126503L, 7078106103809L));
+    List<UserConnection> connections = this.service.listConnections(null, asList(7078106126503L, 7078106103809L));
 
     assertEquals(connections.size(), 2);
     assertEquals(connections.get(0).getStatus(), UserConnection.StatusEnum.PENDING_OUTGOING);
@@ -154,9 +153,7 @@ public class ConnectionServiceTest {
   @Test
   void listConnectionsWithNullListOfUsersTest() {
     this.mockApiClient.onGet(V1_LIST_CONNECTION,
-        pairs(
-            "status", "PENDING_OUTGOING"
-        ),
+        Collections.singletonList(pair("status", "PENDING_OUTGOING")),
         "[\n"
             + "  {\n"
             + "    \"userId\": 7078106126503,\n"
@@ -183,7 +180,7 @@ public class ConnectionServiceTest {
   void listConnectionsFailed() {
     this.mockApiClient.onGet(400, V1_LIST_CONNECTION, "{}");
 
-    assertThrows(ApiRuntimeException.class, () -> this.service.listConnections(ConnectionStatus.ALL, Arrays.asList(7078106126503L, 7078106103809L)));
+    assertThrows(ApiRuntimeException.class, () -> this.service.listConnections(ConnectionStatus.ALL, asList(7078106126503L, 7078106103809L)));
   }
 
   @Test

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/test/MockApiClient.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/test/MockApiClient.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.symphony.bdk.http.api.ApiClient;
+import com.symphony.bdk.http.api.Pair;
 import com.symphony.bdk.http.jersey2.ApiClientJersey2;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -18,7 +19,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.mockito.ArgumentMatchers;
 
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.ParameterizedType;
+import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.List;
 
@@ -33,23 +36,56 @@ import javax.ws.rs.core.Response;
 public class MockApiClient {
 
   private static final ObjectMapper MAPPER = new JsonMapper();
-  private final Client httpClient;
-
-  public MockApiClient() {
+  static {
     MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    this.httpClient = mock(Client.class);
+  }
+  private final Client httpClient = mock(Client.class);
+  {
     when(this.httpClient.target(anyString())).thenThrow(new MockApiClientException("Calling the mocked ApiClient with wrong path"));
   }
 
-  public void onRequestWithResponseCode(String method, int statusCode, String path, String resContent)  {
+  public void onGet(String path, String resContent) {
+    this.onRequestWithResponseCode("GET", 200, path, null, resContent);
+  }
+
+  public void onGet(int statusCode, String path, String resContent) {
+    this.onRequestWithResponseCode("GET", statusCode, path, null, resContent);
+  }
+
+  public void onGet(String path, List<Pair> queryParams, String resContent) {
+    this.onRequestWithResponseCode("GET", 200, path, queryParams, resContent);
+  }
+
+  public void onPost(String path, String resContent) {
+    this.onRequestWithResponseCode("POST", 200, path, null, resContent);
+  }
+
+  public void onPost(int statusCode, String path, String resContent) {
+    this.onRequestWithResponseCode("POST", statusCode, path, null, resContent);
+  }
+
+  public void onDelete(String path, String resContent) {
+    this.onRequestWithResponseCode("DELETE", 200, path, null, resContent);
+  }
+
+  public void onDelete(int statusCode, String path, String resContent) {
+    this.onRequestWithResponseCode("DELETE", statusCode, path, null, resContent);
+  }
+
+  public ApiClient getApiClient(String basePath) {
+    return new ApiClientJersey2(this.httpClient, basePath, new HashMap<>(), null);
+  }
+
+  private void onRequestWithResponseCode(String method, int statusCode, String path, List<Pair> queryParams,
+      String resContent)  {
     WebTarget webTarget = null;
     try {
        webTarget = this.httpClient.target(path);
     } catch (RuntimeException ignored) {
-
+      // ignored
     }
     if (webTarget == null) {
-      webTarget = this.initMockWebTarget();
+      webTarget = this.initMockWebTarget(queryParams);
       doReturn(webTarget).when(this.httpClient).target(path);
     }
     Invocation.Builder invocationBuilder = webTarget.request();
@@ -91,35 +127,26 @@ public class MockApiClient {
     return invocationBuilder;
   }
 
-  private WebTarget initMockWebTarget() {
+  private WebTarget initMockWebTarget(List<Pair> queryParams) {
     WebTarget webTarget = mock(WebTarget.class);
-    when(webTarget.queryParam(anyString(), any())).thenReturn(webTarget);
+
+    if (queryParams != null) {
+      when(webTarget.queryParam(anyString(), any())).thenThrow(new MockApiClientException("Calling the mocked ApiClient with wrong query params"));
+      for (Pair queryParam : queryParams) {
+        when(webTarget.queryParam(eq(queryParam.getName()), eq(escapeString(queryParam.getValue())))).thenReturn(webTarget);
+      }
+    } else {
+      when(webTarget.queryParam(anyString(), any())).thenReturn(webTarget);
+    }
+
     return webTarget;
   }
 
-  public void onGet(String path, String resContent) {
-    this.onRequestWithResponseCode("GET", 200, path, resContent);
-  }
-
-  public void onPost(String path, String resContent) {
-    this.onRequestWithResponseCode("POST", 200, path, resContent);
-  }
-
-  public void onDelete(String path, String resContent) {this.onRequestWithResponseCode("DELETE", 200, path, resContent);}
-
-  public void onGet(int statusCode, String path, String resContent) {
-    this.onRequestWithResponseCode("GET", statusCode, path, resContent);
-  }
-
-  public void onPost(int statusCode, String path, String resContent) {
-    this.onRequestWithResponseCode("POST", statusCode, path, resContent);
-  }
-
-  public void onDelete(int statusCode, String path, String resContent) {
-    this.onRequestWithResponseCode("DELETE", statusCode, path, resContent);
-  }
-
-  public ApiClient getApiClient(String basePath) {
-    return new ApiClientJersey2(this.httpClient, basePath, new HashMap<>(), null);
+  private static String escapeString(String str) {
+    try {
+      return URLEncoder.encode(str, "utf8").replaceAll("\\+", "%20");
+    } catch (UnsupportedEncodingException e) {
+      return str;
+    }
   }
 }

--- a/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/Pair.java
+++ b/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/Pair.java
@@ -3,6 +3,9 @@ package com.symphony.bdk.http.api;
 import lombok.Getter;
 import org.apiguardian.api.API;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Pair of string values. Used by generated code only.
  */
@@ -10,31 +13,48 @@ import org.apiguardian.api.API;
 @API(status = API.Status.INTERNAL)
 public class Pair {
 
-    private String name = "";
-    private String value = "";
+  private String name = "";
+  private String value = "";
 
-    public Pair(String name, String value) {
-        this.setName(name);
-        this.setValue(value);
+  public Pair(String name, String value) {
+    this.setName(name);
+    this.setValue(value);
+  }
+
+  public static Pair pair(String name, String value) {
+    return new Pair(name, value);
+  }
+
+  public static List<Pair> pairs(String... pairs) {
+
+    if (pairs.length % 2 != 0) {
+      throw new IllegalArgumentException("Length of arguments should be a multiple of 2.");
     }
 
-    private void setName(String name) {
-        if (isInvalidString(name)) {
-            return;
-        }
+    List<Pair> result = new ArrayList<>();
+    for (int i = 0; i < pairs.length; i+=2) {
+      result.add(pair(pairs[i], pairs[i + 1]));
+    }
+    return result;
+  }
 
-        this.name = name;
+  private void setName(String name) {
+    if (isInvalidString(name)) {
+      return;
     }
 
-    private void setValue(String value) {
-        if (isInvalidString(value)) {
-            return;
-        }
+    this.name = name;
+  }
 
-        this.value = value;
+  private void setValue(String value) {
+    if (isInvalidString(value)) {
+      return;
     }
 
-    private static boolean isInvalidString(String arg) {
-        return arg == null || arg.trim().isEmpty();
-    }
+    this.value = value;
+  }
+
+  private static boolean isInvalidString(String arg) {
+    return arg == null || arg.trim().isEmpty();
+  }
 }

--- a/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/Pair.java
+++ b/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/Pair.java
@@ -3,9 +3,6 @@ package com.symphony.bdk.http.api;
 import lombok.Getter;
 import org.apiguardian.api.API;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Pair of string values. Used by generated code only.
  */
@@ -23,19 +20,6 @@ public class Pair {
 
   public static Pair pair(String name, String value) {
     return new Pair(name, value);
-  }
-
-  public static List<Pair> pairs(String... pairs) {
-
-    if (pairs.length % 2 != 0) {
-      throw new IllegalArgumentException("Length of arguments should be a multiple of 2.");
-    }
-
-    List<Pair> result = new ArrayList<>();
-    for (int i = 0; i < pairs.length; i+=2) {
-      result.add(pair(pairs[i], pairs[i + 1]));
-    }
-    return result;
   }
 
   private void setName(String name) {


### PR DESCRIPTION
Following our [official documentation](https://symphony.readme.io/restapi/reference#list-connections), the `ConnectionService#listConnections(ConnectionStatus, List<Long>)` are now optional and can therefore be set to `null`. 

Also took the opportunity to improve testing of query params that can now be asserted when using the `MockApiClient`. 