### PR TITLE
Starting Datafeed v1 deprecation process

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -188,7 +188,7 @@ configuration inside service configuration to override the global one.
 
 #### DatafeedConfiguration
 The datafeed configuration will contain information about the datafeed service to be used by the bot:
-- `version`: the version of datafeed service to be used. By default, the bot will use the datafeed v1
+- `version`: the version of datafeed service to be used. By default, the bot will use the datafeed v2
 service. 
 - `idFilePath`: the path to the file which will be used to persist a created datafeed id in case the 
 datafeed service v1 is used.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,7 +121,7 @@ app:
     path: path/to/private-key.pem
 
 datafeed:
-  version: v1
+  version: v2
   retry:
     maxAttempts: 6
     initialIntervalMillis: 2000

--- a/docs/datafeed.md
+++ b/docs/datafeed.md
@@ -1,4 +1,9 @@
 # Datafeed
+> :warning: The datafeed 1 service will be fully replaced by the datafeed 2 service in the future. 
+> Please consider using datafeed 2.  
+> 
+> For more information on the timeline as well as on the benefits of datafeed 2, please reach out to your Technical 
+> Account Manager or to our [developer documentation](https://docs.developers.symphony.com/building-bots-on-symphony/datafeed).
 
 The datafeed loop is a service used for handling the [_Real Time
 Events_](https://developers.symphony.com/restapi/docs/real-time-events). When a user makes an interaction within the IM,

--- a/symphony-bdk-config/src/main/java/com/symphony/bdk/core/config/model/BdkDatafeedConfig.java
+++ b/symphony-bdk-config/src/main/java/com/symphony/bdk/core/config/model/BdkDatafeedConfig.java
@@ -1,5 +1,7 @@
 package com.symphony.bdk.core.config.model;
 
+import static com.symphony.bdk.core.config.util.DeprecationLogger.logDeprecation;
+
 import lombok.Getter;
 import lombok.Setter;
 import org.apiguardian.api.API;
@@ -11,17 +13,27 @@ import java.io.File;
 @API(status = API.Status.STABLE)
 public class BdkDatafeedConfig {
 
-    private String version = "v1";
-    private String idFilePath;
-    private BdkRetryConfig retry = new BdkRetryConfig(BdkRetryConfig.INFINITE_MAX_ATTEMPTS);
+  private String version = "v2";
+  private String idFilePath;
+  private BdkRetryConfig retry = new BdkRetryConfig(BdkRetryConfig.INFINITE_MAX_ATTEMPTS);
 
-    public String getIdFilePath() {
-        if (idFilePath == null || idFilePath.isEmpty()) {
-            return "." + File.separator;
-        }
-        if (!idFilePath.endsWith(File.separator)) {
-            return idFilePath + File.separator;
-        }
-        return idFilePath;
+  public void setVersion(String version) {
+    if ("v1".equalsIgnoreCase(version)) {
+      logDeprecation("The datafeed 1 service will be fully replaced by the datafeed 2 service in the future. "
+          + "Please consider migrating over to datafeed 2. For more information on the timeline as well as on the "
+          + "benefits of datafeed 2, please reach out to your Technical Account Manager or to our developer "
+          + "documentation https://docs.developers.symphony.com/building-bots-on-symphony/datafeed)");
     }
+    this.version = version;
+  }
+
+  public String getIdFilePath() {
+    if (idFilePath == null || idFilePath.isEmpty()) {
+      return "." + File.separator;
+    }
+    if (!idFilePath.endsWith(File.separator)) {
+      return idFilePath + File.separator;
+    }
+    return idFilePath;
+  }
 }

--- a/symphony-bdk-core/build.gradle
+++ b/symphony-bdk-core/build.gradle
@@ -72,10 +72,10 @@ dependencies {
 }
 
 // OpenAPI code generation
-def apiBaseUrl = "https://raw.githubusercontent.com/finos/symphony-api-spec/1217b03323c9fb13ea1c72ba89c99f7540b9b5fc"
+def apiBaseUrl = "https://raw.githubusercontent.com/finos/symphony-api-spec/16a902e2d0f8f64c680b5d799f871a3fc4884890"
 def generatedFolder = "$buildDir/generated/openapi"
 def apisToGenerate = [
-        Agent: 'agent/agent-api-public.yaml',
+        Agent: 'agent/agent-api-public-deprecated.yaml',
         Pod  : 'pod/pod-api-public-deprecated.yaml',
         Auth : 'authenticator/authenticator-api-public-deprecated.yaml',
         Login: 'login/login-api-public.yaml',

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/SymphonyBdkTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/SymphonyBdkTest.java
@@ -1,12 +1,15 @@
 package com.symphony.bdk.core;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
 import com.symphony.bdk.core.activity.ActivityRegistry;
-import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.core.auth.AppAuthSession;
+import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.core.auth.exception.AuthInitializationException;
 import com.symphony.bdk.core.auth.exception.AuthUnauthorizedException;
 import com.symphony.bdk.core.client.ApiClientFactory;
@@ -16,10 +19,10 @@ import com.symphony.bdk.core.config.exception.BotNotConfiguredException;
 import com.symphony.bdk.core.config.model.BdkConfig;
 import com.symphony.bdk.core.service.application.ApplicationService;
 import com.symphony.bdk.core.service.connection.ConnectionService;
+import com.symphony.bdk.core.service.datafeed.DatafeedLoop;
+import com.symphony.bdk.core.service.datafeed.impl.DatafeedLoopV2;
 import com.symphony.bdk.core.service.health.HealthService;
 import com.symphony.bdk.core.service.message.MessageService;
-import com.symphony.bdk.core.service.datafeed.DatafeedLoop;
-import com.symphony.bdk.core.service.datafeed.impl.DatafeedLoopV1;
 import com.symphony.bdk.core.service.presence.PresenceService;
 import com.symphony.bdk.core.service.session.SessionService;
 import com.symphony.bdk.core.service.signal.SignalService;
@@ -27,7 +30,6 @@ import com.symphony.bdk.core.service.stream.StreamService;
 import com.symphony.bdk.core.service.user.UserService;
 import com.symphony.bdk.core.test.JsonHelper;
 import com.symphony.bdk.core.test.MockApiClient;
-
 import com.symphony.bdk.http.api.HttpClient;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -79,7 +81,7 @@ public class SymphonyBdkTest {
     DatafeedLoop datafeedService = this.symphonyBdk.datafeed();
 
     assertNotNull(datafeedService);
-    assertEquals(datafeedService.getClass(), DatafeedLoopV1.class);
+    assertEquals(datafeedService.getClass(), DatafeedLoopV2.class);
   }
 
   @Test


### PR DESCRIPTION
### Description
The datafeed 1 service will be fully replaced by the datafeed 2 service in the future. Please consider migrating over to datafeed 2 APIs /agent/v5/datafeeds. For more information on the timeline as well as on the benefits of datafeed 2, please reach out to your Technical Account Manager or to our developer documentation https://docs.developers.symphony.com/building-bots-on-symphony/datafeed

This PR includes:
- if datafeed version is not defined in the config, the BDK will use DFv2 by default
- added deprecation notice when DFv1 is used
- APIs generation is been updated following swagger deprecation of the APIs https://github.com/finos/symphony-api-spec/pull/143
