### PR TITLE
ApiClient supports authentication schemes

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/client/loadbalancing/LoadBalancedApiClient.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/client/loadbalancing/LoadBalancedApiClient.java
@@ -7,10 +7,13 @@ import com.symphony.bdk.core.config.model.BdkLoadBalancingConfig;
 import com.symphony.bdk.http.api.ApiClient;
 import com.symphony.bdk.http.api.Pair;
 
+import com.symphony.bdk.http.api.auth.Authentication;
+
 import lombok.extern.slf4j.Slf4j;
 import org.apiguardian.api.API;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * An {@link ApiClient} implementation which load balances calls across several base URLs.
@@ -105,6 +108,14 @@ public abstract class LoadBalancedApiClient implements ApiClient {
   @Override
   public String escapeString(String str) {
     return apiClient.escapeString(str);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Map<String, Authentication> getAuthentications() {
+    return this.apiClient.getAuthentications();
   }
 
   private void validateLoadBalancingConfiguration(BdkConfig config) {

--- a/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/ApiClient.java
+++ b/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/ApiClient.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.http.api;
 
+import com.symphony.bdk.http.api.auth.Authentication;
 import com.symphony.bdk.http.api.util.TypeReference;
 
 import org.apiguardian.api.API;
@@ -96,6 +97,12 @@ public interface ApiClient {
    * @return Escaped string
    */
   String escapeString(String str);
+
+  /**
+   * Get authentications (key: authentication name, value: authentication).
+   * @return Map of {@link Authentication} object
+   */
+  Map<String, Authentication> getAuthentications();
 
   /**
    * Change target server according to the load balancing configuration, applies only for calls to the agent.

--- a/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/ApiClientBuilder.java
+++ b/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/ApiClientBuilder.java
@@ -1,5 +1,7 @@
 package com.symphony.bdk.http.api;
 
+import com.symphony.bdk.http.api.auth.Authentication;
+
 import org.apiguardian.api.API;
 
 /**
@@ -119,4 +121,13 @@ public interface ApiClientBuilder {
    * @return the updated instance of {@link ApiClientBuilder}
    */
   ApiClientBuilder withProxyCredentials(String proxyUser, String proxyPassword);
+
+  /**
+   * Puts an authentication scheme.
+   *
+   * @param name Authentication scheme name.
+   * @param authentication Authentication scheme implementation.
+   * @return the updated instance of {@link ApiClientBuilder}
+   */
+  ApiClientBuilder withAuthentication(String name, Authentication authentication);
 }

--- a/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/auth/Authentication.java
+++ b/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/auth/Authentication.java
@@ -1,0 +1,23 @@
+package com.symphony.bdk.http.api.auth;
+
+import com.symphony.bdk.http.api.Pair;
+
+import org.apiguardian.api.API;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This interf
+ */
+@API(status = API.Status.STABLE)
+public interface Authentication {
+
+  /**
+   * Apply authentication settings to header and query params.
+   *
+   * @param queryParams List of query parameters
+   * @param headerParams Map of header parameters
+   */
+  void applyToParams(List<Pair> queryParams, Map<String, String> headerParams);
+}

--- a/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/auth/Authentication.java
+++ b/symphony-bdk-http/symphony-bdk-http-api/src/main/java/com/symphony/bdk/http/api/auth/Authentication.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.http.api.auth;
 
+import com.symphony.bdk.http.api.ApiClient;
 import com.symphony.bdk.http.api.Pair;
 
 import org.apiguardian.api.API;
@@ -8,7 +9,9 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * This interf
+ * Definition of an <a href="https://swagger.io/docs/specification/authentication">authentication scheme</a>.
+ * <p>
+ * An authentication scheme can be set through the {@link ApiClient#getAuthentications()} map.
  */
 @API(status = API.Status.STABLE)
 public interface Authentication {

--- a/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientBuilderJersey2.java
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/src/main/java/com/symphony/bdk/http/jersey2/ApiClientBuilderJersey2.java
@@ -5,6 +5,7 @@ import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 
 import com.symphony.bdk.http.api.ApiClient;
 import com.symphony.bdk.http.api.ApiClientBuilder;
+import com.symphony.bdk.http.api.auth.Authentication;
 import com.symphony.bdk.http.api.util.ApiUtils;
 
 import org.apache.http.config.Registry;
@@ -60,6 +61,7 @@ public class ApiClientBuilderJersey2 implements ApiClientBuilder {
   protected String proxyUrl;
   protected String proxyUser;
   protected String proxyPassword;
+  protected Map<String, Authentication> authentications;
 
   public ApiClientBuilderJersey2() {
     this.basePath = "https://acme.symphony.com";
@@ -76,6 +78,7 @@ public class ApiClientBuilderJersey2 implements ApiClientBuilder {
     this.proxyUrl = null;
     this.proxyUser = null;
     this.proxyPassword = null;
+    this.authentications = new HashMap<>();
     this.withUserAgent(ApiUtils.getUserAgent());
   }
 
@@ -95,7 +98,9 @@ public class ApiClientBuilderJersey2 implements ApiClientBuilder {
     httpClient.property(ClientProperties.CONNECT_TIMEOUT, this.connectionTimeout);
     httpClient.property(ClientProperties.READ_TIMEOUT, this.readTimeout);
 
-    return new ApiClientJersey2(httpClient, this.basePath, this.defaultHeaders, this.temporaryFolderPath);
+    final ApiClient apiClient = new ApiClientJersey2(httpClient, this.basePath, this.defaultHeaders, this.temporaryFolderPath);
+    this.authentications.forEach(apiClient.getAuthentications()::put);
+    return apiClient;
   }
 
   /**
@@ -206,6 +211,15 @@ public class ApiClientBuilderJersey2 implements ApiClientBuilder {
   public ApiClientBuilder withProxyCredentials(String proxyUser, String proxyPassword) {
     this.proxyUser = proxyUser;
     this.proxyPassword = proxyPassword;
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public ApiClientBuilder withAuthentication(String name, Authentication authentication) {
+    this.authentications.put(name, authentication);
     return this;
   }
 

--- a/symphony-bdk-http/symphony-bdk-http-jersey2/src/test/java/com/symphony/bdk/http/jersey2/ApiClientJersey2Test.java
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/src/test/java/com/symphony/bdk/http/jersey2/ApiClientJersey2Test.java
@@ -1,14 +1,12 @@
 package com.symphony.bdk.http.jersey2;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import com.symphony.bdk.http.api.ApiException;
 import com.symphony.bdk.http.api.tracing.DistributedTracingContext;
-
 import com.symphony.bdk.http.api.util.TypeReference;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.UUID;
 
 import javax.ws.rs.HttpMethod;
@@ -51,6 +50,9 @@ class ApiClientJersey2Test {
     when(statusInfo.getFamily()).thenReturn(Response.Status.Family.SUCCESSFUL);
     when(response.getHeaders()).thenReturn(new MultivaluedHashMap<>());
     this.apiClient = new ApiClientJersey2(client, "", Collections.emptyMap(), "");
+    this.apiClient.getAuthentications().put("testAuth", (queryParams, headerParams) -> {
+      headerParams.put("Authorization", "test");
+    });
   }
 
   @Test
@@ -74,12 +76,12 @@ class ApiClientJersey2Test {
         HttpMethod.POST,
         Collections.emptyList(),
         null,
-        Collections.emptyMap(),
-        Collections.emptyMap(),
-        Collections.emptyMap(),
+        new HashMap<>(),
+        new HashMap<>(),
+        new HashMap<>(),
         "application/json",
         "application/json",
-        new String[0],
+        new String[] { "testAuth" },
         new TypeReference<String>() {}
     );
   }

--- a/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClient.java
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/src/main/java/com/symphony/bdk/http/webclient/ApiClientBuilderWebClient.java
@@ -2,6 +2,7 @@ package com.symphony.bdk.http.webclient;
 
 import com.symphony.bdk.http.api.ApiClient;
 import com.symphony.bdk.http.api.ApiClientBuilder;
+import com.symphony.bdk.http.api.auth.Authentication;
 import com.symphony.bdk.http.api.util.ApiUtils;
 
 import io.netty.channel.ChannelOption;
@@ -51,6 +52,7 @@ public class ApiClientBuilderWebClient implements ApiClientBuilder {
   protected int proxyPort;
   protected String proxyUser;
   protected String proxyPassword;
+  protected Map<String, Authentication> authentications;
 
   public ApiClientBuilderWebClient() {
     this.basePath = "";
@@ -61,6 +63,7 @@ public class ApiClientBuilderWebClient implements ApiClientBuilder {
     this.proxyPort = -1;
     this.proxyUser = null;
     this.proxyPassword = null;
+    this.authentications = new HashMap<>();
     this.withUserAgent(ApiUtils.getUserAgent());
   }
 
@@ -74,7 +77,9 @@ public class ApiClientBuilderWebClient implements ApiClientBuilder {
         .baseUrl(this.basePath)
         .build();
 
-    return new ApiClientWebClient(webClient, this.basePath, this.defaultHeaders);
+    final ApiClient apiClient = new ApiClientWebClient(webClient, this.basePath, this.defaultHeaders);
+    this.authentications.forEach(apiClient.getAuthentications()::put);
+    return apiClient;
   }
 
   /**
@@ -168,6 +173,15 @@ public class ApiClientBuilderWebClient implements ApiClientBuilder {
   public ApiClientBuilder withProxyCredentials(String proxyUser, String proxyPassword) {
     this.proxyUser = proxyUser;
     this.proxyPassword = proxyPassword;
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public ApiClientBuilder withAuthentication(String name, Authentication authentication) {
+    this.authentications.put(name, authentication);
     return this;
   }
 


### PR DESCRIPTION
The `ApiClient` interface now allows to configure a list of authentication schemes, according to the [OpenAPI specification](https://swagger.io/docs/specification/authentication). 

This will especially be useful for the support of CommonJwt (i.e. OAuth) authentication. 