### PR TITLE
#614 Add a decorator to the  ApplicationEventMulticaster

### DIFF
--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkDatafeedConfig.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkDatafeedConfig.java
@@ -8,6 +8,7 @@ import com.symphony.bdk.core.service.datafeed.impl.DatafeedLoopV1;
 import com.symphony.bdk.core.service.datafeed.impl.DatafeedLoopV2;
 import com.symphony.bdk.core.service.session.SessionService;
 import com.symphony.bdk.gen.api.DatafeedApi;
+import com.symphony.bdk.http.api.tracing.MDCUtils;
 import com.symphony.bdk.spring.SymphonyBdkCoreProperties;
 import com.symphony.bdk.spring.events.RealTimeEvent;
 import com.symphony.bdk.spring.events.RealTimeEventsDispatcher;
@@ -67,13 +68,15 @@ public class BdkDatafeedConfig {
   }
 
   /**
-   * Allows to publish application {@link RealTimeEvent} asynchronously from {@link RealTimeEventsDispatcher}.
+   * Allows publishing application {@link RealTimeEvent} asynchronously from {@link RealTimeEventsDispatcher}.
    */
   @Bean(name = "applicationEventMulticaster")
   @ConditionalOnProperty(value = "bdk.datafeed.event.async", havingValue = "true", matchIfMissing = true)
   public ApplicationEventMulticaster simpleApplicationEventMulticaster() {
     final SimpleApplicationEventMulticaster eventMulticaster = new SimpleApplicationEventMulticaster();
-    eventMulticaster.setTaskExecutor(new SimpleAsyncTaskExecutor());
+    SimpleAsyncTaskExecutor simpleAsyncTaskExecutor = new SimpleAsyncTaskExecutor();
+    simpleAsyncTaskExecutor.setTaskDecorator(MDCUtils::wrap);
+    eventMulticaster.setTaskExecutor(simpleAsyncTaskExecutor);
     return eventMulticaster;
   }
 }

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkOboServiceConfig.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkOboServiceConfig.java
@@ -1,7 +1,7 @@
 package com.symphony.bdk.spring.config;
 
-import com.symphony.bdk.core.auth.ExtensionAppAuthenticator;
 import com.symphony.bdk.core.auth.AuthenticatorFactory;
+import com.symphony.bdk.core.auth.ExtensionAppAuthenticator;
 import com.symphony.bdk.core.auth.OboAuthenticator;
 import com.symphony.bdk.core.auth.exception.AuthInitializationException;
 import com.symphony.bdk.core.config.model.BdkConfig;

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/test/java/com/symphony/bdk/spring/events/RealTimeEventListenerAsyncTest.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/test/java/com/symphony/bdk/spring/events/RealTimeEventListenerAsyncTest.java
@@ -1,0 +1,91 @@
+package com.symphony.bdk.spring.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+import com.symphony.bdk.gen.api.model.V4Initiator;
+import com.symphony.bdk.gen.api.model.V4SymphonyElementsAction;
+import com.symphony.bdk.http.api.tracing.DistributedTracingContext;
+import com.symphony.bdk.http.api.tracing.MDCUtils;
+
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.event.ApplicationEventMulticaster;
+import org.springframework.context.event.SimpleApplicationEventMulticaster;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.util.ErrorHandler;
+
+@SpringBootTest(classes = RealTimeEventsAsyncTestListener.class)
+@ContextConfiguration(classes = RealTimeEventListenerAsyncTest.TestContextConfig.class)
+@ExtendWith(SpringExtension.class)
+public class RealTimeEventListenerAsyncTest {
+  @Autowired
+  private ApplicationEventPublisher publisher;
+
+  @SpyBean
+  private RealTimeEventsAsyncTestListener eventListener;
+
+  private RealTimeEventsDispatcher dispatcher;
+
+  private V4Initiator initiator;
+
+  static boolean hasException = false;
+
+  @BeforeEach
+  public void setUp() {
+    dispatcher = new RealTimeEventsDispatcher(publisher);
+    initiator = new V4Initiator();
+  }
+
+  @AfterEach
+  void tearDown() {
+    MDC.clear();
+  }
+
+  @Test
+  @SneakyThrows
+  void testOnSymphonyElementsAction() {
+    final V4SymphonyElementsAction payload = new V4SymphonyElementsAction();
+    // Inject trace id and the current thread name
+    DistributedTracingContext.setTraceId();
+    MDC.put("thread_name", Thread.currentThread().getName());
+    dispatcher.onSymphonyElementsAction(initiator, payload);
+
+    verify(eventListener, timeout(100).only()).onSymphonyElementsAction(eq(new RealTimeEvent<>(initiator, payload)));
+    assertThat(hasException).isFalse();
+  }
+
+  @TestConfiguration
+  static class TestContextConfig {
+    @Bean(name = "applicationEventMulticaster")
+    public ApplicationEventMulticaster simpleApplicationEventMulticaster() {
+      final SimpleApplicationEventMulticaster eventMulticaster = new SimpleApplicationEventMulticaster();
+      SimpleAsyncTaskExecutor simpleAsyncTaskExecutor = new SimpleAsyncTaskExecutor();
+      simpleAsyncTaskExecutor.setTaskDecorator(MDCUtils::wrap);
+      eventMulticaster.setTaskExecutor(simpleAsyncTaskExecutor);
+      eventMulticaster.setErrorHandler(new RealTimeEventListenerAsyncTest.TestErrorHandler());
+      return eventMulticaster;
+    }
+  }
+
+  static class TestErrorHandler implements ErrorHandler {
+    @Override
+    public void handleError(Throwable throwable) {
+      hasException = true;
+    }
+  }
+}

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/test/java/com/symphony/bdk/spring/events/RealTimeEventsAsyncTestListener.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/test/java/com/symphony/bdk/spring/events/RealTimeEventsAsyncTestListener.java
@@ -1,0 +1,26 @@
+package com.symphony.bdk.spring.events;
+
+import com.symphony.bdk.gen.api.model.V4SymphonyElementsAction;
+import com.symphony.bdk.http.api.tracing.DistributedTracingContext;
+
+import org.slf4j.MDC;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+public class RealTimeEventsAsyncTestListener {
+
+  @EventListener
+  public void onSymphonyElementsAction(RealTimeEvent<V4SymphonyElementsAction> event) {
+    Objects.requireNonNull(event.getInitiator());
+    Objects.requireNonNull(event.getSource());
+    // Test the MDC values have been copied from the parent thread
+    Objects.requireNonNull(MDC.get(DistributedTracingContext.TRACE_ID));
+    // Make sure the current thread is different from the parent thread, so child thread
+    if (Thread.currentThread().getName().equals(MDC.get("thread_name"))) {
+      throw new IllegalStateException("test failed - thread name must be different.");
+    }
+  }
+}


### PR DESCRIPTION
### Ticket
Closes #614 

### Description
This commit allows to copy the MDC values from the parent thread to the child
thread through a task decorator, otherwise the MDC values, especially the trace
id is lost, hence the tracibility is broken.

### Dependencies
N/A

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
