### PR TITLE
#670: Retry error message does not use the correct api base path in AbstractExtensionAppAuthenticator

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/impl/AbstractExtensionAppAuthenticator.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/impl/AbstractExtensionAppAuthenticator.java
@@ -55,7 +55,7 @@ public abstract class AbstractExtensionAppAuthenticator implements ExtensionAppA
   @Override
   public PodCertificate getPodCertificate() {
     return RetryWithRecovery.executeAndRetry(podCertificateRetryBuilder,
-        "AbstractExtensionAppAuthenticator.getPodCertificate", getBasePath(), this::callGetPodCertificate);
+        "AbstractExtensionAppAuthenticator.getPodCertificate", getPodCertificateBasePath(), this::callGetPodCertificate);
   }
 
   protected ExtensionAppTokens retrieveExtensionAppSession(String appToken) throws AuthUnauthorizedException {
@@ -71,7 +71,7 @@ public abstract class AbstractExtensionAppAuthenticator implements ExtensionAppA
     final String unauthorizedErrorMessage = "Unable to authenticate app with ID : " + appId + ". "
         + "It usually happens when the app has not been configured or is not activated.";
 
-    return authenticationRetry.executeAndRetry("AbstractExtensionAppAuthenticator.retrieveExtAppTokens", getBasePath(),
+    return authenticationRetry.executeAndRetry("AbstractExtensionAppAuthenticator.retrieveExtAppTokens", getAuthenticationBasePath(),
         () -> authenticateAndRetrieveTokens(appToken), unauthorizedErrorMessage);
   }
 
@@ -79,5 +79,7 @@ public abstract class AbstractExtensionAppAuthenticator implements ExtensionAppA
 
   protected abstract ExtensionAppTokens authenticateAndRetrieveTokens(String appToken) throws ApiException;
 
-  protected abstract String getBasePath();
+  protected abstract String getPodCertificateBasePath();
+
+  protected abstract String getAuthenticationBasePath();
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/impl/ExtensionAppAuthenticatorCertImpl.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/impl/ExtensionAppAuthenticatorCertImpl.java
@@ -74,7 +74,12 @@ public class ExtensionAppAuthenticatorCertImpl extends AbstractExtensionAppAuthe
   }
 
   @Override
-  protected String getBasePath(){
+  protected String getPodCertificateBasePath() {
     return certificatePodApi.getApiClient().getBasePath();
+  }
+
+  @Override
+  protected String getAuthenticationBasePath() {
+    return certificateAuthenticationApi.getApiClient().getBasePath();
   }
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/impl/ExtensionAppAuthenticatorRsaImpl.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/impl/ExtensionAppAuthenticatorRsaImpl.java
@@ -77,13 +77,18 @@ public class ExtensionAppAuthenticatorRsaImpl extends AbstractExtensionAppAuthen
   }
 
   @Override
