### PR TITLE
#588 Add a constructor in AuthenticatorFactory to specify an Extensi…

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/impl/ExtensionAppAuthenticatorCertImpl.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/impl/ExtensionAppAuthenticatorCertImpl.java
@@ -33,9 +33,7 @@ public class ExtensionAppAuthenticatorCertImpl extends AbstractExtensionAppAuthe
   private final CertificatePodApi certificatePodApi;
 
   public ExtensionAppAuthenticatorCertImpl(BdkRetryConfig retryConfig, String appId, ApiClient sessionAuthClient) {
-    super(retryConfig, appId);
-    this.certificateAuthenticationApi = new CertificateAuthenticationApi(sessionAuthClient);
-    this.certificatePodApi = new CertificatePodApi(sessionAuthClient);
+    this(retryConfig, appId, sessionAuthClient, new InMemoryTokensRepository());
   }
 
   public ExtensionAppAuthenticatorCertImpl(BdkRetryConfig retryConfig, String appId, ApiClient sessionAuthClient,

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/impl/ExtensionAppAuthenticatorRsaImpl.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/impl/ExtensionAppAuthenticatorRsaImpl.java
@@ -40,10 +40,7 @@ public class ExtensionAppAuthenticatorRsaImpl extends AbstractExtensionAppAuthen
       PrivateKey appPrivateKey,
       ApiClient loginApiClient,
       ApiClient podApiClient) {
-    super(retryConfig, appId);
-    this.appPrivateKey = appPrivateKey;
-    this.authenticationApi = new AuthenticationApi(loginApiClient);
-    this.podApi = new PodApi(podApiClient);
+    this(retryConfig, appId, appPrivateKey, loginApiClient, podApiClient, new InMemoryTokensRepository());
   }
 
   public ExtensionAppAuthenticatorRsaImpl(BdkRetryConfig retryConfig,

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/impl/ExtensionAppAuthenticatorCertImplTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/impl/ExtensionAppAuthenticatorCertImplTest.java
@@ -3,6 +3,7 @@ package com.symphony.bdk.core.auth.impl;
 import static com.symphony.bdk.core.test.BdkRetryConfigTestHelper.ofMinimalInterval;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
@@ -35,6 +36,12 @@ public class ExtensionAppAuthenticatorCertImplTest {
         "appId",
         mockApiClient.getApiClient("/sessionauth"),
         tokensRepository);
+  }
+
+  @Test
+  void testConstructObject() {
+    assertNotNull(new ExtensionAppAuthenticatorCertImpl(ofMinimalInterval(1), "appId",
+        mockApiClient.getApiClient("/sessionauth")));
   }
 
   @Test

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/impl/ExtensionAppAuthenticatorRsaImplTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/impl/ExtensionAppAuthenticatorRsaImplTest.java
@@ -3,6 +3,7 @@ package com.symphony.bdk.core.auth.impl;
 import static com.symphony.bdk.core.test.BdkRetryConfigTestHelper.ofMinimalInterval;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
@@ -43,6 +44,16 @@ class ExtensionAppAuthenticatorRsaImplTest {
         mockApiClient.getApiClient("/login"),
         mockApiClient.getApiClient("/pod"),
         tokensRepository);
+  }
+
+  @Test
+  void testConstructObject() {
+    authenticator = new ExtensionAppAuthenticatorRsaImpl(
+        ofMinimalInterval(1),
+        "appId",
+        PRIVATE_KEY,
+        mockApiClient.getApiClient("/login"),
+        mockApiClient.getApiClient("/pod"));
   }
 
   @Test

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/impl/ExtensionAppAuthenticatorRsaImplTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/impl/ExtensionAppAuthenticatorRsaImplTest.java
@@ -48,12 +48,12 @@ class ExtensionAppAuthenticatorRsaImplTest {
 
   @Test
   void testConstructObject() {
-    authenticator = new ExtensionAppAuthenticatorRsaImpl(
+    assertNotNull(new ExtensionAppAuthenticatorRsaImpl(
         ofMinimalInterval(1),
         "appId",
         PRIVATE_KEY,
         mockApiClient.getApiClient("/login"),
-        mockApiClient.getApiClient("/pod"));
+        mockApiClient.getApiClient("/pod")));
   }
 
   @Test

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkCoreConfig.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkCoreConfig.java
@@ -2,9 +2,12 @@ package com.symphony.bdk.spring.config;
 
 import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.core.auth.AuthenticatorFactory;
+import com.symphony.bdk.core.auth.ExtensionAppTokensRepository;
 import com.symphony.bdk.core.auth.exception.AuthInitializationException;
 import com.symphony.bdk.core.auth.exception.AuthUnauthorizedException;
+import com.symphony.bdk.core.auth.impl.InMemoryTokensRepository;
 import com.symphony.bdk.core.client.ApiClientFactory;
+import com.symphony.bdk.gen.api.model.ExtensionAppTokens;
 import com.symphony.bdk.http.api.ApiClient;
 import com.symphony.bdk.http.jersey2.ApiClientBuilderProviderJersey2;
 import com.symphony.bdk.spring.SymphonyBdkCoreProperties;
@@ -69,8 +72,14 @@ public class BdkCoreConfig {
 
   @Bean
   @ConditionalOnMissingBean
-  public AuthenticatorFactory authenticatorFactory(SymphonyBdkCoreProperties properties, ApiClientFactory apiClientFactory) {
-    return new AuthenticatorFactory(properties, apiClientFactory);
+  public ExtensionAppTokensRepository extensionAppTokensRepository() {
+    return new InMemoryTokensRepository();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public AuthenticatorFactory authenticatorFactory(SymphonyBdkCoreProperties properties, ApiClientFactory apiClientFactory, ExtensionAppTokensRepository extensionAppTokensRepository) {
+    return new AuthenticatorFactory(properties, apiClientFactory, extensionAppTokensRepository);
   }
 
   @Bean


### PR DESCRIPTION
…onAppTokenRepository impl

### Ticket
588 https://github.com/finos/symphony-bdk-java/issues/588

### Description
I just add a constructor in **AuthenticatorFactory** to be able to choose if I want Extension App token to be stored in memory or in any other way I could want.

Just add a constructor with **ExtensionAppTokensRepository**, which will be pass to constructor of **ExtensionAppAuthenticatorCertImpl** and **ExtensionAppAuthenticatorRsaImpl**

### Dependencies
None

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
