### PR TITLE
Generate javadoc for group extension

### DIFF
--- a/symphony-bdk-core/build.gradle
+++ b/symphony-bdk-core/build.gradle
@@ -72,7 +72,7 @@ dependencies {
 }
 
 // OpenAPI code generation
-def apiBaseUrl = "https://raw.githubusercontent.com/symphonyoss/symphony-api-spec/1217b03323c9fb13ea1c72ba89c99f7540b9b5fc"
+def apiBaseUrl = "https://raw.githubusercontent.com/finos/symphony-api-spec/1217b03323c9fb13ea1c72ba89c99f7540b9b5fc"
 def generatedFolder = "$buildDir/generated/openapi"
 def apisToGenerate = [
         Agent: 'agent/agent-api-public.yaml',
@@ -88,6 +88,7 @@ apisToGenerate.each { api, path ->
         src "$apiBaseUrl/$path"
         dest "$buildDir/openapi/$api/${path.split("/")[1]}"
         overwrite false
+        useETag  "all"
     }
 
     def generateTask = tasks.create(name: "generate$api",

--- a/symphony-bdk-extensions/symphony-group-extension/build.gradle
+++ b/symphony-bdk-extensions/symphony-group-extension/build.gradle
@@ -7,6 +7,10 @@ plugins {
 
 description = 'Symphony Java BDK - Groups Extension'
 
+javadoc {
+    options.group 'Extension - Group', 'com.symphony.bdk.ext*'
+}
+
 dependencies {
     implementation project(':symphony-bdk-core')
     implementation project(':symphony-bdk-extension-api')
@@ -22,7 +26,7 @@ dependencies {
     testImplementation 'com.tngtech.archunit:archunit-junit5'
 }
 
-def baseSpecsUrl = 'https://raw.githubusercontent.com/finos/symphony-api-spec/master/profile-manager'
+def baseSpecsUrl = 'https://raw.githubusercontent.com/finos/symphony-api-spec/af73762a33357436edacca0b198cc18192e96606/profile-manager'
 
 task downloadFile(type: Download) {
     src([
@@ -31,7 +35,7 @@ task downloadFile(type: Download) {
     ])
     dest buildDir
     onlyIfModified true
-    useETag true
+    useETag "all"
 }
 
 openApiGenerate {
@@ -41,6 +45,8 @@ openApiGenerate {
 }
 
 tasks.openApiGenerate.dependsOn tasks.downloadFile
+tasks.sourcesJar.dependsOn tasks.downloadFile
+tasks.sourcesJar.dependsOn tasks.openApiGenerate
 
 jacocoTestCoverageVerification {
     violationRules {


### PR DESCRIPTION
### Description
Also fix build warnings about etag for API specs.
Also update the url to symphony-api-spec and avoid using master to make
sure builds are reproductible.

### Dependencies
N/A
### Checklist
- [X] Referenced an issue in the PR title or description
- [X] Filled properly the description and dependencies, if any
- [N/A] Unit/Integration tests updated or added
- [N/A] Javadoc added or updated
- [N/A] Updated the documentation in [docs folder](../docs)