-  protected String getBasePath() {
+  protected PodCertificate callGetPodCertificate() throws ApiException {
+    return this.podApi.v1PodcertGet();
+  }
+
+  @Override
+  protected String getAuthenticationBasePath() {
     return authenticationApi.getApiClient().getBasePath();
   }
 
   @Override
-  protected PodCertificate callGetPodCertificate() throws ApiException {
-    return this.podApi.v1PodcertGet();
+  protected String getPodCertificateBasePath() {
+    return podApi.getApiClient().getBasePath();
   }
 
   /**

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/MessageService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/MessageService.java
@@ -290,6 +290,14 @@ public class MessageService implements OboMessageService, OboService<OboMessageS
   }
 
   /**
+   * {@inheritDoc}
+   */
+  public List<String> getAttachmentTypes() {
+    return executeAndRetry("getAttachmentTypes", podApi.getApiClient().getBasePath(),
+        () -> podApi.v1FilesAllowedTypesGet(authSession.getSessionToken()));
+  }
+
+  /**
    * Update an existing message. The existing message must be a valid social message, that has not been deleted.
    *
    * @param messageToUpdate the message to be updated
@@ -447,17 +455,6 @@ public class MessageService implements OboMessageService, OboService<OboMessageS
   public MessageStatus getMessageStatus(@Nonnull String messageId) {
     return executeAndRetry("getMessageStatus", messageApi.getApiClient().getBasePath(),
         () -> messageApi.v1MessageMidStatusGet(toUrlSafeIdIfNeeded(messageId), authSession.getSessionToken()));
-  }
-
-  /**
-   * Retrieves a list of supported file extensions for attachments.
-   *
-   * @return a list of String containing all allowed file extensions for attachments
-   * @see <a href="https://developers.symphony.com/restapi/reference#attachment-types">Attachment Types</a>
-   */
-  public List<String> getAttachmentTypes() {
-    return executeAndRetry("getAttachmentTypes", podApi.getApiClient().getBasePath(),
-        () -> podApi.v1FilesAllowedTypesGet(authSession.getSessionToken()));
   }
 
   /**

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/OboMessageService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/OboMessageService.java
@@ -9,6 +9,8 @@ import com.symphony.bdk.template.api.TemplateEngine;
 
 import org.apiguardian.api.API;
 
+import java.util.List;
+
 import javax.annotation.Nonnull;
 
 /**
@@ -74,4 +76,12 @@ public interface OboMessageService {
    * @see <a href="https://developers.symphony.com/restapi/reference/suppress-message">Suppress Message</a>
    */
   MessageSuppressionResponse suppressMessage(@Nonnull String messageId);
+
+  /**
+   * Retrieves a list of supported file extensions for attachments.
+   *
+   * @return a list of String containing all allowed file extensions for attachments
+   * @see <a href="https://developers.symphony.com/restapi/reference#attachment-types">Attachment Types</a>
+   */
+  List<String> getAttachmentTypes();
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/stream/OboStreamService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/stream/OboStreamService.java
@@ -3,15 +3,19 @@ package com.symphony.bdk.core.service.stream;
 import com.symphony.bdk.core.service.pagination.model.PaginationAttribute;
 import com.symphony.bdk.core.service.pagination.model.StreamPaginationAttribute;
 import com.symphony.bdk.gen.api.model.ShareContent;
+import com.symphony.bdk.gen.api.model.Stream;
 import com.symphony.bdk.gen.api.model.StreamAttributes;
 import com.symphony.bdk.gen.api.model.StreamFilter;
 import com.symphony.bdk.gen.api.model.V2Message;
+import com.symphony.bdk.gen.api.model.V2RoomSearchCriteria;
 import com.symphony.bdk.gen.api.model.V2StreamAttributes;
+import com.symphony.bdk.gen.api.model.V3RoomAttributes;
+import com.symphony.bdk.gen.api.model.V3RoomDetail;
+import com.symphony.bdk.gen.api.model.V3RoomSearchResults;
 
 import org.apiguardian.api.API;
 
 import java.util.List;
-import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -23,6 +27,44 @@ import javax.annotation.Nullable;
 public interface OboStreamService {
 
   /**
+   * {@link StreamService#create(List)}
+   *
+   * @param uids User ids of the participant
+   * @return The created IM
+   * @see <a href="https://developers.symphony.com/restapi/reference/create-im-or-mim">Create IM or MIM</a>
+   */
+   Stream create(@Nonnull Long... uids);
+
+  /**
+   * Create a new single or multi party instant message conversation between the caller and specified users.
+   * <p>
+   * The caller is implicitly included in the members of the created chat.
+   * <p>
+   * Duplicate users will be included in the membership of the chat but
+   * the duplication will be silently ignored.
+   * <p>
+   * If there is an existing IM conversation with the same set of participants then
+   * the id of that existing stream will be returned.
+   * <p>
+   * If the given list of user ids contains only one id, an IM will be created, otherwise, a MIM will be created.
+   *
+   * @param uids List of user ids of the participants.
+   * @return The created IM or MIM
+   * @see <a href="https://developers.symphony.com/restapi/reference/create-im-or-mim">Create IM or MIM</a>
+   */
+  Stream create(@Nonnull List<Long> uids);
+
+  /**
+   * Create a new chatroom.
+   * If no  attributes are specified, the room is created as a private chatroom.
+   *
+   * @param roomAttributes Attributes of the created room
+   * @return The created chatroom
+   * @see <a href="https://developers.symphony.com/restapi/reference/create-room-v3">Create Room V3</a>
+   */
+  V3RoomDetail create(@Nonnull V3RoomAttributes roomAttributes);
+
+  /**
    * {@link StreamService#getStream(String)}
    *
    * @param streamId    The stream id.
@@ -30,6 +72,15 @@ public interface OboStreamService {
    * @see <a href="https://developers.symphony.com/restapi/reference/stream-info-v2">Stream Info V2</a>
    */
   V2StreamAttributes getStream(@Nonnull String streamId);
+
+  /**
+   * Get information about a particular room.
+   *
+   * @param roomId The room id.
+   * @return The information about the room with the given room id.
+   * @see <a href="https://developers.symphony.com/restapi/reference#room-info-v3">Room Info V3</a>
+   */
+  V3RoomDetail getRoomInfo(@Nonnull String roomId);
 
   /**
    * {@link StreamService#listStreams(StreamFilter)}
@@ -54,22 +105,74 @@ public interface OboStreamService {
    * {@link StreamService#listAllStreams(StreamFilter)}
    *
    * @param filter The stream searching criteria.
-   * @return a {@link Stream} of matching streams according to the searching criteria.
+   * @return a {@link java.util.stream.Stream} of matching streams according to the searching criteria.
    * @see <a href="https://developers.symphony.com/restapi/reference/list-user-streams">List Streams</a>
    */
   @API(status = API.Status.EXPERIMENTAL)
-  Stream<StreamAttributes> listAllStreams(@Nullable StreamFilter filter);
+  java.util.stream.Stream<StreamAttributes> listAllStreams(@Nullable StreamFilter filter);
 
   /**
    * {@link StreamService#listAllStreams(StreamFilter, StreamPaginationAttribute)}
    *
    * @param filter      The stream searching criteria.
    * @param pagination  The chunkSize and totalSize for pagination.
-   * @return a {@link Stream} of matching streams according to the searching criteria.
+   * @return a {@link java.util.stream.Stream} of matching streams according to the searching criteria.
    * @see <a href="https://developers.symphony.com/restapi/reference/list-user-streams">List Streams</a>
    */
   @API(status = API.Status.EXPERIMENTAL)
-  Stream<StreamAttributes> listAllStreams(@Nullable StreamFilter filter, @Nonnull StreamPaginationAttribute pagination);
+  java.util.stream.Stream<StreamAttributes> listAllStreams(@Nullable StreamFilter filter,
+      @Nonnull StreamPaginationAttribute pagination);
+
+  /**
+   * Search rooms according to the specified criteria.
+   *
+   * @param query The room searching criteria
+   * @return The rooms returned according to the given criteria.
+   * @see <a href="https://developers.symphony.com/restapi/reference/search-rooms-v3">Search Rooms V3</a>
+   */
+  V3RoomSearchResults searchRooms(@Nonnull V2RoomSearchCriteria query);
+
+  /**
+   * Search rooms according to the specified criteria.
+   *
+   * @param query      The room searching criteria.
+   * @param pagination The skip and limit for pagination.
+   * @return The rooms returned according to the given criteria.
+   * @see <a href="https://developers.symphony.com/restapi/reference/search-rooms-v3">Search Rooms V3</a>
+   */
+  V3RoomSearchResults searchRooms(@Nonnull V2RoomSearchCriteria query, @Nonnull PaginationAttribute pagination);
+
+  /**
+   * Search rooms and return in a {@link java.util.stream.Stream} according to the specified criteria.
+   *
+   * @param query The room searching criteria.
+   * @return A {@link java.util.stream.Stream} of rooms returned according to the given criteria.
+   * @see <a href="https://developers.symphony.com/restapi/reference/search-rooms-v3">Search Rooms V3</a>
+   */
+  @API(status = API.Status.EXPERIMENTAL)
+  java.util.stream.Stream<V3RoomDetail> searchAllRooms(@Nonnull V2RoomSearchCriteria query);
+
+  /**
+   * Search rooms and return in a {@link java.util.stream.Stream} according to the specified criteria.
+   *
+   * @param query      The room searching criteria.
+   * @param pagination The chunkSize and totalSize for stream pagination.
+   * @return A {@link java.util.stream.Stream} of rooms returned according to the given criteria.
+   * @see <a href="https://developers.symphony.com/restapi/reference/search-rooms-v3">Search Rooms V3</a>
+   */
+  @API(status = API.Status.EXPERIMENTAL)
+  java.util.stream.Stream<V3RoomDetail> searchAllRooms(@Nonnull V2RoomSearchCriteria query,
+      @Nonnull StreamPaginationAttribute pagination);
+
+  /**
+   * Update the attributes of an existing chatroom.
+   *
+   * @param roomId         The id of the room to be updated
+   * @param roomAttributes The attributes to be updated to the room
+   * @return The information of the room after being updated.
+   * @see <a href="https://developers.symphony.com/restapi/reference#update-room-v3">Update Room V3</a>
+   */
+  V3RoomDetail updateRoom(@Nonnull String roomId, @Nonnull V3RoomAttributes roomAttributes);
 
   /**
    * {@link StreamService#addMemberToRoom(Long, String)}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/stream/StreamService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/stream/StreamService.java
@@ -199,46 +199,22 @@ public class StreamService implements OboStreamService, OboService<OboStreamServ
   }
 
   /**
-   * Create a new single or multi party instant message conversation between the caller and specified users.
-   * <p>
-   * The caller is implicitly included in the members of the created chat.
-   * <p>
-   * Duplicate users will be included in the membership of the chat but
-   * the duplication will be silently ignored.
-   * <p>
-   * If there is an existing IM conversation with the same set of participants then
-   * the id of that existing stream will be returned.
-   * <p>
-   * If the given list of user ids contains only one id, an IM will be created, otherwise, a MIM will be created.
-   *
-   * @param uids List of user ids of the participants.
-   * @return The created IM or MIM
-   * @see <a href="https://developers.symphony.com/restapi/reference/create-im-or-mim">Create IM or MIM</a>
-   */
-
-  public Stream create(@Nonnull List<Long> uids) {
-    return executeAndRetry("createStreamByUserIds", streamsApi.getApiClient().getBasePath(),
-        () -> streamsApi.v1ImCreatePost(authSession.getSessionToken(), uids));
-  }
-
-  /**
-   * {@link StreamService#create(List)}
-   *
-   * @param uids User ids of the participant
-   * @return The created IM
-   * @see <a href="https://developers.symphony.com/restapi/reference/create-im-or-mim">Create IM or MIM</a>
+   * {@inheritDoc}
    */
   public Stream create(@Nonnull Long... uids) {
     return this.create(Arrays.asList(uids));
   }
 
   /**
-   * Create a new chatroom.
-   * If no  attributes are specified, the room is created as a private chatroom.
-   *
-   * @param roomAttributes Attributes of the created room
-   * @return The created chatroom
-   * @see <a href="https://developers.symphony.com/restapi/reference/create-room-v3">Create Room V3</a>
+   * {@inheritDoc}
+   */
+  public Stream create(@Nonnull List<Long> uids) {
+    return executeAndRetry("createStreamByUserIds", streamsApi.getApiClient().getBasePath(),
+        () -> streamsApi.v1ImCreatePost(authSession.getSessionToken(), uids));
+  }
+
+  /**
+   * {@inheritDoc}
    */
   public V3RoomDetail create(@Nonnull V3RoomAttributes roomAttributes) {
     return executeAndRetry("createStream", streamsApi.getApiClient().getBasePath(),
@@ -246,11 +222,27 @@ public class StreamService implements OboStreamService, OboService<OboStreamServ
   }
 
   /**
-   * Search rooms according to the specified criteria.
-   *
-   * @param query The room searching criteria
-   * @return The rooms returned according to the given criteria.
-   * @see <a href="https://developers.symphony.com/restapi/reference/search-rooms-v3">Search Rooms V3</a>
+   * {@inheritDoc}
+   */
+  public V3RoomDetail updateRoom(@Nonnull String roomId, @Nonnull V3RoomAttributes roomAttributes) {
+    if(roomAttributes.getPinnedMessageId() != null) {
+      String pinnedMessageId = toUrlSafeIdIfNeeded(roomAttributes.getPinnedMessageId());
+      roomAttributes.setPinnedMessageId(pinnedMessageId);
+    }
+    return executeAndRetry("updateRoom", streamsApi.getApiClient().getBasePath(),
+        () -> streamsApi.v3RoomIdUpdatePost(toUrlSafeIdIfNeeded(roomId), authSession.getSessionToken(), roomAttributes));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public V3RoomDetail getRoomInfo(@Nonnull String roomId) {
+    return executeAndRetry("getRoomInfo", streamsApi.getApiClient().getBasePath(),
+        () -> streamsApi.v3RoomIdInfoGet(toUrlSafeIdIfNeeded(roomId), authSession.getSessionToken()));
+  }
+
+  /**
+   * {@inheritDoc}
    */
   public V3RoomSearchResults searchRooms(@Nonnull V2RoomSearchCriteria query) {
     return executeAndRetry("searchRooms", streamsApi.getApiClient().getBasePath(),
@@ -258,12 +250,7 @@ public class StreamService implements OboStreamService, OboService<OboStreamServ
   }
 
   /**
-   * Search rooms according to the specified criteria.
-   *
-   * @param query      The room searching criteria.
-   * @param pagination The skip and limit for pagination.
-   * @return The rooms returned according to the given criteria.
-   * @see <a href="https://developers.symphony.com/restapi/reference/search-rooms-v3">Search Rooms V3</a>
+   * {@inheritDoc}
    */
   public V3RoomSearchResults searchRooms(@Nonnull V2RoomSearchCriteria query, @Nonnull PaginationAttribute pagination) {
     return executeAndRetry("searchRooms", streamsApi.getApiClient().getBasePath(),
@@ -272,11 +259,7 @@ public class StreamService implements OboStreamService, OboService<OboStreamServ
   }
 
   /**
-   * Search rooms and return in a {@link java.util.stream.Stream} according to the specified criteria.
-   *
-   * @param query The room searching criteria.
-   * @return A {@link java.util.stream.Stream} of rooms returned according to the given criteria.
-   * @see <a href="https://developers.symphony.com/restapi/reference/search-rooms-v3">Search Rooms V3</a>
+   * {@inheritDoc}
    */
   @API(status = API.Status.EXPERIMENTAL)
   public java.util.stream.Stream<V3RoomDetail> searchAllRooms(@Nonnull V2RoomSearchCriteria query) {
@@ -287,12 +270,7 @@ public class StreamService implements OboStreamService, OboService<OboStreamServ
   }
 
   /**
-   * Search rooms and return in a {@link java.util.stream.Stream} according to the specified criteria.
-   *
-   * @param query      The room searching criteria.
-   * @param pagination The chunkSize and totalSize for stream pagination.
-   * @return A {@link java.util.stream.Stream} of rooms returned according to the given criteria.
-   * @see <a href="https://developers.symphony.com/restapi/reference/search-rooms-v3">Search Rooms V3</a>
+   * {@inheritDoc}
    */
   @API(status = API.Status.EXPERIMENTAL)
   public java.util.stream.Stream<V3RoomDetail> searchAllRooms(@Nonnull V2RoomSearchCriteria query,
@@ -300,18 +278,6 @@ public class StreamService implements OboStreamService, OboService<OboStreamServ
     OffsetBasedPaginatedApi<V3RoomDetail> api =
         (offset, limit) -> searchRooms(query, new PaginationAttribute(offset, limit)).getRooms();
     return new OffsetBasedPaginatedService<>(api, pagination.getChunkSize(), pagination.getTotalSize()).stream();
-  }
-
-  /**
-   * Get information about a particular room.
-   *
-   * @param roomId The room id.
-   * @return The information about the room with the given room id.
-   * @see <a href="https://developers.symphony.com/restapi/reference#room-info-v3">Room Info V3</a>
-   */
-  public V3RoomDetail getRoomInfo(@Nonnull String roomId) {
-    return executeAndRetry("getRoomInfo", streamsApi.getApiClient().getBasePath(),
-        () -> streamsApi.v3RoomIdInfoGet(toUrlSafeIdIfNeeded(roomId), authSession.getSessionToken()));
   }
 
   /**
@@ -325,23 +291,6 @@ public class StreamService implements OboStreamService, OboService<OboStreamServ
   public RoomDetail setRoomActive(@Nonnull String roomId, @Nonnull Boolean active) {
     return executeAndRetry("setRoomActive", streamsApi.getApiClient().getBasePath(),
         () -> streamsApi.v1RoomIdSetActivePost(toUrlSafeIdIfNeeded(roomId), active, authSession.getSessionToken()));
-  }
-
-  /**
-   * Update the attributes of an existing chatroom.
-   *
-   * @param roomId         The id of the room to be updated
-   * @param roomAttributes The attributes to be updated to the room
-   * @return The information of the room after being updated.
-   * @see <a href="https://developers.symphony.com/restapi/reference#update-room-v3">Update Room V3</a>
-   */
-  public V3RoomDetail updateRoom(@Nonnull String roomId, @Nonnull V3RoomAttributes roomAttributes) {
-    if(roomAttributes.getPinnedMessageId() != null) {
-      String pinnedMessageId = toUrlSafeIdIfNeeded(roomAttributes.getPinnedMessageId());
-      roomAttributes.setPinnedMessageId(pinnedMessageId);
-    }
-    return executeAndRetry("updateRoom", streamsApi.getApiClient().getBasePath(),
-        () -> streamsApi.v3RoomIdUpdatePost(toUrlSafeIdIfNeeded(roomId), authSession.getSessionToken(), roomAttributes));
   }
 
   /**

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/impl/AbstractExtensionAppAuthenticatorTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/impl/AbstractExtensionAppAuthenticatorTest.java
@@ -46,7 +46,12 @@ class AbstractExtensionAppAuthenticatorTest {
     }
 
     @Override
-    protected String getBasePath() {
+    protected String getPodCertificateBasePath() {
+      return "localhost.symphony.com";
+    }
+
+    @Override
+    protected String getAuthenticationBasePath() {
       return "localhost.symphony.com";
     }
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/MessageServiceTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/MessageServiceTest.java
@@ -155,7 +155,7 @@ class MessageServiceTest {
     final V4Stream v4Stream = new V4Stream().streamId(STREAM_ID);
     Instant now = Instant.now();
     assertNotNull(service.listMessages(v4Stream, now));
-    verify(service).listMessages(eq(STREAM_ID), eq(now));
+    verify(service).listMessages(STREAM_ID, now);
   }
 
   @Test
@@ -167,7 +167,7 @@ class MessageServiceTest {
     Instant now = Instant.now();
     PaginationAttribute pagination = new PaginationAttribute(2, 2);
     assertNotNull(service.listMessages(v4Stream, now, pagination));
-    verify(service).listMessages(eq(STREAM_ID), eq(now), eq(pagination));
+    verify(service).listMessages(STREAM_ID, now, pagination);
   }
 
   @Test
@@ -198,15 +198,17 @@ class MessageServiceTest {
 
   @Test
   void testSearchMessagesQueryValidation() {
+    final MessageSearchQuery query = new MessageSearchQuery().streamType("FOO");
     assertThrows(
         IllegalArgumentException.class,
-        () -> messageService.searchMessages(new MessageSearchQuery().streamType("FOO")),
+        () -> messageService.searchMessages(query),
         "checks if streamType value is a valid one"
     );
 
+    final MessageSearchQuery query2 = new MessageSearchQuery().text("foo");
     assertThrows(
         IllegalArgumentException.class,
-        () -> messageService.searchMessages(new MessageSearchQuery().text("foo")),
+        () -> messageService.searchMessages(query2),
         "text require streamId arg to be provided"
     );
   }
@@ -230,7 +232,7 @@ class MessageServiceTest {
     final V4Stream v4Stream = new V4Stream().streamId(STREAM_ID);
 
     assertNotNull(service.send(v4Stream, MESSAGE));
-    verify(service).send(eq(STREAM_ID), eq(MESSAGE));
+    verify(service).send(STREAM_ID, MESSAGE);
   }
 
   @Test
@@ -416,6 +418,14 @@ class MessageServiceTest {
         JsonHelper.readFromClasspath("/message/get_attachment_types.json"));
 
     assertEquals(Arrays.asList(".csv", ".gif"), messageService.getAttachmentTypes());
+  }
+
+  @Test
+  void testGetAttachmentTypesInOboMode() throws IOException {
+    mockApiClient.onGet(V1_ALLOWED_TYPES,
+        JsonHelper.readFromClasspath("/message/get_attachment_types.json"));
+
+    assertEquals(Arrays.asList(".csv", ".gif"), messageService.obo(this.authSession).getAttachmentTypes());
   }
 
   @Test

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/stream/StreamServiceTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/stream/StreamServiceTest.java
@@ -120,8 +120,8 @@ public class StreamServiceTest {
         new RetryWithRecoveryBuilder<>());
     V2StreamAttributes stream = this.service.obo(this.authSession).getStream("p9B316LKDto7iOECc8Xuz3qeWsc0bdA");
 
-    assertEquals(stream.getId(), "p9B316LKDto7iOECc8Xuz3qeWsc0bdA");
-    assertEquals(stream.getOrigin(), "INTERNAL");
+    assertEquals("p9B316LKDto7iOECc8Xuz3qeWsc0bdA", stream.getId());
+    assertEquals("INTERNAL", stream.getOrigin());
   }
 
   @Test
@@ -130,14 +130,24 @@ public class StreamServiceTest {
 
     Stream stream = this.service.create(Arrays.asList(7215545078541L, 7215512356741L));
 
-    assertEquals(stream.getId(), "xhGxbTcvTDK6EIMMrwdOrX___quztr2HdA");
+    assertEquals("xhGxbTcvTDK6EIMMrwdOrX___quztr2HdA", stream.getId());
   }
 
   @Test
   void createIMorMIMTestFailed() {
     this.mockApiClient.onPost(400, V1_IM_CREATE, "{}");
 
-    assertThrows(ApiRuntimeException.class, () -> this.service.create(Arrays.asList(7215545078541L, 7215512356741L)));
+    List<Long> userIds = Arrays.asList(7215545078541L, 7215512356741L);
+    assertThrows(ApiRuntimeException.class, () -> this.service.create(userIds));
+  }
+
+  @Test
+  void createIMorMIMInOboModeTest() {
+    this.mockApiClient.onPost(V1_IM_CREATE, "{\"id\": \"xhGxbTcvTDK6EIMMrwdOrX___quztr2HdA\"}");
+
+    Stream stream = this.service.obo(this.authSession).create(Arrays.asList(7215545078541L, 7215512356741L));
+
+    assertEquals("xhGxbTcvTDK6EIMMrwdOrX___quztr2HdA", stream.getId());
   }
 
   @Test
@@ -146,7 +156,7 @@ public class StreamServiceTest {
 
     Stream stream = this.service.create(7215545078541L);
 
-    assertEquals(stream.getId(), "xhGxbTcvTDK6EIMMrwdOrX___quztr2HdA");
+    assertEquals("xhGxbTcvTDK6EIMMrwdOrX___quztr2HdA", stream.getId());
   }
 
   @Test
@@ -157,22 +167,44 @@ public class StreamServiceTest {
   }
 
   @Test
+  void createIMInOboModeTest() {
+    this.mockApiClient.onPost(V1_IM_CREATE, "{\"id\": \"xhGxbTcvTDK6EIMMrwdOrX___quztr2HdA\"}");
+
+    Stream stream = this.service.obo(this.authSession).create(7215545078541L);
+
+    assertEquals("xhGxbTcvTDK6EIMMrwdOrX___quztr2HdA", stream.getId());
+  }
+
+  @Test
   void createRoomChatTest() throws IOException {
     this.mockApiClient.onPost(V3_ROOM_CREATE, JsonHelper.readFromClasspath(
         "/stream/v3_room_detail.json"));
 
     V3RoomDetail roomDetail = this.service.create(new V3RoomAttributes());
 
-    assertEquals(roomDetail.getRoomAttributes().getName(), "API room");
-    assertEquals(roomDetail.getRoomAttributes().getDescription(), "Created via the API");
-    assertEquals(roomDetail.getRoomSystemInfo().getId(), "bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA");
+    assertEquals("API room", roomDetail.getRoomAttributes().getName() );
+    assertEquals("Created via the API", roomDetail.getRoomAttributes().getDescription());
+    assertEquals("bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA", roomDetail.getRoomSystemInfo().getId());
   }
 
   @Test
   void createRoomChatTestFailed() {
     this.mockApiClient.onPost(400, V3_ROOM_CREATE, "{}");
 
-    assertThrows(ApiRuntimeException.class, () -> this.service.create(new V3RoomAttributes()));
+    V3RoomAttributes v3RoomAttributes = new V3RoomAttributes();
+    assertThrows(ApiRuntimeException.class, () -> this.service.create(v3RoomAttributes));
+  }
+
+  @Test
+  void createRoomChatInOboModeTest() throws IOException {
+    this.mockApiClient.onPost(V3_ROOM_CREATE, JsonHelper.readFromClasspath(
+        "/stream/v3_room_detail.json"));
+
+    V3RoomDetail roomDetail = this.service.obo(this.authSession).create(new V3RoomAttributes());
+
+    assertEquals("API room", roomDetail.getRoomAttributes().getName());
+    assertEquals("Created via the API", roomDetail.getRoomAttributes().getDescription());
+    assertEquals("bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA", roomDetail.getRoomSystemInfo().getId());
   }
 
   @Test
@@ -182,14 +214,15 @@ public class StreamServiceTest {
     V3RoomSearchResults searchResults = this.service.searchRooms(new V2RoomSearchCriteria());
 
     assertEquals(searchResults.getCount(), 2);
-    assertEquals(searchResults.getRooms().get(0).getRoomAttributes().getName(), "Automobile Industry Room");
+    assertEquals("Automobile Industry Room", searchResults.getRooms().get(0).getRoomAttributes().getName());
   }
 
   @Test
   void searchRoomsTestFailed() {
     this.mockApiClient.onPost(400, V3_ROOM_SEARCH, "{}");
 
-    assertThrows(ApiRuntimeException.class, () -> this.service.searchRooms(new V2RoomSearchCriteria()));
+    V2RoomSearchCriteria v2RoomSearchCriteria = new V2RoomSearchCriteria();
+    assertThrows(ApiRuntimeException.class, () -> this.service.searchRooms(v2RoomSearchCriteria));
   }
 
   @Test
@@ -199,8 +232,29 @@ public class StreamServiceTest {
     V3RoomSearchResults searchResults =
         this.service.searchRooms(new V2RoomSearchCriteria(), new PaginationAttribute(0, 100));
 
-    assertEquals(searchResults.getCount(), 2);
-    assertEquals(searchResults.getRooms().get(0).getRoomAttributes().getName(), "Automobile Industry Room");
+    assertEquals(2, searchResults.getCount());
+    assertEquals("Automobile Industry Room", searchResults.getRooms().get(0).getRoomAttributes().getName());
+  }
+
+  @Test
+  void searchRoomsInOboModeTest() throws IOException {
+    this.mockApiClient.onPost(V3_ROOM_SEARCH, JsonHelper.readFromClasspath("/stream/room_search.json"));
+
+    V3RoomSearchResults searchResults = this.service.obo(this.authSession).searchRooms(new V2RoomSearchCriteria());
+
+    assertEquals(2, searchResults.getCount());
+    assertEquals("Automobile Industry Room", searchResults.getRooms().get(0).getRoomAttributes().getName());
+  }
+
+  @Test
+  void searchRoomsSkipLimitInOboModeTest() throws IOException {
+    this.mockApiClient.onPost(V3_ROOM_SEARCH, JsonHelper.readFromClasspath("/stream/room_search.json"));
+
+    V3RoomSearchResults searchResults =
+        this.service.obo(this.authSession).searchRooms(new V2RoomSearchCriteria(), new PaginationAttribute(0, 100));
+
+    assertEquals(2, searchResults.getCount());
+    assertEquals("Automobile Industry Room", searchResults.getRooms().get(0).getRoomAttributes().getName());
   }
 
   @Test
@@ -210,8 +264,8 @@ public class StreamServiceTest {
     List<V3RoomDetail> searchResults =
         this.service.searchAllRooms(new V2RoomSearchCriteria()).collect(Collectors.toList());
 
-    assertEquals(searchResults.size(), 2);
-    assertEquals(searchResults.get(0).getRoomAttributes().getName(), "Automobile Industry Room");
+    assertEquals(2, searchResults.size());
+    assertEquals("Automobile Industry Room", searchResults.get(0).getRoomAttributes().getName());
   }
 
   @Test
@@ -222,8 +276,32 @@ public class StreamServiceTest {
         this.service.searchAllRooms(new V2RoomSearchCriteria(), new StreamPaginationAttribute(100, 100))
             .collect(Collectors.toList());
 
-    assertEquals(searchResults.size(), 2);
-    assertEquals(searchResults.get(0).getRoomAttributes().getName(), "Automobile Industry Room");
+    assertEquals(2, searchResults.size());
+    assertEquals("Automobile Industry Room", searchResults.get(0).getRoomAttributes().getName());
+  }
+
+  @Test
+  void searchAllRoomsInOboModeTest() throws IOException {
+    this.mockApiClient.onPost(V3_ROOM_SEARCH, JsonHelper.readFromClasspath("/stream/room_search.json"));
+
+    List<V3RoomDetail> searchResults =
+        this.service.obo(this.authSession).searchAllRooms(new V2RoomSearchCriteria()).collect(Collectors.toList());
+
+    assertEquals(2, searchResults.size());
+    assertEquals("Automobile Industry Room", searchResults.get(0).getRoomAttributes().getName());
+  }
+
+  @Test
+  void searchAllRoomsStreamPaginationInOboModeTest() throws IOException {
+    this.mockApiClient.onPost(V3_ROOM_SEARCH, JsonHelper.readFromClasspath("/stream/room_search.json"));
+
+    List<V3RoomDetail> searchResults =
+        this.service.obo(this.authSession)
+            .searchAllRooms(new V2RoomSearchCriteria(), new StreamPaginationAttribute(100, 100))
+            .collect(Collectors.toList());
+
+    assertEquals(2, searchResults.size());
+    assertEquals("Automobile Industry Room", searchResults.get(0).getRoomAttributes().getName());
   }
 
   @Test
@@ -233,9 +311,9 @@ public class StreamServiceTest {
 
     V3RoomDetail roomDetail = this.service.getRoomInfo("bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA");
 
-    assertEquals(roomDetail.getRoomAttributes().getName(), "API room");
-    assertEquals(roomDetail.getRoomAttributes().getDescription(), "Created via the API");
-    assertEquals(roomDetail.getRoomSystemInfo().getId(), "bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA");
+    assertEquals("API room", roomDetail.getRoomAttributes().getName());
+    assertEquals("Created via the API", roomDetail.getRoomAttributes().getDescription());
+    assertEquals("bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA", roomDetail.getRoomSystemInfo().getId());
   }
 
   @Test
@@ -245,7 +323,7 @@ public class StreamServiceTest {
 
     V3RoomDetail roomDetail = this.service.getRoomInfo(fromUrlSafeId("bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA"));
 
-    assertEquals(roomDetail.getRoomAttributes().getName(), "API room");
+    assertEquals("API room", roomDetail.getRoomAttributes().getName());
   }
 
   @Test
@@ -256,13 +334,25 @@ public class StreamServiceTest {
   }
 
   @Test
+  void getRoomInfoInOboModeTest() throws IOException {
+    this.mockApiClient.onGet(V3_ROOM_INFO.replace("{id}", "bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA"),
+        JsonHelper.readFromClasspath("/stream/v3_room_detail.json"));
+
+    V3RoomDetail roomDetail = this.service.obo(this.authSession).getRoomInfo("bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA");
+
+    assertEquals("API room", roomDetail.getRoomAttributes().getName());
+    assertEquals("Created via the API", roomDetail.getRoomAttributes().getDescription());
+    assertEquals("bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA", roomDetail.getRoomSystemInfo().getId());
+  }
+
+  @Test
   void setRoomActiveTest() throws IOException {
     this.mockApiClient.onPost(V1_ROOM_SET_ACTIVE.replace("{id}", "HNmksPVAR6-f14WqKXmqHX___qu8LMLgdA"),
         JsonHelper.readFromClasspath("/stream/room_detail.json"));
 
     RoomDetail roomDetail = this.service.setRoomActive("HNmksPVAR6-f14WqKXmqHX___qu8LMLgdA", true);
 
-    assertEquals(roomDetail.getRoomSystemInfo().getActive(), true);
+    assertTrue(roomDetail.getRoomSystemInfo().getActive());
   }
 
   @Test
@@ -280,9 +370,9 @@ public class StreamServiceTest {
 
     V3RoomDetail roomDetail = this.service.updateRoom("bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA", new V3RoomAttributes());
 
-    assertEquals(roomDetail.getRoomAttributes().getName(), "API room");
-    assertEquals(roomDetail.getRoomAttributes().getDescription(), "Created via the API");
-    assertEquals(roomDetail.getRoomSystemInfo().getId(), "bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA");
+    assertEquals("API room", roomDetail.getRoomAttributes().getName());
+    assertEquals("Created via the API", roomDetail.getRoomAttributes().getDescription());
+    assertEquals("bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA", roomDetail.getRoomSystemInfo().getId());
   }
 
   @Test
@@ -290,14 +380,15 @@ public class StreamServiceTest {
     this.mockApiClient.onPost(V3_ROOM_UPDATE.replace("{id}", "bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA"),
         JsonHelper.readFromClasspath("/stream/v3_room_detail.json"));
 
-    V3RoomAttributes attributes =  new V3RoomAttributes();
+    V3RoomAttributes attributes = new V3RoomAttributes();
     attributes.setPinnedMessageId(fromUrlSafeId("wxv6PbPtTSvnjOwVLCss93___oMVTf_AbQ"));
     this.service.updateRoom(fromUrlSafeId("bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA"), attributes);
 
     final ArgumentCaptor<V3RoomAttributes> attributesArgumentCaptor = ArgumentCaptor.forClass(V3RoomAttributes.class);
     final ArgumentCaptor<String> idArgumentCaptor = ArgumentCaptor.forClass(String.class);
 
-    verify(streamsApi).v3RoomIdUpdatePost(idArgumentCaptor.capture(), any(String.class), attributesArgumentCaptor.capture());
+    verify(streamsApi).v3RoomIdUpdatePost(idArgumentCaptor.capture(), any(String.class),
+        attributesArgumentCaptor.capture());
 
     assertEquals("bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA", idArgumentCaptor.getValue());
     assertEquals("wxv6PbPtTSvnjOwVLCss93___oMVTf_AbQ", attributesArgumentCaptor.getValue().getPinnedMessageId());
@@ -307,8 +398,41 @@ public class StreamServiceTest {
   void updateRoomTestFailed() {
     this.mockApiClient.onPost(400, V3_ROOM_UPDATE.replace("{id}", "bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA"), "{}");
 
+    V3RoomAttributes v3RoomAttributes = new V3RoomAttributes();
     assertThrows(ApiRuntimeException.class,
-        () -> this.service.updateRoom("bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA", new V3RoomAttributes()));
+        () -> this.service.updateRoom("bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA", v3RoomAttributes));
+  }
+
+  @Test
+  void updateRoomInOboModeTest() throws IOException {
+    this.mockApiClient.onPost(V3_ROOM_UPDATE.replace("{id}", "bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA"),
+        JsonHelper.readFromClasspath("/stream/v3_room_detail.json"));
+
+    V3RoomDetail roomDetail =
+        this.service.obo(this.authSession).updateRoom("bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA", new V3RoomAttributes());
+
+    assertEquals("API room", roomDetail.getRoomAttributes().getName());
+    assertEquals("Created via the API", roomDetail.getRoomAttributes().getDescription());
+    assertEquals("bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA", roomDetail.getRoomSystemInfo().getId());
+  }
+
+  @Test
+  void updateRoomInOboModeTest_base64() throws IOException, ApiException {
+    this.mockApiClient.onPost(V3_ROOM_UPDATE.replace("{id}", "bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA"),
+        JsonHelper.readFromClasspath("/stream/v3_room_detail.json"));
+
+    V3RoomAttributes attributes = new V3RoomAttributes();
+    attributes.setPinnedMessageId(fromUrlSafeId("wxv6PbPtTSvnjOwVLCss93___oMVTf_AbQ"));
+    this.service.obo(this.authSession).updateRoom(fromUrlSafeId("bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA"), attributes);
+
+    final ArgumentCaptor<V3RoomAttributes> attributesArgumentCaptor = ArgumentCaptor.forClass(V3RoomAttributes.class);
+    final ArgumentCaptor<String> idArgumentCaptor = ArgumentCaptor.forClass(String.class);
+
+    verify(streamsApi).v3RoomIdUpdatePost(idArgumentCaptor.capture(), any(String.class),
+        attributesArgumentCaptor.capture());
+
+    assertEquals("bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA", idArgumentCaptor.getValue());
+    assertEquals("wxv6PbPtTSvnjOwVLCss93___oMVTf_AbQ", attributesArgumentCaptor.getValue().getPinnedMessageId());
   }
 
   @Test
@@ -319,15 +443,16 @@ public class StreamServiceTest {
         this.service.listStreams(new StreamFilter().addStreamTypesItem(new StreamType().type(
             StreamType.TypeEnum.IM)));
 
-    assertEquals(streams.size(), 1);
-    assertEquals(streams.get(0).getId(), "iWyZBIOdQQzQj0tKOLRivX___qu6YeyZdA");
+    assertEquals(1, streams.size());
+    assertEquals("iWyZBIOdQQzQj0tKOLRivX___qu6YeyZdA", streams.get(0).getId());
   }
 
   @Test
   void listStreamsTestFailed() {
     this.mockApiClient.onPost(400, V1_STREAM_LIST, "{}");
 
-    assertThrows(ApiRuntimeException.class, () -> this.service.listStreams(new StreamFilter()));
+    StreamFilter streamFilter = new StreamFilter();
+    assertThrows(ApiRuntimeException.class, () -> this.service.listStreams(streamFilter));
   }
 
   @Test
@@ -337,8 +462,8 @@ public class StreamServiceTest {
     List<StreamAttributes> streams =
         this.service.listStreams(new StreamFilter().addStreamTypesItem(new StreamType().type(
             StreamType.TypeEnum.IM)), new PaginationAttribute(0, 100));
-    assertEquals(streams.size(), 1);
-    assertEquals(streams.get(0).getId(), "iWyZBIOdQQzQj0tKOLRivX___qu6YeyZdA");
+    assertEquals(1, streams.size());
+    assertEquals("iWyZBIOdQQzQj0tKOLRivX___qu6YeyZdA", streams.get(0).getId());
   }
 
   @Test
@@ -348,8 +473,8 @@ public class StreamServiceTest {
     List<StreamAttributes> streams =
         this.service.listAllStreams(new StreamFilter().addStreamTypesItem(new StreamType().type(
             StreamType.TypeEnum.IM))).collect(Collectors.toList());
-    assertEquals(streams.size(), 1);
-    assertEquals(streams.get(0).getId(), "iWyZBIOdQQzQj0tKOLRivX___qu6YeyZdA");
+    assertEquals(1, streams.size());
+    assertEquals("iWyZBIOdQQzQj0tKOLRivX___qu6YeyZdA", streams.get(0).getId());
   }
 
   @Test
@@ -359,8 +484,8 @@ public class StreamServiceTest {
     List<StreamAttributes> streams =
         this.service.listAllStreams(new StreamFilter().addStreamTypesItem(new StreamType().type(
             StreamType.TypeEnum.IM)), new StreamPaginationAttribute(100, 100)).collect(Collectors.toList());
-    assertEquals(streams.size(), 1);
-    assertEquals(streams.get(0).getId(), "iWyZBIOdQQzQj0tKOLRivX___qu6YeyZdA");
+    assertEquals(1, streams.size());
+    assertEquals("iWyZBIOdQQzQj0tKOLRivX___qu6YeyZdA", streams.get(0).getId());
   }
 
   @Test
@@ -370,8 +495,8 @@ public class StreamServiceTest {
 
     V2StreamAttributes stream = this.service.getStream("p9B316LKDto7iOECc8Xuz3qeWsc0bdA");
 
-    assertEquals(stream.getId(), "p9B316LKDto7iOECc8Xuz3qeWsc0bdA");
-    assertEquals(stream.getOrigin(), "INTERNAL");
+    assertEquals("p9B316LKDto7iOECc8Xuz3qeWsc0bdA", stream.getId());
+    assertEquals("INTERNAL", stream.getOrigin());
   }
 
   @Test
@@ -387,7 +512,7 @@ public class StreamServiceTest {
 
     Stream stream = this.service.createInstantMessageAdmin(Arrays.asList(7215545078541L, 7215545078461L));
 
-    assertEquals(stream.getId(), "xhGxbTcvTDK6EIMMrwdOrX___quztr2HdA");
+    assertEquals("xhGxbTcvTDK6EIMMrwdOrX___quztr2HdA", stream.getId());
   }
 
   @Test
@@ -407,8 +532,8 @@ public class StreamServiceTest {
     attributes.setPinnedMessageId("vd7qwNb6hLoUV0BfXXPC43___oPIvkwJbQ");
     V1IMDetail imDetail = this.service.updateInstantMessage("usnBKBkH_BVrGOiVpaupEH___okFfE7QdA", attributes);
 
-    assertEquals(imDetail.getImSystemInfo().getId(), "usnBKBkH_BVrGOiVpaupEH___okFfE7QdA");
-    assertEquals(imDetail.getV1IMAttributes().getPinnedMessageId(), "vd7qwNb6hLoUV0BfXXPC43___oPIvkwJbQ");
+    assertEquals("usnBKBkH_BVrGOiVpaupEH___okFfE7QdA", imDetail.getImSystemInfo().getId());
+    assertEquals("vd7qwNb6hLoUV0BfXXPC43___oPIvkwJbQ", imDetail.getV1IMAttributes().getPinnedMessageId());
   }
 
   @Test
@@ -416,14 +541,15 @@ public class StreamServiceTest {
     this.mockApiClient.onPost(V1_IM_UPDATE.replace("{id}", "bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA"),
         JsonHelper.readFromClasspath("/stream/im_info.json"));
 
-    V1IMAttributes attributes =  new V1IMAttributes();
+    V1IMAttributes attributes = new V1IMAttributes();
     attributes.setPinnedMessageId(fromUrlSafeId("wxv6PbPtTSvnjOwVLCss93___oMVTf_AbQ"));
     this.service.updateInstantMessage(fromUrlSafeId("bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA"), attributes);
 
     final ArgumentCaptor<V1IMAttributes> attributesArgumentCaptor = ArgumentCaptor.forClass(V1IMAttributes.class);
     final ArgumentCaptor<String> idArgumentCaptor = ArgumentCaptor.forClass(String.class);
 
-    verify(streamsApi).v1ImIdUpdatePost(idArgumentCaptor.capture(), any(String.class), attributesArgumentCaptor.capture());
+    verify(streamsApi).v1ImIdUpdatePost(idArgumentCaptor.capture(), any(String.class),
+        attributesArgumentCaptor.capture());
 
     assertEquals("bjHSiY4iz3ar4iIh6-VzCX___peoM7cPdA", idArgumentCaptor.getValue());
     assertEquals("wxv6PbPtTSvnjOwVLCss93___oMVTf_AbQ", attributesArgumentCaptor.getValue().getPinnedMessageId());
@@ -433,7 +559,8 @@ public class StreamServiceTest {
   void updateIMTestFail() {
     this.mockApiClient.onPost(400, V1_IM_UPDATE.replace("{id}", "p9B316LKDto7iOECc8Xuz3qeWsc0bdA"), "{}");
 
-    assertThrows(ApiRuntimeException.class, () -> this.service.updateInstantMessage("p9B316LKDto7iOECc8Xuz3qeWsc0bdA", new V1IMAttributes()));
+    assertThrows(ApiRuntimeException.class,
+        () -> this.service.updateInstantMessage("p9B316LKDto7iOECc8Xuz3qeWsc0bdA", new V1IMAttributes()));
   }
 
   @Test
@@ -443,15 +570,16 @@ public class StreamServiceTest {
 
     V1IMDetail imDetail = this.service.getInstantMessageInfo("usnBKBkH_BVrGOiVpaupEH___okFfE7QdA");
 
-    assertEquals(imDetail.getImSystemInfo().getId(), "usnBKBkH_BVrGOiVpaupEH___okFfE7QdA");
-    assertEquals(imDetail.getV1IMAttributes().getPinnedMessageId(), "vd7qwNb6hLoUV0BfXXPC43___oPIvkwJbQ");
+    assertEquals("usnBKBkH_BVrGOiVpaupEH___okFfE7QdA", imDetail.getImSystemInfo().getId());
+    assertEquals("vd7qwNb6hLoUV0BfXXPC43___oPIvkwJbQ", imDetail.getV1IMAttributes().getPinnedMessageId());
   }
 
   @Test
   void getIMInfoTestFail() {
     this.mockApiClient.onGet(400, V1_IM_INFO.replace("{id}", "p9B316LKDto7iOECc8Xuz3qeWsc0bdA"), "{}");
 
-    assertThrows(ApiRuntimeException.class, () -> this.service.getInstantMessageInfo("p9B316LKDto7iOECc8Xuz3qeWsc0bdA"));
+    assertThrows(ApiRuntimeException.class,
+        () -> this.service.getInstantMessageInfo("p9B316LKDto7iOECc8Xuz3qeWsc0bdA"));
   }
 
   @Test
@@ -461,7 +589,7 @@ public class StreamServiceTest {
 
     RoomDetail roomDetail = this.service.setRoomActiveAdmin("HNmksPVAR6-f14WqKXmqHX___qu8LMLgdA", true);
 
-    assertEquals(roomDetail.getRoomSystemInfo().getActive(), true);
+    assertTrue(roomDetail.getRoomSystemInfo().getActive());
   }
 
   @Test
@@ -479,10 +607,10 @@ public class StreamServiceTest {
 
     V2AdminStreamList streamList = this.service.listStreamsAdmin(new V2AdminStreamFilter());
 
-    assertEquals(streamList.getCount(), 4);
-    assertEquals(streamList.getStreams().get(0).getId(), "Q2KYGm7JkljrgymMajYTJ3___qcLPr1UdA");
-    assertEquals(streamList.getStreams().get(1).getId(), "_KnoYrMkhEn3H2_8vE0kl3___qb5SANQdA");
-    assertEquals(streamList.getStreams().get(2).getId(), "fBoaBSRUyb5Rq3YgeSqZvX___qbf5IAhdA");
+    assertEquals(4, streamList.getCount());
+    assertEquals("Q2KYGm7JkljrgymMajYTJ3___qcLPr1UdA", streamList.getStreams().get(0).getId());
+    assertEquals("_KnoYrMkhEn3H2_8vE0kl3___qb5SANQdA", streamList.getStreams().get(1).getId());
+    assertEquals("fBoaBSRUyb5Rq3YgeSqZvX___qbf5IAhdA", streamList.getStreams().get(2).getId());
   }
 
   @Test
@@ -499,10 +627,10 @@ public class StreamServiceTest {
     V2AdminStreamList streamList =
         this.service.listStreamsAdmin(new V2AdminStreamFilter(), new PaginationAttribute(0, 100));
 
-    assertEquals(streamList.getCount(), 4);
-    assertEquals(streamList.getStreams().get(0).getId(), "Q2KYGm7JkljrgymMajYTJ3___qcLPr1UdA");
-    assertEquals(streamList.getStreams().get(1).getId(), "_KnoYrMkhEn3H2_8vE0kl3___qb5SANQdA");
-    assertEquals(streamList.getStreams().get(2).getId(), "fBoaBSRUyb5Rq3YgeSqZvX___qbf5IAhdA");
+    assertEquals(4, streamList.getCount());
+    assertEquals("Q2KYGm7JkljrgymMajYTJ3___qcLPr1UdA", streamList.getStreams().get(0).getId());
+    assertEquals("_KnoYrMkhEn3H2_8vE0kl3___qb5SANQdA", streamList.getStreams().get(1).getId());
+    assertEquals("fBoaBSRUyb5Rq3YgeSqZvX___qbf5IAhdA", streamList.getStreams().get(2).getId());
   }
 
   @Test
@@ -512,10 +640,10 @@ public class StreamServiceTest {
     List<V2AdminStreamInfo> streamList =
         this.service.listAllStreamsAdmin(new V2AdminStreamFilter()).collect(Collectors.toList());
 
-    assertEquals(streamList.size(), 4);
-    assertEquals(streamList.get(0).getId(), "Q2KYGm7JkljrgymMajYTJ3___qcLPr1UdA");
-    assertEquals(streamList.get(1).getId(), "_KnoYrMkhEn3H2_8vE0kl3___qb5SANQdA");
-    assertEquals(streamList.get(2).getId(), "fBoaBSRUyb5Rq3YgeSqZvX___qbf5IAhdA");
+    assertEquals(4, streamList.size());
+    assertEquals("Q2KYGm7JkljrgymMajYTJ3___qcLPr1UdA", streamList.get(0).getId());
+    assertEquals("_KnoYrMkhEn3H2_8vE0kl3___qb5SANQdA", streamList.get(1).getId());
+    assertEquals("fBoaBSRUyb5Rq3YgeSqZvX___qbf5IAhdA", streamList.get(2).getId());
   }
 
   @Test
@@ -526,10 +654,10 @@ public class StreamServiceTest {
         this.service.listAllStreamsAdmin(new V2AdminStreamFilter(), new StreamPaginationAttribute(100, 100))
             .collect(Collectors.toList());
 
-    assertEquals(streamList.size(), 4);
-    assertEquals(streamList.get(0).getId(), "Q2KYGm7JkljrgymMajYTJ3___qcLPr1UdA");
-    assertEquals(streamList.get(1).getId(), "_KnoYrMkhEn3H2_8vE0kl3___qb5SANQdA");
-    assertEquals(streamList.get(2).getId(), "fBoaBSRUyb5Rq3YgeSqZvX___qbf5IAhdA");
+    assertEquals(4, streamList.size());
+    assertEquals("Q2KYGm7JkljrgymMajYTJ3___qcLPr1UdA", streamList.get(0).getId());
+    assertEquals("_KnoYrMkhEn3H2_8vE0kl3___qb5SANQdA", streamList.get(1).getId());
+    assertEquals("fBoaBSRUyb5Rq3YgeSqZvX___qbf5IAhdA", streamList.get(2).getId());
   }
 
   @Test
@@ -539,9 +667,9 @@ public class StreamServiceTest {
 
     V2MembershipList membersList = this.service.listStreamMembers("1234");
 
-    assertEquals(membersList.getCount(), 2);
-    assertEquals(membersList.getMembers().get(0).getJoinDate(), 1485366753320L);
-    assertEquals(membersList.getMembers().get(1).getJoinDate(), 1485366753279L);
+    assertEquals(2, membersList.getCount());
+    assertEquals(1485366753320L, membersList.getMembers().get(0).getJoinDate());
+    assertEquals(1485366753279L, membersList.getMembers().get(1).getJoinDate());
   }
 
   @Test
@@ -558,9 +686,9 @@ public class StreamServiceTest {
 
     V2MembershipList membersList = this.service.listStreamMembers("1234", new PaginationAttribute(0, 100));
 
-    assertEquals(membersList.getCount(), 2);
-    assertEquals(membersList.getMembers().get(0).getJoinDate(), 1485366753320L);
-    assertEquals(membersList.getMembers().get(1).getJoinDate(), 1485366753279L);
+    assertEquals(2, membersList.getCount());
+    assertEquals(1485366753320L, membersList.getMembers().get(0).getJoinDate());
+    assertEquals(1485366753279L, membersList.getMembers().get(1).getJoinDate());
   }
 
   @Test
@@ -570,9 +698,9 @@ public class StreamServiceTest {
 
     List<V2MemberInfo> membersList = this.service.listAllStreamMembers("1234").collect(Collectors.toList());
 
-    assertEquals(membersList.size(), 2);
-    assertEquals(membersList.get(0).getJoinDate(), 1485366753320L);
-    assertEquals(membersList.get(1).getJoinDate(), 1485366753279L);
+    assertEquals(2, membersList.size());
+    assertEquals(1485366753320L, membersList.get(0).getJoinDate());
+    assertEquals(1485366753279L, membersList.get(1).getJoinDate());
   }
 
   @Test
@@ -583,9 +711,9 @@ public class StreamServiceTest {
     List<V2MemberInfo> membersList =
         this.service.listAllStreamMembers("1234", new StreamPaginationAttribute(100, 100)).collect(Collectors.toList());
 
-    assertEquals(membersList.size(), 2);
-    assertEquals(membersList.get(0).getJoinDate(), 1485366753320L);
-    assertEquals(membersList.get(1).getJoinDate(), 1485366753279L);
+    assertEquals(2, membersList.size());
+    assertEquals(1485366753320L, membersList.get(0).getJoinDate());
+    assertEquals(1485366753279L, membersList.get(1).getJoinDate());
   }
 
   @Test
@@ -605,10 +733,10 @@ public class StreamServiceTest {
 
     List<MemberInfo> memberInfos = this.service.listRoomMembers("1234");
 
-    assertEquals(memberInfos.size(), 2);
-    assertEquals(memberInfos.get(0).getId(), 7078106103900L);
+    assertEquals(2, memberInfos.size());
+    assertEquals(7078106103900L, memberInfos.get(0).getId());
     assertFalse(memberInfos.get(0).getOwner());
-    assertEquals(memberInfos.get(1).getId(), 7078106103809L);
+    assertEquals(7078106103809L, memberInfos.get(1).getId());
     assertTrue(memberInfos.get(1).getOwner());
   }
 


### PR DESCRIPTION
### Description
Closes #670 
Added two methods, one to get the basepath used to get pod certificate and another one to get the basepath used to authenticate and retrieve tokens.