### PR TITLE
Update springboot version

### DIFF
--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     // import Spring Boot's BOM
-    api platform('org.springframework.boot:spring-boot-dependencies:2.6.7')
+    api platform('org.springframework.boot:spring-boot-dependencies:2.6.8')
     // import Jackson's BOM
     api platform('com.fasterxml.jackson:jackson-bom:2.13.2.20220328')
     // define all our dependencies versions

--- a/symphony-bdk-examples/bdk-app-spring-boot-example/build.gradle
+++ b/symphony-bdk-examples/bdk-app-spring-boot-example/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'bdk.java-common-conventions'
-    id 'org.springframework.boot' version "2.6.7"
+    id 'org.springframework.boot' version "2.6.8"
 }
 
 description = 'Symphony Java BDK Examples for the SpringBoot integration'

--- a/symphony-bdk-examples/bdk-spring-boot-example/build.gradle
+++ b/symphony-bdk-examples/bdk-spring-boot-example/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'bdk.java-common-conventions'
-    id 'org.springframework.boot' version "2.6.7"
+    id 'org.springframework.boot' version "2.6.8"
 }
 
 description = 'Symphony Java BDK Examples for the SpringBoot integration'


### PR DESCRIPTION
Due to CVE2022-22978 vulnerability in spring-security-web-5.6.3,
springboot version has to be updated to 2.6.8 to get rid of
this issue.

### Description
Closes #[ISSUE NUMBER]

Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced an issue in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
