### PR TITLE
Remove unsupported Datahose events from documentation

### DIFF
--- a/docs/datafeed.md
+++ b/docs/datafeed.md
@@ -198,11 +198,8 @@ datahose:
 The minimal configuration for the datahose service is the `filters` field. It should contain at least one value chosen
 among the following:
 * SOCIALMESSAGE
-* CHANNEL_CREATE
-* CHANNEL_UPDATE
 * CREATE_ROOM
 * UPDATE_ROOM
-* UPDATE_STREAM
 
 :warning: If you want to use `SOCIALMESSAGE` filter (i.e. consume message sent events), `ceservice` credentials must be
 configured in your Symphony agent.


### PR DESCRIPTION
Those events are not yet handled by the Agent so avoid mentioning them
in the documentation.
