### PR TITLE
Target specific commit for symphony-api-specs

### DIFF
--- a/symphony-bdk-core/build.gradle
+++ b/symphony-bdk-core/build.gradle
@@ -72,7 +72,7 @@ dependencies {
 }
 
 // OpenAPI code generation
-def apiBaseUrl = "https://raw.githubusercontent.com/symphonyoss/symphony-api-spec/b50c9a7a5d5e64b957dae3c9c7a801749971dcd4"
+def apiBaseUrl = "https://raw.githubusercontent.com/symphonyoss/symphony-api-spec/1217b03323c9fb13ea1c72ba89c99f7540b9b5fc"
 def generatedFolder = "$buildDir/generated/openapi"
 def apisToGenerate = [
         Agent: 'agent/agent-api-public.yaml',

--- a/symphony-bdk-core/build.gradle
+++ b/symphony-bdk-core/build.gradle
@@ -72,12 +72,12 @@ dependencies {
 }
 
 // OpenAPI code generation
-def apiBaseUrl = "https://raw.githubusercontent.com/symphonyoss/symphony-api-spec/master"
+def apiBaseUrl = "https://raw.githubusercontent.com/symphonyoss/symphony-api-spec/b50c9a7a5d5e64b957dae3c9c7a801749971dcd4"
 def generatedFolder = "$buildDir/generated/openapi"
 def apisToGenerate = [
         Agent: 'agent/agent-api-public.yaml',
         Pod  : 'pod/pod-api-public-deprecated.yaml',
-        Auth : 'authenticator/authenticator-api-public.yaml',
+        Auth : 'authenticator/authenticator-api-public-deprecated.yaml',
         Login: 'login/login-api-public.yaml',
 ]
 


### PR DESCRIPTION
Goal of this PR is to start targeting a specific commit of the [Symphony-api-spec](https://github.com/finos/symphony-api-spec) repository and not always target the master branch, this way we'll have more control over compatibility and what features are included in each BDK version.

Also since from 20.14 we are starting deprecation process of apps authentication endpoint using certificate, we are going to generate the code from the authenticator-api-public-deprecated.yaml file so that we still support those APIs.
