### PR TITLE
#592 Generated enums don't throw exception when parsing unknown values

### DIFF
--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/gen/GeneratedEnumTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/gen/GeneratedEnumTest.java
@@ -1,0 +1,39 @@
+package com.symphony.bdk.core.gen;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.symphony.bdk.gen.api.model.UserAttributes;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+/**
+ * We modified the templates/modelInnerEnum.mustache in order to not throw an exception when a returned enum value
+ * is unknown. Instead, we just print a warning and return null. This specific test class aims to highlight this
+ * modification and ensures that removing or modifying the mustache template will break the unit tests.
+ */
+public class GeneratedEnumTest {
+
+  @Test
+  @DisplayName("Generated enum should not fail on unknown value")
+  void shouldNotFailOnUnknownEnumValue() {
+
+    final Logger logger = (Logger) LoggerFactory.getLogger("com.symphony.bdk.gen.api.model");
+    final ListAppender<ILoggingEvent> testAppender = new ListAppender<>();
+    logger.addAppender(testAppender);
+
+    testAppender.start();
+    assertNull(UserAttributes.AccountTypeEnum.fromValue("FOOBAR"));
+    testAppender.stop();
+
+    assertEquals(1, testAppender.list.size());
+    assertEquals(Level.WARN, testAppender.list.get(0).getLevel());
+    assertEquals("Unexpected value 'FOOBAR', returning null.", testAppender.list.get(0).getMessage());
+  }
+}

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/user/UserServiceTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/user/UserServiceTest.java
@@ -134,6 +134,20 @@ class UserServiceTest {
 
     assertEquals(userDetail.getUserAttributes().getCompanyName(), "Company");
     assertEquals(userDetail.getUserAttributes().getUserName(), "johndoe");
+    assertEquals(V2UserAttributes.AccountTypeEnum.NORMAL, userDetail.getUserAttributes().getAccountType());
+    assertEquals(userDetail.getRoles().size(), 6);
+  }
+
+  @Test
+  void getUserDetailWithUnknownAccountType() throws IOException {
+    String response = JsonHelper.readFromClasspath("/user/user_detail_unknown_account_type.json");
+    this.mockApiClient.onGet(V2_USER_DETAIL_BY_ID.replace("{uid}", "1234"), response);
+
+    V2UserDetail userDetail = this.service.getUserDetail(1234L);
+
+    assertEquals(userDetail.getUserAttributes().getCompanyName(), "Company");
+    assertEquals(userDetail.getUserAttributes().getUserName(), "johndoe");
+    assertNull(userDetail.getUserAttributes().getAccountType());
     assertEquals(userDetail.getRoles().size(), 6);
   }
 

--- a/symphony-bdk-core/src/test/resources/user/user_detail_unknown_account_type.json
+++ b/symphony-bdk-core/src/test/resources/user/user_detail_unknown_account_type.json
@@ -1,0 +1,43 @@
+{
+  "userAttributes": {
+    "emailAddress": "johndoe@symphony.com",
+    "firstName": "John",
+    "lastName": "Doe",
+    "userName": "johndoe",
+    "displayName": "John Doe",
+    "companyName": "Company",
+    "department": "Departament",
+    "division": "Division",
+    "title": "Junior Trader",
+    "twoFactorAuthPhone": "+15419999999",
+    "workPhoneNumber": "+15419999999",
+    "mobilePhoneNumber": "+15419999999",
+    "accountType": "FOOBAR",
+    "location": "New York",
+    "jobFunction": "Trader",
+    "assetClasses": [
+      "Equities"
+    ],
+    "industries": [
+      "Healthcare",
+      "Technology"
+    ]
+  },
+  "userSystemInfo": {
+    "id": 7215545078461,
+    "status": "ENABLED",
+    "createdDate": 1461508270000,
+    "createdBy": "7215545057281",
+    "lastUpdatedDate": 1461508270000,
+    "lastLoginDate": 1461508270000,
+    "deactivatedDate": 1461508270000
+  },
+  "roles": [
+    "INDIVIDUAL",
+    "COMPLIANCE_OFFICER",
+    "COMPLIANCE_OFFICER.MONITOR_ROOMS",
+    "COMPLIANCE_OFFICER.MONITOR_WALL_POSTS",
+    "COMPLIANCE_OFFICER.LOCK_AND_UNLOCK_ROOM",
+    "COMPLIANCE_OFFICER.BAN_AND_UNBAN_ROOM_MEMBER"
+  ]
+}

--- a/templates/modelInnerEnum.mustache
+++ b/templates/modelInnerEnum.mustache
@@ -1,0 +1,48 @@
+    /**
+     * {{description}}{{^description}}Gets or Sets {{{name}}}{{/description}}
+     */
+    {{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} {
+        {{#allowableValues}}
+        {{#enumVars}}
+        {{#enumDescription}}
+        /**
+        * {{.}}
+        */
+        {{/enumDescription}}
+        {{{name}}}({{{value}}}){{^-last}},
+        {{/-last}}{{#-last}};{{/-last}}
+        {{/enumVars}}
+        {{/allowableValues}}
+
+        private final {{{dataType}}} value;
+
+        {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}({{{dataType}}} value) {
+            this.value = value;
+        }
+
+        {{#jackson}}
+        @JsonValue
+        {{/jackson}}
+        public {{{dataType}}} getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        {{#jackson}}
+        @JsonCreator
+        {{/jackson}}
+        public static {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue({{{dataType}}} value) {
+            for ({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+                if (b.value.equals(value)) {
+                    return b;
+                }
+            }
+
+            org.slf4j.LoggerFactory.getLogger({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.class).warn("Unexpected value '" + value + "', returning null.");
+            return null;
+        }
+    }


### PR DESCRIPTION
Closes https://github.com/finos/symphony-bdk-java/issues/592

We want to avoid response parsing issues when API returns an unknown enum value. The `modelInnerEnum.mustache` template has been modified in order to: 
- return null
- print warning log 