### PR TITLE
[beta] Support of message update endpoint

### DIFF
--- a/docs/message.md
+++ b/docs/message.md
@@ -7,6 +7,7 @@ More precisely:
 * [Search messages](https://developers.symphony.com/restapi/reference#message-search-post)
 * [Get message IDs by timestamp](https://developers.symphony.com/restapi/reference#get-message-ids-by-timestamp)
 * [Send message](https://developers.symphony.com/restapi/reference#create-message-v4)
+* [Update message](https://developers.symphony.com/restapi/reference#update-message-v4)
 * [Import messages](https://developers.symphony.com/restapi/reference#import-message-v4)
 * [Get attachment](https://developers.symphony.com/restapi/reference#attachment)
 * [List attachments](https://developers.symphony.com/restapi/reference#list-attachments)

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/MessageService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/MessageService.java
@@ -290,6 +290,25 @@ public class MessageService implements OboMessageService, OboService<OboMessageS
   }
 
   /**
+   * Update an existing message. The existing message must be a valid social message, that has not been deleted.
+   *
+   * @param streamId the ID of the stream to send the message to
+   * @param messageId the ID of the message to be
+   * @return a {@link V4Message} object containing the details of the sent message
+   * @see <a href="https://developers.symphony.com/restapi/reference#update-message-v4">Create Message v4</a>
+   */
+  public V4Message update(@Nonnull String streamId, @Nonnull String messageId, @Nonnull Message message) {
+    return this.executeAndRetry("update", messagesApi.getApiClient().getBasePath(), () ->  {
+      final String path = String.format(
+          "/v4/stream/%s/message/%s/update",
+          this.messagesApi.getApiClient().escapeString(toUrlSafeIdIfNeeded(streamId)),
+          this.messagesApi.getApiClient().escapeString(toUrlSafeIdIfNeeded(messageId))
+      );
+      return doSendFormData(path, getForm(message), new TypeReference<V4Message>() {});
+    });
+  }
+
+  /**
    * Sends a message to multiple existing streams.
    *
    * @param streamIds the list of stream IDs to send the message to

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/MessageService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/MessageService.java
@@ -297,6 +297,7 @@ public class MessageService implements OboMessageService, OboService<OboMessageS
    * @return a {@link V4Message} object containing the details of the sent message
    * @see <a href="https://developers.symphony.com/restapi/reference#update-message-v4">Create Message v4</a>
    */
+  @API(status = API.Status.EXPERIMENTAL)
   public V4Message update(@Nonnull String streamId, @Nonnull String messageId, @Nonnull Message message) {
     return this.executeAndRetry("update", messagesApi.getApiClient().getBasePath(), () ->  {
       final String path = String.format(

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/MessageService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/MessageService.java
@@ -292,20 +292,34 @@ public class MessageService implements OboMessageService, OboService<OboMessageS
   /**
    * Update an existing message. The existing message must be a valid social message, that has not been deleted.
    *
-   * @param streamId the ID of the stream to send the message to
-   * @param messageId the ID of the message to be
+   * @param messageToUpdate the message to be updated
+   * @param content the update content (attachments are not supported yet)
    * @return a {@link V4Message} object containing the details of the sent message
-   * @see <a href="https://developers.symphony.com/restapi/reference#update-message-v4">Create Message v4</a>
+   * @see <a href="https://developers.symphony.com/restapi/reference#update-message-v4">Create Update v4</a>
    */
   @API(status = API.Status.EXPERIMENTAL)
-  public V4Message update(@Nonnull String streamId, @Nonnull String messageId, @Nonnull Message message) {
+  public V4Message update(@Nonnull V4Message messageToUpdate, @Nonnull Message content) {
+    return this.update(messageToUpdate.getStream().getStreamId(), messageToUpdate.getMessageId(), content);
+  }
+
+  /**
+   * Update an existing message. The existing message must be a valid social message, that has not been deleted.
+   *
+   * @param streamId the ID of the stream where the message to be updated comes from
+   * @param messageId the ID of the message to be updated
+   * @param content the update content (attachments are not supported yet)
+   * @return a {@link V4Message} object containing the details of the sent message
+   * @see <a href="https://developers.symphony.com/restapi/reference#update-message-v4">Create Update v4</a>
+   */
+  @API(status = API.Status.EXPERIMENTAL)
+  public V4Message update(@Nonnull String streamId, @Nonnull String messageId, @Nonnull Message content) {
     return this.executeAndRetry("update", messagesApi.getApiClient().getBasePath(), () ->  {
       final String path = String.format(
           "/v4/stream/%s/message/%s/update",
           this.messagesApi.getApiClient().escapeString(toUrlSafeIdIfNeeded(streamId)),
           this.messagesApi.getApiClient().escapeString(toUrlSafeIdIfNeeded(messageId))
       );
-      return doSendFormData(path, getForm(message), new TypeReference<V4Message>() {});
+      return doSendFormData(path, getForm(content), new TypeReference<V4Message>() {});
     });
   }
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/MessageServiceTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/MessageServiceTest.java
@@ -76,6 +76,7 @@ class MessageServiceTest {
   private static final String V4_STREAM_MESSAGE = "/agent/v4/stream/{sid}/message";
   private static final String V4_SEARCH_MESSAGES = "/agent/v1/message/search";
   private static final String V4_STREAM_MESSAGE_CREATE = "/agent/v4/stream/{sid}/message/create";
+  private static final String V4_STREAM_MESSAGE_UPDATE = "/agent/v4/stream/{sid}/message/{mid}/update";
   private static final String V4_MESSAGE_IMPORT = "/agent/v4/message/import";
   private static final String V4_BLAST_MESSAGE = "/agent/v4/message/blast";
   private static final String V1_MESSAGE_SUPPRESSION = "/pod/v1/admin/messagesuppression/{id}/suppress";
@@ -326,6 +327,21 @@ class MessageServiceTest {
     assertEquals("2.0", message.getVersion());
     assertEquals(MESSAGE, message.getContent());
     assertEquals("test.doc", message.getAttachments().get(0).getFilename());
+  }
+
+  @Test
+  void testMessageUpdate() throws IOException {
+    mockApiClient.onPost(V4_STREAM_MESSAGE_UPDATE.replace("{sid}", STREAM_ID).replace("{mid}", MESSAGE_ID),
+        JsonHelper.readFromClasspath("/message/update_message.json"));
+
+    final Message message = Message.builder().content("This is a message update").build();
+    final V4Message updateMessage = messageService.update(STREAM_ID, MESSAGE_ID, message);
+
+    assertEquals(MESSAGE_ID, updateMessage.getMessageId());
+    assertEquals("gXFV8vN37dNqjojYS_y2wX___o2KxfmUdA", updateMessage.getStream().getStreamId());
+    assertEquals("vanscOQk6IJXm-6XAN3B33___oiRvNNKdA", updateMessage.getInitialMessageId());
+    assertEquals("j7-VAoCY_1pGAYSye_MtI3___oPXo8VHbQ", updateMessage.getReplacing());
+    assertEquals(1599659432867L, updateMessage.getInitialTimestamp());
   }
 
   @Test

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/MessageServiceTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/MessageServiceTest.java
@@ -334,8 +334,9 @@ class MessageServiceTest {
     mockApiClient.onPost(V4_STREAM_MESSAGE_UPDATE.replace("{sid}", STREAM_ID).replace("{mid}", MESSAGE_ID),
         JsonHelper.readFromClasspath("/message/update_message.json"));
 
-    final Message message = Message.builder().content("This is a message update").build();
-    final V4Message updateMessage = messageService.update(STREAM_ID, MESSAGE_ID, message);
+    final V4Message messageToUpdate = new V4Message().stream(new V4Stream().streamId(STREAM_ID)).messageId(MESSAGE_ID);
+    final Message content = Message.builder().content("This is a message update").build();
+    final V4Message updateMessage = this.messageService.update(messageToUpdate, content);
 
     assertEquals(MESSAGE_ID, updateMessage.getMessageId());
     assertEquals("gXFV8vN37dNqjojYS_y2wX___o2KxfmUdA", updateMessage.getStream().getStreamId());

--- a/symphony-bdk-core/src/test/resources/message/update_message.json
+++ b/symphony-bdk-core/src/test/resources/message/update_message.json
@@ -1,0 +1,33 @@
+{
+    "messageId": "messageId",
+    "timestamp": 1599659432866,
+    "message": "<div data-format=\"PresentationML\" data-version=\"2.0\">Hello, World!</div>",
+    "sharedMessage": null,
+    "data": null,
+    "attachments": null,
+    "user": {
+        "userId": 12987981103694,
+        "firstName": null,
+        "lastName": null,
+        "displayName": "bot-name",
+        "email": "fakemail@symphony.com",
+        "username": "bot-name"
+    },
+    "stream": {
+        "streamId": "gXFV8vN37dNqjojYS_y2wX___o2KxfmUdA",
+        "streamType": "IM",
+        "roomName": null,
+        "members": null,
+        "external": null,
+        "crossPod": null
+    },
+    "externalRecipients": null,
+    "diagnostic": null,
+    "userAgent": "user-agent",
+    "originalFormat": "com.symphony.messageml.v2",
+    "disclaimer": null,
+    "sid": "6ca2b92d-f198-4059-9073-9701c26ab5f3",
+    "initialMessageId": "vanscOQk6IJXm-6XAN3B33___oiRvNNKdA",
+    "initialTimestamp": 1599659432867,
+    "replacing": "j7-VAoCY_1pGAYSye_MtI3___oPXo8VHbQ"
+}

--- a/symphony-bdk-examples/bdk-core-examples/src/main/java/com/symphony/bdk/examples/MessageUpdateExampleMain.java
+++ b/symphony-bdk-examples/bdk-core-examples/src/main/java/com/symphony/bdk/examples/MessageUpdateExampleMain.java
@@ -37,7 +37,7 @@ public class MessageUpdateExampleMain {
         "cat", "dromedary_camel", "dolphin", "dog", "hamster", "goat", "panda_face", "koala", "frog", "penguin"
     }[index];
 
-    V4Message previousMessage = bdk.messages().send(streamId, "Let's the show begin!");
+    V4Message previousMessage = bdk.messages().send(streamId, "Let the show begin!");
     pinMessage(bdk, previousMessage);
 
     for (int i = 0; i < 10; i++) {

--- a/symphony-bdk-examples/bdk-core-examples/src/main/java/com/symphony/bdk/examples/MessageUpdateExampleMain.java
+++ b/symphony-bdk-examples/bdk-core-examples/src/main/java/com/symphony/bdk/examples/MessageUpdateExampleMain.java
@@ -1,0 +1,35 @@
+package com.symphony.bdk.examples;
+
+import static com.symphony.bdk.core.activity.command.SlashCommand.slash;
+import static com.symphony.bdk.core.config.BdkConfigLoader.loadFromSymphonyDir;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+
+import com.symphony.bdk.core.SymphonyBdk;
+import com.symphony.bdk.core.service.message.model.Message;
+import com.symphony.bdk.gen.api.model.V4Message;
+
+import lombok.SneakyThrows;
+
+/**
+ * This demonstrates a basic usage of the message update feature.
+ */
+public class MessageUpdateExampleMain {
+
+  public static void main(String[] args) throws Exception {
+
+    final SymphonyBdk bdk = new SymphonyBdk(loadFromSymphonyDir("config.yaml"));
+
+    bdk.activities().register(slash("/go", false, context -> {
+      newSingleThreadExecutor().submit(() -> startTheShow(bdk, context.getStreamId()));
+    }));
+
+    bdk.datafeed().start();
+  }
+
+  @SneakyThrows
+  private static void startTheShow(SymphonyBdk bdk, String streamId) {
+    V4Message initialMessage = bdk.messages().send(streamId, "This is an initial message");
+    Thread.sleep(2000L);
+    bdk.messages().update(streamId, initialMessage.getMessageId(), Message.builder().content("This is a message update").build());
+  }
+}

--- a/symphony-bdk-examples/bdk-core-examples/src/main/java/com/symphony/bdk/examples/MessageUpdateExampleMain.java
+++ b/symphony-bdk-examples/bdk-core-examples/src/main/java/com/symphony/bdk/examples/MessageUpdateExampleMain.java
@@ -2,34 +2,57 @@ package com.symphony.bdk.examples;
 
 import static com.symphony.bdk.core.activity.command.SlashCommand.slash;
 import static com.symphony.bdk.core.config.BdkConfigLoader.loadFromSymphonyDir;
-import static java.util.concurrent.Executors.newSingleThreadExecutor;
 
 import com.symphony.bdk.core.SymphonyBdk;
 import com.symphony.bdk.core.service.message.model.Message;
+import com.symphony.bdk.gen.api.model.V3RoomAttributes;
 import com.symphony.bdk.gen.api.model.V4Message;
+import com.symphony.bdk.http.api.ApiRuntimeException;
 
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.function.Function;
 
 /**
  * This demonstrates a basic usage of the message update feature.
  */
+@Slf4j
 public class MessageUpdateExampleMain {
 
   public static void main(String[] args) throws Exception {
 
     final SymphonyBdk bdk = new SymphonyBdk(loadFromSymphonyDir("config.yaml"));
 
-    bdk.activities().register(slash("/go", false, context -> {
-      newSingleThreadExecutor().submit(() -> startTheShow(bdk, context.getStreamId()));
-    }));
+    bdk.activities().register(slash("/go", false, context -> startTheShow(bdk, context.getStreamId())));
 
     bdk.datafeed().start();
   }
 
   @SneakyThrows
   private static void startTheShow(SymphonyBdk bdk, String streamId) {
-    V4Message initialMessage = bdk.messages().send(streamId, "This is an initial message");
-    Thread.sleep(2000L);
-    bdk.messages().update(streamId, initialMessage.getMessageId(), Message.builder().content("This is a message update").build());
+
+    // just for this example, obviously!
+    Function<Integer, String> pickEmoji = index -> new String[] {
+        "cat", "dromedary_camel", "dolphin", "dog", "hamster", "goat", "panda_face", "koala", "frog", "penguin"
+    }[index];
+
+    V4Message previousMessage = bdk.messages().send(streamId, "Let's the show begin!");
+    pinMessage(bdk, previousMessage);
+
+    for (int i = 0; i < 10; i++) {
+      Thread.sleep((long) (Math.random() * (5000L - 500L)));
+      String mml = "<emoji shortcode=\"" + pickEmoji.apply(i) + "\" /><br/><br/>Update <b>#" + (i + 1) + "</b>";
+      previousMessage = bdk.messages().update(previousMessage, Message.builder().content(mml).build());
+    }
+  }
+
+  private static void pinMessage(SymphonyBdk bdk, V4Message previousMessage) {
+    try {
+      V3RoomAttributes attrs = new V3RoomAttributes().pinnedMessageId(previousMessage.getMessageId());
+      bdk.streams().updateRoom(previousMessage.getStream().getStreamId(), attrs);
+    } catch (ApiRuntimeException ex) {
+      log.info("Message can only be pinned in room");
+    }
   }
 }


### PR DESCRIPTION
Added new message update endpoint to `MessageService` class.
- Mentioned in markdown doc 
- Simple demo created (`MessageUpdateExampleMain.java`). I'd like make it a bit more fun so I'll modify it before merging this PR
----
![message-update-show](https://user-images.githubusercontent.com/39826516/135249490-02969db7-bb81-44e8-b5ee-b84d9b7b2fe1.gif)

