### PR TITLE
Improved DF loop retry strategy by supporting SocketException found in root exception causes

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/client/loadbalancing/ExternalLoadBalancingStrategy.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/client/loadbalancing/ExternalLoadBalancingStrategy.java
@@ -22,7 +22,7 @@ public class ExternalLoadBalancingStrategy implements LoadBalancingStrategy {
     this.signalsApi = signalsApi;
     this.retryBuilder = new RetryWithRecoveryBuilder<String>()
         .retryConfig(retryConfig)
-        .retryOnException(RetryWithRecoveryBuilder::isNetworkOrMinorError);
+        .retryOnException(RetryWithRecoveryBuilder::isNetworkIssueOrMinorError);
   }
 
   /**

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/retry/RetryWithRecovery.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/retry/RetryWithRecovery.java
@@ -34,7 +34,7 @@ public abstract class RetryWithRecovery<T> {
 
   /**
    * This is a helper function designed to cover most of the retry cases.
-   * It retries on the conditions defined by {@link RetryWithRecoveryBuilder#isNetworkOrMinorError}
+   * It retries on the conditions defined by {@link RetryWithRecoveryBuilder#isNetworkIssueOrMinorError}
    * and refreshes the authSession if we get an unauthorized error.
    *
    * @param baseRetryBuilder the {@link RetryWithRecoveryBuilder} containing the base settings for the retry mechanism.

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV1.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV1.java
@@ -96,7 +96,7 @@ public class DatafeedLoopV1 extends AbstractDatafeedLoop {
 
     try {
       this.datafeedId = this.datafeedId == null ? this.createDatafeed.execute() : this.datafeedId;
-      log.debug("Start reading events from datafeed {}", datafeedId);
+      log.info("Start reading events from datafeed {}", datafeedId);
       this.started.set(true);
       do {
 

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2.java
@@ -117,7 +117,7 @@ public class DatafeedLoopV2 extends AbstractDatafeedLoop {
       if (this.datafeed == null) {
         this.datafeed = this.createDatafeed.execute();
       }
-      log.debug("Start reading events from datafeed {}", this.datafeed.getId());
+      log.info("Start reading events from datafeed {}", this.datafeed.getId());
       this.started.set(true);
       do {
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/retry/resilience4j/Resilience4jRetryWithRecoveryTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/retry/resilience4j/Resilience4jRetryWithRecoveryTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
 import java.net.ConnectException;
+import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.util.Collections;
@@ -253,7 +254,8 @@ class Resilience4jRetryWithRecoveryTest {
     when(supplier.get()).thenThrow(new RuntimeException(new UnknownHostException("Unknown host")));
 
     try {
-      Resilience4jRetryWithRecovery.executeAndRetry(new RetryWithRecoveryBuilder<String>(), "test",
+      Resilience4jRetryWithRecovery.executeAndRetry(
+          new RetryWithRecoveryBuilder<String>().retryConfig(ofMinimalInterval(3)), "test",
           "localhost.symphony.com", supplier);
     } catch (RuntimeException e){
       assertEquals("Network error occurred while trying to connect to the \"POD\" at the following address: "
@@ -269,12 +271,27 @@ class Resilience4jRetryWithRecoveryTest {
 
     try {
       Resilience4jRetryWithRecovery.executeAndRetry(
-          new RetryWithRecoveryBuilder<String>().retryConfig(ofMinimalInterval(3)), "test", "localhost.symphony.com",
-          supplier);
+          new RetryWithRecoveryBuilder<String>().retryConfig(ofMinimalInterval(3)), "test",
+          "localhost.symphony.com", supplier);
     } catch (RuntimeException e){
       assertEquals("Timeout occurred while trying to connect to the \"POD\" at the following address: "
           + "localhost.symphony.com. Please check that the address is correct. Also consider checking your "
           + "proxy/firewall connections.", e.getMessage());
+    }
+  }
+
+  @Test
+  void testExecuteAndRetryShouldThrowRuntimeExceptionWhenSocketException() throws Throwable {
+    SupplierWithApiException<String> supplier = mock(ConcreteSupplier.class);
+    when(supplier.get()).thenThrow(new ProcessingException(new SocketException("Socket exception")));
+
+    try {
+      Resilience4jRetryWithRecovery.executeAndRetry(
+          new RetryWithRecoveryBuilder<String>().retryConfig(ofMinimalInterval(3)), "test",
+          "localhost.symphony.com", supplier);
+    } catch (RuntimeException e){
+      assertEquals("An unknown error occurred while trying to connect to localhost.symphony.com. "
+          + "Please check below for more information: ", e.getMessage());
     }
   }
 

--- a/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientJersey2.java
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientJersey2.java
@@ -8,6 +8,7 @@ import com.symphony.bdk.http.api.Pair;
 import com.symphony.bdk.http.api.tracing.DistributedTracingContext;
 import com.symphony.bdk.http.api.util.TypeReference;
 
+import org.apache.http.NoHttpResponseException;
 import org.apache.http.conn.ConnectTimeoutException;
 import org.apiguardian.api.API;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
@@ -20,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.URLEncoder;
 import java.nio.file.Files;
@@ -212,7 +214,12 @@ public class ApiClientJersey2 implements ApiClient {
     } catch (ProcessingException e) {
       if (e.getCause() instanceof ConnectTimeoutException) {
         throw new ProcessingException(new SocketTimeoutException(e.getCause().getMessage()));
-      } else {
+      }
+      else if (e.getCause() instanceof NoHttpResponseException) {
+        // ensures that it will be caught later in the retry strategy
+        throw new ProcessingException(new SocketException(e.getCause().getMessage()));
+      }
+      else {
         throw e;
       }
     }


### PR DESCRIPTION
This PR brings some improvements in the Datafeed loop strategy, especially when Agent goes down in an unexpected way. The `RetryWithRecoveryBuilder` will now look deeper in the root exception causes and try to detect if the root cause is a `SocketException`. 

 On the `ApiClientJersey2` side, we now catch potential `NoHttpResponseException` that can be thrown in similar situation. and wrap them as `SocketException`. 