### PR TITLE
#511: added a check for argument name unicity in slash command pattern

### DIFF
--- a/docs/activity-api.md
+++ b/docs/activity-api.md
@@ -106,6 +106,8 @@ In the slash command definition, each argument must be separated by a whitespace
 * `{arg1} {@arg2}` is valid
 * `{arg1}{arg2}` is invalid
 
+Argument names must be unique inside a given pattern.
+
 When a slash command matches, arguments can be retrieved thanks to the `getArguments()` method in the `CommandContext` class.
 
 ```java

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/exception/SlashCommandSyntaxException.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/exception/SlashCommandSyntaxException.java
@@ -11,4 +11,8 @@ public class SlashCommandSyntaxException extends RuntimeException {
   public SlashCommandSyntaxException(String message, Throwable cause) {
     super(message, cause);
   }
+
+  public SlashCommandSyntaxException(String message) {
+    super(message);
+  }
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/parsing/SlashCommandPattern.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/parsing/SlashCommandPattern.java
@@ -10,8 +10,10 @@ import org.apiguardian.api.API;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
@@ -44,6 +46,7 @@ public class SlashCommandPattern {
   public SlashCommandPattern(String pattern) {
     try {
       this.tokens = buildTokens(pattern);
+      checkArgumentNamesUnicity();
     } catch(PatternSyntaxException e) {
       throw new SlashCommandSyntaxException("Bad slash command pattern."
           + "Slash command pattern must be either words separated by spaces "
@@ -148,5 +151,14 @@ public class SlashCommandPattern {
       }
     }
     return arguments;
+  }
+
+  private void checkArgumentNamesUnicity() {
+    List<String> argumentNames = getArgumentNames();
+    Set<String> uniqueArgumentNames = new HashSet<>(argumentNames);
+
+    if (argumentNames.size() != uniqueArgumentNames.size()) {
+      throw new SlashCommandSyntaxException("Argument names must be unique");
+    }
   }
 }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/parsing/SlashCommandPatternTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/parsing/SlashCommandPatternTest.java
@@ -106,6 +106,11 @@ class SlashCommandPatternTest {
   }
 
   @Test
+  void twiceTheSameArgumentShouldThrowException() {
+    assertThrows(SlashCommandSyntaxException.class, () -> new SlashCommandPattern("{arg} {arg}"));
+  }
+
+  @Test
   void oneStaticTokenAndOneArgument() {
     final String argumentName = "arg";
     SlashCommandPattern pattern = new SlashCommandPattern("/command {" + argumentName + "}");
@@ -177,6 +182,11 @@ class SlashCommandPatternTest {
     assertEquals(12345678L, mention.getUserId());
     assertEquals("jane-doe", mention.getUserDisplayName());
     assertEquals("@jane-doe", mention.getText());
+  }
+
+  @Test
+  void twiceTheSameArgumentWithDifferentTypesShouldThrowException() {
+    assertThrows(SlashCommandSyntaxException.class, () -> new SlashCommandPattern("{arg} {@arg}"));
   }
 
   @Test


### PR DESCRIPTION
### Ticket
#511

### Description
Added a check to verify argument names are unique in a slash command definition.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
