### PR TITLE
Improving freemarker template engine configuration

### DIFF
--- a/symphony-bdk-template/symphony-bdk-template-freemarker/src/main/java/com/symphony/bdk/template/freemarker/FreeMarkerEngine.java
+++ b/symphony-bdk-template/symphony-bdk-template-freemarker/src/main/java/com/symphony/bdk/template/freemarker/FreeMarkerEngine.java
@@ -60,7 +60,7 @@ public class FreeMarkerEngine implements TemplateEngine {
     cfg.setLogTemplateExceptions(false);
     cfg.setWrapUncheckedExceptions(true);
     cfg.setFallbackOnNullLoopVariable(false);
-    cfg.setNumberFormat("0.######");
+    cfg.setNumberFormat("computer");
     DefaultObjectWrapperBuilder owb = new DefaultObjectWrapperBuilder(Configuration.VERSION_2_3_29);
     owb.setMethodAppearanceFineTuner((in, out) -> out.setMethodShadowsProperty(false));
     cfg.setObjectWrapper(owb.build());

--- a/symphony-bdk-template/symphony-bdk-template-freemarker/src/main/java/com/symphony/bdk/template/freemarker/FreeMarkerEngine.java
+++ b/symphony-bdk-template/symphony-bdk-template-freemarker/src/main/java/com/symphony/bdk/template/freemarker/FreeMarkerEngine.java
@@ -5,6 +5,7 @@ import com.symphony.bdk.template.api.TemplateEngine;
 import com.symphony.bdk.template.api.TemplateException;
 
 import freemarker.template.Configuration;
+import freemarker.template.DefaultObjectWrapperBuilder;
 import freemarker.template.TemplateExceptionHandler;
 import org.apache.commons.io.FilenameUtils;
 import org.apiguardian.api.API;
@@ -59,6 +60,10 @@ public class FreeMarkerEngine implements TemplateEngine {
     cfg.setLogTemplateExceptions(false);
     cfg.setWrapUncheckedExceptions(true);
     cfg.setFallbackOnNullLoopVariable(false);
+    cfg.setNumberFormat("0.######");
+    DefaultObjectWrapperBuilder owb = new DefaultObjectWrapperBuilder(Configuration.VERSION_2_3_29);
+    owb.setMethodAppearanceFineTuner((in, out) -> out.setMethodShadowsProperty(false));
+    cfg.setObjectWrapper(owb.build());
     return cfg;
   }
 }

--- a/symphony-bdk-template/symphony-bdk-template-freemarker/src/test/java/com/symphony/bdk/template/freemarker/FreeMarkerTemplateTest.java
+++ b/symphony-bdk-template/symphony-bdk-template-freemarker/src/test/java/com/symphony/bdk/template/freemarker/FreeMarkerTemplateTest.java
@@ -9,6 +9,7 @@ import com.symphony.bdk.template.api.TemplateException;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -68,6 +69,28 @@ public class FreeMarkerTemplateTest {
   }
 
   @Test
+  public void testFromClasspathWithObjects() {
+    Class1 class1 = new Class1();
+    class1.setParameter1(Collections.singletonMap("message", "Hello"));
+    Map<String, Object> params = new HashMap<>();
+    params.put("test", class1);
+
+    Template freeMarkerTemplate = new FreeMarkerEngine().newTemplateFromClasspath("/subFolder/testWithObject.ftl");
+    assertTemplateProducesOutput(freeMarkerTemplate, params, "Hello world!\n");
+  }
+
+  @Test
+  public void testFromClasspathWithLong() {
+    Long userId = 12345678L;
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("userId", userId);
+
+    Template freeMarkerTemplate = new FreeMarkerEngine().newTemplateFromClasspath("/subFolder/testWithLong.ftl");
+    assertTemplateProducesOutput(freeMarkerTemplate, parameters,
+        "<messageML>Hello <mention uid='" + userId + "'/></messageML>\n");
+  }
+
+  @Test
   public void testWithNotFoundResource() {
     assertThrows(TemplateException.class, () -> new FreeMarkerEngine().newTemplateFromClasspath("./not/found.ftl"));
   }
@@ -83,6 +106,18 @@ public class FreeMarkerTemplateTest {
       {
     assertEquals(FreeMarkerTemplate.class, freeMarkerTemplate.getClass());
     assertEquals(expectedOutput, freeMarkerTemplate.process(parameters));
+  }
+
+  public static class Class1 {
+    private Map<String, String>  parameter;
+
+    public Map<String, String> getParameter() {
+      return parameter;
+    }
+
+    public void setParameter1(Map<String, String> parameter) {
+      this.parameter = parameter;
+    }
   }
 
 }

--- a/symphony-bdk-template/symphony-bdk-template-freemarker/src/test/resources/subFolder/testWithLong.ftl
+++ b/symphony-bdk-template/symphony-bdk-template-freemarker/src/test/resources/subFolder/testWithLong.ftl
@@ -1,0 +1,1 @@
+<messageML>Hello <mention uid='${userId}'/></messageML>

--- a/symphony-bdk-template/symphony-bdk-template-freemarker/src/test/resources/subFolder/testWithObject.ftl
+++ b/symphony-bdk-template/symphony-bdk-template-freemarker/src/test/resources/subFolder/testWithObject.ftl
@@ -1,0 +1,1 @@
+${test.parameter.message} world!


### PR DESCRIPTION
### Description
- Enforcing numbers format to not add , or . in between. Before while using numbers, freemarker was formatting them from "123456" to "123,456" this was causing issues especially when dealing with userIds.
- Enforcing freemarker to access beans object fields without the need to specify the get in the variable. Before only this definition was working ${event.getParameter().getAnother()}, now also this one will work: ${event.parameter.another}