### PR TITLE
Upgrade Symphony API specifications for parent message id / Upgrade Spring Boot to 2.6.7

### DIFF
--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     // import Spring Boot's BOM
-    api platform('org.springframework.boot:spring-boot-dependencies:2.6.6')
+    api platform('org.springframework.boot:spring-boot-dependencies:2.6.7')
     // import Jackson's BOM
     api platform('com.fasterxml.jackson:jackson-bom:2.13.2.20220328')
     // define all our dependencies versions

--- a/symphony-bdk-core/build.gradle
+++ b/symphony-bdk-core/build.gradle
@@ -72,7 +72,7 @@ dependencies {
 }
 
 // OpenAPI code generation
-def apiBaseUrl = "https://raw.githubusercontent.com/finos/symphony-api-spec/16a902e2d0f8f64c680b5d799f871a3fc4884890"
+def apiBaseUrl = "https://raw.githubusercontent.com/finos/symphony-api-spec/76f5817b321c055048e3b4caeedbc0c3d3f86890"
 def generatedFolder = "$buildDir/generated/openapi"
 def apisToGenerate = [
         Agent: 'agent/agent-api-public-deprecated.yaml',

--- a/symphony-bdk-examples/bdk-app-spring-boot-example/build.gradle
+++ b/symphony-bdk-examples/bdk-app-spring-boot-example/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'bdk.java-common-conventions'
-    id 'org.springframework.boot' version "2.6.6"
+    id 'org.springframework.boot' version "2.6.7"
 }
 
 description = 'Symphony Java BDK Examples for the SpringBoot integration'

--- a/symphony-bdk-examples/bdk-spring-boot-example/build.gradle
+++ b/symphony-bdk-examples/bdk-spring-boot-example/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'bdk.java-common-conventions'
-    id 'org.springframework.boot' version "2.6.6"
+    id 'org.springframework.boot' version "2.6.7"
 }
 
 description = 'Symphony Java BDK Examples for the SpringBoot integration'


### PR DESCRIPTION
### Description
Agent API is now returning the parentMessageId as part of V4Message
payloads to retrieve the original message in case of a forward or a
reply.

### Dependencies
https://github.com/finos/symphony-api-spec/pull/150

### Checklist
- [X] Referenced an issue in the PR title or description
- [X] Filled properly the description and dependencies, if any
- [X] Unit/Integration tests updated or added
- [X] Javadoc added or updated
- [X] Updated the documentation in [docs folder](../docs)
