### PR TITLE
Fix DF2 ID format regex pattern bug

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2.java
@@ -52,7 +52,7 @@ public class DatafeedLoopV2 extends AbstractAckIdEventLoop {
    * We must exclude potential datahose feeds when we are reusing a datafeed.
    * Datahose feeds are in the format *_p_*, e.g. "d25098517ec62f1fc65cd111667a8386_p_be940".
    */
-  private static final Pattern FANOUT_FEED_PATTERN = Pattern.compile("^[^\\s_]+_f_[^\\s_]+$");
+  private static final Pattern FANOUT_FEED_PATTERN = Pattern.compile("^[^\\s_]+_f(_[^\\s_]+)?$");
 
   private final RetryWithRecoveryBuilder<?> retryWithRecoveryBuilder;
   private final RetryWithRecovery<Void> readDatafeed;


### PR DESCRIPTION
The existing feed id does not have the suffix after '_f',
which does not matche with the regex pattern.
With this commit, the regex pattern will match the existing
DF ID as well as the new DF ID value (haveing the suffix
after '_f').

### Description
Closes #[ISSUE NUMBER]

Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [x] Referenced an issue in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [x] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
