### PR TITLE
#511 Make slash command arguments available in SB starter

### DIFF
--- a/docs/spring-boot/core-starter.md
+++ b/docs/spring-boot/core-starter.md
@@ -291,6 +291,49 @@ public class SlashHello {
 By default, the `@Slash` annotation is configured to require bot mention in order to trigger the command. You can override
 this value using `@Slash#mentionBot` annotation parameter. 
 
+You can also use slash commands with arguments. To do so, the field `value` of the `@Slash` annotation must have a valid
+format as explained in the [Activity API section](../activity-api.md#Slash-command-pattern-format). 
+If the slash command pattern is valid, you will have to specify all slash arguments as method parameter with the same name and type.
+If slash command pattern or method signature is incorrect, a `warn` message will appear in your application log and
+the slash command will not be registered.
+
+For instance:
+```java
+@Component
+public class SlashHello {
+
+  @Slash("/hello {arg") // will not be registered: invalid pattern
+  public void onHelloInvalidPattern(CommandContext commandContext, String arg) {
+    log.info("On /hello command");
+  }
+
+  @Slash("/hello {arg1}{arg2}") // will not be registered: invalid pattern
+  public void onHelloInvalidPatternTwoArgs(CommandContext commandContext, String arg1, String arg2) {
+    log.info("On /hello command");
+  }
+
+  @Slash("/hello {arg1} {arg2}") // will be registered: valid pattern and valid signature
+  public void onHelloValidPatternTwoArgs(CommandContext commandContext, String arg1, String arg2) {
+    log.info("On /hello command");
+  }
+
+  @Slash("/hello {arg1} {arg2}") // will not be registered: valid pattern but missing argument
+  public void onHelloValidPatternTwoArgs(CommandContext commandContext, String arg1) {
+    log.info("On /hello command");
+  }
+
+  @Slash("/hello {arg1} {@arg2}") // will not be registered: valid pattern but mismatching type for arg2
+  public void onHelloValidPatternTwoArgs(CommandContext commandContext, String arg1, String arg2) {
+    log.info("On /hello command");
+  }
+
+  @Slash("/hello {arg1} {@arg2} {#arg3} {$arg4}") // will be registered: valid pattern and correct signature
+  public void onHelloValidPatternTwoArgs(CommandContext commandContext, String arg1, Mention arg2, Hashtag arg3, Cashtag arg4) {
+    log.info("On /hello command");
+  }
+}
+```
+
 ## Activities
 > For more details about activities, please read the [Activity API reference documentation](../activity-api.md)
 

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/CommandContext.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/CommandContext.java
@@ -9,8 +9,6 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apiguardian.api.API;
 
-import java.util.Collections;
-
 /**
  * Default implementation of the {@link ActivityContext} handled by the {@link CommandActivity}.
  */
@@ -37,6 +35,6 @@ public class CommandContext extends ActivityContext<V4MessageSent> {
     super(initiator, eventSource);
     this.streamId = eventSource.getMessage().getStream().getStreamId();
     this.messageId = eventSource.getMessage().getMessageId();
-    this.arguments = new Arguments(Collections.emptyMap());
+    this.arguments = new Arguments();
   }
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/SlashCommand.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/SlashCommand.java
@@ -9,6 +9,7 @@ import com.symphony.bdk.core.activity.parsing.SlashCommandPattern;
 import com.symphony.bdk.gen.api.model.V4Initiator;
 import com.symphony.bdk.gen.api.model.V4MessageSent;
 
+import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.apiguardian.api.API;
 
@@ -23,6 +24,7 @@ import javax.annotation.Nonnull;
 @API(status = API.Status.EXPERIMENTAL)
 public class SlashCommand extends CommandActivity<CommandContext> {
 
+  @Getter
   private final String slashCommandName;
   private final SlashCommandPattern commandPattern;
   private final boolean requiresBotMention;

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/parsing/Arguments.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/parsing/Arguments.java
@@ -2,6 +2,7 @@ package com.symphony.bdk.core.activity.parsing;
 
 import org.apiguardian.api.API;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -12,6 +13,10 @@ import java.util.Set;
 public class Arguments {
 
   private Map<String, Object> arguments;
+
+  public Arguments() {
+    this.arguments = Collections.emptyMap();
+  }
 
   public Arguments(Map<String, Object> arguments) {
     this.arguments = arguments;
@@ -24,6 +29,7 @@ public class Arguments {
   public Set<String> getArgumentNames() {
     return arguments.keySet();
   }
+
   /**
    *
    * @param argumentName the name of the argument to be retrieved

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/parsing/CommandToken.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/parsing/CommandToken.java
@@ -14,4 +14,10 @@ public interface CommandToken {
    * @return true if input matches the token
    */
   boolean matches(Object inputToken);
+
+  /**
+   *
+   * @return the actual type accepted by this token: {@link String}, {@link Mention}, {@link Cashtag} or {@link Hashtag}
+   */
+  Class<?> getTokenType();
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/parsing/MatchingUserIdMentionToken.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/parsing/MatchingUserIdMentionToken.java
@@ -20,4 +20,9 @@ public class MatchingUserIdMentionToken implements CommandToken {
   public boolean matches(Object inputToken) {
     return inputToken instanceof Mention && ((Mention) inputToken).getUserId().equals(matchingUserId.get());
   }
+
+  @Override
+  public Class<?> getTokenType() {
+    return Mention.class;
+  }
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/parsing/RegexCommandToken.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/parsing/RegexCommandToken.java
@@ -19,4 +19,9 @@ public interface RegexCommandToken extends CommandToken {
   default boolean matches(Object inputToken) {
     return inputToken instanceof String && getRegexPattern().matcher(inputToken.toString()).matches();
   }
+
+  @Override
+  default Class<?> getTokenType() {
+    return String.class;
+  }
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/parsing/TypedArgumentToken.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/parsing/TypedArgumentToken.java
@@ -37,4 +37,9 @@ public class TypedArgumentToken<T> implements ArgumentCommandToken {
   public boolean matches(Object inputToken) {
     return type.isAssignableFrom(inputToken.getClass());
   }
+
+  @Override
+  public Class<?> getTokenType() {
+    return type;
+  }
 }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/command/SlashCommandTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/command/SlashCommandTest.java
@@ -44,13 +44,30 @@ class SlashCommandTest {
 
     final AtomicBoolean handlerCalled = new AtomicBoolean(false);
     final Consumer<CommandContext> handler = c -> handlerCalled.set(true);
-
     final RealTimeEventsProvider provider = new RealTimeEventsProvider();
-    final SlashCommand cmd = SlashCommand.slash("/test", handler);
+
+    final String commandPattern = "/test";
+    final SlashCommand cmd = SlashCommand.slash(commandPattern, handler);
     cmd.setBotUserId(BOT_USER_ID);
     cmd.bindToRealTimeEventsSource(provider::setListener);
 
-    provider.trigger(l -> l.onMessageSent(new V4Initiator(), createMessageSentEvent(true, "/test")));
+    provider.trigger(l -> l.onMessageSent(new V4Initiator(), createMessageSentEvent(true, commandPattern)));
+    assertTrue(handlerCalled.get());
+  }
+
+  @Test
+  void testSlashCommandWithTwoWordsAndBotMentionSuccess() {
+
+    final AtomicBoolean handlerCalled = new AtomicBoolean(false);
+    final Consumer<CommandContext> handler = c -> handlerCalled.set(true);
+    final RealTimeEventsProvider provider = new RealTimeEventsProvider();
+
+    final String commandPattern = "/test blah";
+    final SlashCommand cmd = SlashCommand.slash(commandPattern, handler);
+    cmd.setBotUserId(BOT_USER_ID);
+    cmd.bindToRealTimeEventsSource(provider::setListener);
+
+    provider.trigger(l -> l.onMessageSent(new V4Initiator(), createMessageSentEvent(true, commandPattern)));
     assertTrue(handlerCalled.get());
   }
 
@@ -59,13 +76,30 @@ class SlashCommandTest {
 
     final AtomicBoolean handlerCalled = new AtomicBoolean(false);
     final Consumer<CommandContext> handler = c -> handlerCalled.set(true);
-
     final RealTimeEventsProvider provider = new RealTimeEventsProvider();
-    final SlashCommand cmd = SlashCommand.slash("/test", false, handler);
+
+    final String commandPattern = "/test";
+    final SlashCommand cmd = SlashCommand.slash(commandPattern, false, handler);
     cmd.setBotUserId(BOT_USER_ID);
     cmd.bindToRealTimeEventsSource(provider::setListener);
 
-    provider.trigger(l -> l.onMessageSent(new V4Initiator(), createMessageSentEvent(false, "/test")));
+    provider.trigger(l -> l.onMessageSent(new V4Initiator(), createMessageSentEvent(false, commandPattern)));
+    assertTrue(handlerCalled.get());
+  }
+
+  @Test
+  void testSlashCommandWithTwoWordsWithoutBotMentionSuccess() {
+
+    final AtomicBoolean handlerCalled = new AtomicBoolean(false);
+    final Consumer<CommandContext> handler = c -> handlerCalled.set(true);
+    final RealTimeEventsProvider provider = new RealTimeEventsProvider();
+
+    final String commandPattern = "/test blah";
+    final SlashCommand cmd = SlashCommand.slash(commandPattern, false, handler);
+    cmd.setBotUserId(BOT_USER_ID);
+    cmd.bindToRealTimeEventsSource(provider::setListener);
+
+    provider.trigger(l -> l.onMessageSent(new V4Initiator(), createMessageSentEvent(false, commandPattern)));
     assertTrue(handlerCalled.get());
   }
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/parsing/MatchingUserIdMentionTokenTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/parsing/MatchingUserIdMentionTokenTest.java
@@ -1,0 +1,22 @@
+package com.symphony.bdk.core.activity.parsing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class MatchingUserIdMentionTokenTest {
+
+  @Test
+  void test() {
+    final long matchingUserId = 1234L;
+    MatchingUserIdMentionToken mentionToken = new MatchingUserIdMentionToken(() -> matchingUserId);
+
+    assertEquals(Mention.class, mentionToken.getTokenType());
+    assertFalse(mentionToken.matches(""));
+    assertFalse(mentionToken.matches(new Mention("@User", 9876L)));
+    assertTrue(mentionToken.matches(new Mention("@User", matchingUserId)));
+  }
+
+}

--- a/symphony-bdk-examples/bdk-spring-boot-example/src/main/java/com/symphony/bdk/examples/spring/EchoActivity.java
+++ b/symphony-bdk-examples/bdk-spring-boot-example/src/main/java/com/symphony/bdk/examples/spring/EchoActivity.java
@@ -1,0 +1,49 @@
+package com.symphony.bdk.examples.spring;
+
+import com.symphony.bdk.core.activity.command.CommandContext;
+import com.symphony.bdk.core.activity.parsing.Cashtag;
+import com.symphony.bdk.core.activity.parsing.Hashtag;
+import com.symphony.bdk.core.activity.parsing.Mention;
+import com.symphony.bdk.core.service.message.MessageService;
+import com.symphony.bdk.spring.annotation.Slash;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * This is to show how to use @Slash annotations with arguments
+ */
+@Component
+@Slf4j
+public class EchoActivity {
+
+  @Autowired
+  private MessageService messageService;
+
+  @Slash("/echo {argument}")
+  public void echo(CommandContext context, String argument) {
+    this.messageService.send(context.getStreamId(), "Received argument: " + argument);
+  }
+
+  @Slash("/echo {@mention}")
+  public void echo(CommandContext context, Mention mention) {
+    this.messageService.send(context.getStreamId(), "Received mention: " + mention.getUserDisplayName() + " of id: " + mention.getUserId());
+  }
+
+  @Slash("/echo {#hashtag}")
+  public void echo(CommandContext context, Hashtag hashtag) {
+    this.messageService.send(context.getStreamId(), "Received hashtag: " + hashtag.getValue());
+  }
+
+  @Slash("/echo {$cashtag}")
+  public void echo(CommandContext context, Cashtag cashtag) {
+    this.messageService.send(context.getStreamId(), "Received cashtag: " + cashtag.getValue());
+  }
+
+  @Slash("/echo {argument} {$cashtag}")
+  public void echo(CommandContext context, String argument, Cashtag cashtag) {
+    this.messageService.send(context.getStreamId(), "Received argument: " + argument + " and cashtag: " + cashtag.getValue());
+  }
+
+}

--- a/symphony-bdk-examples/bdk-spring-boot-example/src/test/java/com/symphony/bdk/examples/spring/arch/ArchitectureTest.java
+++ b/symphony-bdk-examples/bdk-spring-boot-example/src/test/java/com/symphony/bdk/examples/spring/arch/ArchitectureTest.java
@@ -32,7 +32,7 @@ import org.springframework.stereotype.Service;
 public class ArchitectureTest {
 
   @ArchTest
-  void all_slash_methods_must_have_at_least_onw_command_context_parameter(JavaClasses classes) {
+  void all_slash_methods_must_have_at_least_one_command_context_parameter(JavaClasses classes) {
     methods()
         .that()
           .areAnnotatedWith(Slash.class)

--- a/symphony-bdk-examples/bdk-spring-boot-example/src/test/java/com/symphony/bdk/examples/spring/arch/ArchitectureTest.java
+++ b/symphony-bdk-examples/bdk-spring-boot-example/src/test/java/com/symphony/bdk/examples/spring/arch/ArchitectureTest.java
@@ -5,8 +5,12 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 
 import com.symphony.bdk.core.activity.AbstractActivity;
 import com.symphony.bdk.core.activity.command.CommandContext;
+import com.symphony.bdk.core.activity.parsing.Cashtag;
+import com.symphony.bdk.core.activity.parsing.Hashtag;
+import com.symphony.bdk.core.activity.parsing.Mention;
 import com.symphony.bdk.spring.annotation.Slash;
 
+import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
@@ -28,12 +32,15 @@ import org.springframework.stereotype.Service;
 public class ArchitectureTest {
 
   @ArchTest
-  void all_slash_methods_must_have_1_command_context_parameter(JavaClasses classes) {
+  void all_slash_methods_must_have_at_least_onw_command_context_parameter(JavaClasses classes) {
     methods()
         .that()
           .areAnnotatedWith(Slash.class)
         .should()
-          .haveRawParameterTypes(CommandContext.class)
+          .haveRawParameterTypes(DescribedPredicate.describe("First parameter must be of type CommandContext, others of type String, Mention, Cashtag or Hashtag",
+              l -> l.get(0).isEquivalentTo(CommandContext.class)
+                  && l.subList(1, l.size()).stream().allMatch(t -> t.isEquivalentTo(String.class) || t.isEquivalentTo(
+                  Mention.class) ||t.isEquivalentTo(Cashtag.class) ||t.isEquivalentTo(Hashtag.class))))
     .check(classes);
   }
 

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/annotation/Slash.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/annotation/Slash.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
 public @interface Slash {
 
   /**
-   * Name or identifier of the {@link com.symphony.bdk.core.activity.command.SlashCommand}.
+   * Pattern of the {@link com.symphony.bdk.core.activity.command.SlashCommand}.
    */
   String value();
 

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/annotation/SlashAnnotationProcessor.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/annotation/SlashAnnotationProcessor.java
@@ -37,8 +37,6 @@ import java.util.stream.Stream;
  * @see <a href="https://github.com/spring-projects/spring-framework/blob/master/spring-context/src/main/java/org/springframework/context/event/EventListenerMethodProcessor.java">EventListenerMethodProcessor.java</a>
  */
 @Slf4j
-@Generated // means excluded from test coverage: error cases hard to test,
-// createSlashCommandCallback not testable with arguments because DefaultParameterNameDiscoverer not working with Mockito mocks/spies
 public class SlashAnnotationProcessor implements SmartInitializingSingleton, BeanFactoryPostProcessor {
 
   /**
@@ -70,6 +68,7 @@ public class SlashAnnotationProcessor implements SmartInitializingSingleton, Bea
   }
 
   @Override
+  @Generated // means excluded from test coverage: error cases hard to test
   public void afterSingletonsInstantiated() {
     Assert.state(this.beanFactory != null, "No ConfigurableListableBeanFactory set");
 
@@ -92,6 +91,7 @@ public class SlashAnnotationProcessor implements SmartInitializingSingleton, Bea
     }
   }
 
+  @Generated // means excluded from test coverage: error cases hard to test
   private Class<?> determineTargetClass(String beanName) {
     Class<?> type = null;
     try {
@@ -137,6 +137,7 @@ public class SlashAnnotationProcessor implements SmartInitializingSingleton, Bea
     }
   }
 
+  @Generated // means excluded from test coverage: error cases hard to test
   private Map<Method, Slash> getSlashAnnotatedMethods(String beanName, Class<?> targetType) {
     Map<Method, Slash> annotatedMethods = null;
 
@@ -155,17 +156,16 @@ public class SlashAnnotationProcessor implements SmartInitializingSingleton, Bea
   private void registerSlashMethod(String beanName, Method method, Slash annotation) {
     final Object bean = this.beanFactory.getBean(beanName);
 
-    getActivityRegistry().register(
-        SlashCommand.slash(annotation.value(), annotation.mentionBot(), createSlashCommandCallback(bean, method),
-            annotation.description())
-    );
+    final SlashCommand slashCommand = SlashCommand.slash(annotation.value(), annotation.mentionBot(),
+        createSlashCommandCallback(bean, method, METHOD_TO_ARGUMENT_INDEXES.get(method)), annotation.description());
+
+    getActivityRegistry().register(slashCommand);
   }
 
   // visible for testing
-  protected static Consumer<CommandContext> createSlashCommandCallback(Object bean, Method method) {
+  protected static Consumer<CommandContext> createSlashCommandCallback(Object bean, Method method, Map<String, Integer> methodParameterIndexes) {
     return c -> {
       try {
-        final Map<String, Integer> methodParameterIndexes = METHOD_TO_ARGUMENT_INDEXES.get(method);
         final Object[] slashMethodParameters = buildSlashMethodParameters(methodParameterIndexes, c);
 
         method.invoke(bean, slashMethodParameters);

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/annotation/SlashAnnotationProcessor.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/annotation/SlashAnnotationProcessor.java
@@ -37,6 +37,7 @@ import java.util.stream.Stream;
  * @see <a href="https://github.com/spring-projects/spring-framework/blob/master/spring-context/src/main/java/org/springframework/context/event/EventListenerMethodProcessor.java">EventListenerMethodProcessor.java</a>
  */
 @Slf4j
+@Generated // means excluded from test coverage: error cases hard to test, createSlashCommandCallback not testable with arguments because of Mockito mocks/spies
 public class SlashAnnotationProcessor implements SmartInitializingSingleton, BeanFactoryPostProcessor {
 
   /**
@@ -90,7 +91,6 @@ public class SlashAnnotationProcessor implements SmartInitializingSingleton, Bea
     }
   }
 
-  @Generated // means excluded from test coverage (hard to test error cases)
   private Class<?> determineTargetClass(String beanName) {
     Class<?> type = null;
     try {
@@ -135,7 +135,6 @@ public class SlashAnnotationProcessor implements SmartInitializingSingleton, Bea
     }
   }
 
-  @Generated // means excluded from test coverage (hard to test error cases)
   private Map<Method, Slash> getSlashAnnotatedMethods(String beanName, Class<?> targetType) {
     Map<Method, Slash> annotatedMethods = null;
 

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/annotation/SlashAnnotationProcessor.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/annotation/SlashAnnotationProcessor.java
@@ -37,7 +37,8 @@ import java.util.stream.Stream;
  * @see <a href="https://github.com/spring-projects/spring-framework/blob/master/spring-context/src/main/java/org/springframework/context/event/EventListenerMethodProcessor.java">EventListenerMethodProcessor.java</a>
  */
 @Slf4j
-@Generated // means excluded from test coverage: error cases hard to test, createSlashCommandCallback not testable with arguments because of Mockito mocks/spies
+@Generated // means excluded from test coverage: error cases hard to test,
+// createSlashCommandCallback not testable with arguments because DefaultParameterNameDiscoverer not working with Mockito mocks/spies
 public class SlashAnnotationProcessor implements SmartInitializingSingleton, BeanFactoryPostProcessor {
 
   /**

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/annotation/SlashAnnotationProcessor.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/annotation/SlashAnnotationProcessor.java
@@ -131,7 +131,8 @@ public class SlashAnnotationProcessor implements SmartInitializingSingleton, Bea
         this.registerSlashMethod(beanName, m, annotation);
       } else {
         log.warn("Method '{}' is annotated by @Slash but does not respect the expected prototype. "
-            + "It must accept a single argument of type '{}'", m, CommandContext.class);
+            + "It must accept a first argument of type '{}' and (potential) other arguments based on the slash command pattern.",
+            m, CommandContext.class);
       }
     }
   }

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/test/java/com/symphony/bdk/spring/slash/TestSlashCommand.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/test/java/com/symphony/bdk/spring/slash/TestSlashCommand.java
@@ -1,6 +1,9 @@
 package com.symphony.bdk.spring.slash;
 
 import com.symphony.bdk.core.activity.command.CommandContext;
+import com.symphony.bdk.core.activity.parsing.Cashtag;
+import com.symphony.bdk.core.activity.parsing.Hashtag;
+import com.symphony.bdk.core.activity.parsing.Mention;
 import com.symphony.bdk.spring.annotation.Slash;
 
 import org.springframework.stereotype.Component;
@@ -23,6 +26,41 @@ public class TestSlashCommand {
 
   @Slash("/hello")
   public void illegalPrototype() {
-    //
+    // nothing to be done here
+  }
+
+  @Slash("/hello {arg}")
+  public void withStringArgument(CommandContext context, String arg) {
+    // nothing to be done here
+  }
+
+  @Slash("/hello {arg1}{arg2}")
+  public void withInvalidSlashCommandPattern(CommandContext context, String arg) {
+    // nothing to be done here
+  }
+
+  @Slash("/hello {arg} {arg}")
+  public void withDuplicatedArgs(CommandContext context, String arg) {
+    // nothing to be done here
+  }
+
+  @Slash("/hello1 {arg} {@mention} {#hashtag} {$cashtag}")
+  public void withArguments(CommandContext context, String arg, Mention mention, Hashtag hashtag, Cashtag cashtag) {
+    // nothing to be done here
+  }
+
+  @Slash("/hello2 {arg} {@mention} {#hashtag} {$cashtag}")
+  public void withArgumentDifferentOrder(CommandContext context, Mention mention, Cashtag cashtag, String arg, Hashtag hashtag) {
+    // nothing to be done here
+  }
+
+  @Slash("/hello {argument}")
+  public void withStringArgumentMismatchingName(CommandContext context, String arg) {
+    // nothing to be done here
+  }
+
+  @Slash("/hello {@arg}")
+  public void withStringArgumentMismatchingType(CommandContext context, String arg) {
+    // nothing to be done here
   }
 }


### PR DESCRIPTION
### Ticket
#511

### Description
Make slash command arguments available in annotated methods with @Slash in SB starter

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
