### PR TITLE
Support user suspension API

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/user/UserService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/user/UserService.java
@@ -730,13 +730,33 @@ public class UserService implements OboUserService, OboService<OboUserService> {
   }
 
   /**
-   * Suspends or re-activates a user account.
+   * Suspends a user account.
+   * Calling this endpoint requires a service account with the User Provisioning role.
    *
-   * @param userId  user id
-   * @param userSuspension action to perform on the user
+   * @param userId  user id to suspend
+   * @param reason  reason why the user has to be suspended
+   * @param until   timestamp in milliseconds
    * @see <a href="https://developers.symphony.com/restapi/reference#suspend-user-v1">Suspend User Account v1</a>
    */
-  public void suspendUser(@Nonnull Long userId, @Nonnull UserSuspension userSuspension) {
+  public void suspendUser(@Nonnull Long userId, @Nonnull String reason, @Nonnull Long until) {
+    UserSuspension userSuspension = new UserSuspension();
+    userSuspension.setSuspended(true);
+    userSuspension.setSuspensionReason(reason);
+    userSuspension.setSuspendedUntil(until);
+    executeAndRetry("suspendUser",
+        () -> userApi.v1AdminUserUserIdSuspensionUpdatePut(authSession.getSessionToken(), userId, userSuspension));
+  }
+
+  /**
+   * Re-activates a user account.
+   * Calling this endpoint requires a service account with the User Provisioning role.
+   *
+   * @param userId  user id to reactivate
+   * @see <a href="https://developers.symphony.com/restapi/reference#suspend-user-v1">Suspend User Account v1</a>
+   */
+  public void unsuspendUser(@Nonnull Long userId) {
+    UserSuspension userSuspension = new UserSuspension();
+    userSuspension.setSuspended(false);
     executeAndRetry("suspendUser",
         () -> userApi.v1AdminUserUserIdSuspensionUpdatePut(authSession.getSessionToken(), userId, userSuspension));
   }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/user/UserService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/user/UserService.java
@@ -46,6 +46,7 @@ import org.apiguardian.api.API;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
@@ -735,14 +736,14 @@ public class UserService implements OboUserService, OboService<OboUserService> {
    *
    * @param userId  user id to suspend
    * @param reason  reason why the user has to be suspended
-   * @param until   timestamp in milliseconds
+   * @param until   instant till when the user should be suspended
    * @see <a href="https://developers.symphony.com/restapi/reference#suspend-user-v1">Suspend User Account v1</a>
    */
-  public void suspendUser(@Nonnull Long userId, @Nonnull String reason, @Nonnull Long until) {
+  public void suspendUser(@Nonnull Long userId, @Nonnull String reason, @Nonnull Instant until) {
     UserSuspension userSuspension = new UserSuspension();
     userSuspension.setSuspended(true);
     userSuspension.setSuspensionReason(reason);
-    userSuspension.setSuspendedUntil(until);
+    userSuspension.setSuspendedUntil(until.toEpochMilli());
     executeAndRetry("suspendUser",
         () -> userApi.v1AdminUserUserIdSuspensionUpdatePut(authSession.getSessionToken(), userId, userSuspension));
   }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/user/UserServiceTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/user/UserServiceTest.java
@@ -1047,7 +1047,7 @@ class UserServiceTest {
     UserSuspension userSuspension = new UserSuspension();
     userSuspension.setSuspended(true);
     userSuspension.setSuspensionReason("reason why");
-    userSuspension.setSuspendedUntil(67890L);
+    userSuspension.setSuspendedUntil(Instant.now().toEpochMilli());
 
     this.service.suspendUser(1234L, "reason why", Instant.now());
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/user/UserServiceTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/user/UserServiceTest.java
@@ -1039,14 +1039,15 @@ class UserServiceTest {
   }
 
   @Test
-  void suspendUserTest() throws ApiException {
+  void suspendUserTestSuccess() throws ApiException {
     this.mockApiClient.onPut(SUSPEND_USER.replace("{uid}", "1234"), "{}");
 
     UserSuspension userSuspension = new UserSuspension();
     userSuspension.setSuspended(true);
     userSuspension.setSuspensionReason("reason why");
+    userSuspension.setSuspendedUntil(67890L);
 
-    this.service.suspendUser(1234L, userSuspension);
+    this.service.suspendUser(1234L, "reason why", 67890L);
 
     verify(spiedUserApi).v1AdminUserUserIdSuspensionUpdatePut(
         eq("1234"),
@@ -1059,6 +1060,29 @@ class UserServiceTest {
     this.mockApiClient.onPut(400, SUSPEND_USER.replace("{uid}", "1234"), "{}");
 
     assertThrows(ApiRuntimeException.class,
-        () -> this.service.suspendUser(1234L, new UserSuspension()));
+        () -> this.service.suspendUser(1234L, "reason", 6789L));
+  }
+
+  @Test
+  void unsuspendUserTestSuccess() throws ApiException {
+    this.mockApiClient.onPut(SUSPEND_USER.replace("{uid}", "1234"), "{}");
+
+    UserSuspension userSuspension = new UserSuspension();
+    userSuspension.setSuspended(false);
+
+    this.service.unsuspendUser(1234L);
+
+    verify(spiedUserApi).v1AdminUserUserIdSuspensionUpdatePut(
+        eq("1234"),
+        eq(1234L),
+        eq(userSuspension));
+  }
+
+  @Test
+  void unsuspendUserTestFailed() {
+    this.mockApiClient.onPut(400, SUSPEND_USER.replace("{uid}", "1234"), "{}");
+
+    assertThrows(ApiRuntimeException.class,
+        () -> this.service.unsuspendUser(1234L));
   }
 }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/user/UserServiceTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/user/UserServiceTest.java
@@ -53,6 +53,8 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
@@ -1047,7 +1049,7 @@ class UserServiceTest {
     userSuspension.setSuspensionReason("reason why");
     userSuspension.setSuspendedUntil(67890L);
 
-    this.service.suspendUser(1234L, "reason why", 67890L);
+    this.service.suspendUser(1234L, "reason why", Instant.now());
 
     verify(spiedUserApi).v1AdminUserUserIdSuspensionUpdatePut(
         eq("1234"),
@@ -1060,7 +1062,7 @@ class UserServiceTest {
     this.mockApiClient.onPut(400, SUSPEND_USER.replace("{uid}", "1234"), "{}");
 
     assertThrows(ApiRuntimeException.class,
-        () -> this.service.suspendUser(1234L, "reason", 6789L));
+        () -> this.service.suspendUser(1234L, "reason", Instant.now().plus(Duration.ofDays(1))));
   }
 
   @Test


### PR DESCRIPTION
Related to https://github.com/finos/symphony-bdk-java/issues/598, we decided to ease the usage of this endpoint by providing two different functions to suspend/unsuspend a user account.
- suspendUser(userId, reason, until)
- unsuspendUser(userId)