### PR TITLE
#670: Retry error message does not use the correct api base path in AbstractExtensionAppAuthenticator

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/impl/AbstractExtensionAppAuthenticator.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/impl/AbstractExtensionAppAuthenticator.java
@@ -55,7 +55,7 @@ public abstract class AbstractExtensionAppAuthenticator implements ExtensionAppA
   @Override
   public PodCertificate getPodCertificate() {
     return RetryWithRecovery.executeAndRetry(podCertificateRetryBuilder,
-        "AbstractExtensionAppAuthenticator.getPodCertificate", getBasePath(), this::callGetPodCertificate);
+        "AbstractExtensionAppAuthenticator.getPodCertificate", getPodCertificateBasePath(), this::callGetPodCertificate);
   }
 
   protected ExtensionAppTokens retrieveExtensionAppSession(String appToken) throws AuthUnauthorizedException {
@@ -71,7 +71,7 @@ public abstract class AbstractExtensionAppAuthenticator implements ExtensionAppA
     final String unauthorizedErrorMessage = "Unable to authenticate app with ID : " + appId + ". "
         + "It usually happens when the app has not been configured or is not activated.";
 
-    return authenticationRetry.executeAndRetry("AbstractExtensionAppAuthenticator.retrieveExtAppTokens", getBasePath(),
+    return authenticationRetry.executeAndRetry("AbstractExtensionAppAuthenticator.retrieveExtAppTokens", getAuthenticationBasePath(),
         () -> authenticateAndRetrieveTokens(appToken), unauthorizedErrorMessage);
   }
 
@@ -79,5 +79,7 @@ public abstract class AbstractExtensionAppAuthenticator implements ExtensionAppA
 
   protected abstract ExtensionAppTokens authenticateAndRetrieveTokens(String appToken) throws ApiException;
 
-  protected abstract String getBasePath();
+  protected abstract String getPodCertificateBasePath();
+
+  protected abstract String getAuthenticationBasePath();
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/impl/ExtensionAppAuthenticatorCertImpl.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/impl/ExtensionAppAuthenticatorCertImpl.java
@@ -21,7 +21,7 @@ import org.apiguardian.api.API;
 import javax.annotation.Nonnull;
 
 /**
- * Extension app authenticator RSA implementation.
+ * Extension app authenticator Cert implementation.
  *
  * @see <a href="https://docs.developers.symphony.com/building-extension-applications-on-symphony/app-authentication/circle-of-trust-authentication">Application Authentication</a>
  */
@@ -74,7 +74,12 @@ public class ExtensionAppAuthenticatorCertImpl extends AbstractExtensionAppAuthe
   }
 
   @Override
-  protected String getBasePath(){
+  protected String getPodCertificateBasePath() {
     return certificatePodApi.getApiClient().getBasePath();
+  }
+
+  @Override
+  protected String getAuthenticationBasePath() {
+    return certificateAuthenticationApi.getApiClient().getBasePath();
   }
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/impl/ExtensionAppAuthenticatorRsaImpl.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/impl/ExtensionAppAuthenticatorRsaImpl.java
@@ -77,13 +77,18 @@ public class ExtensionAppAuthenticatorRsaImpl extends AbstractExtensionAppAuthen
   }
 
   @Override
-  protected String getBasePath() {
+  protected PodCertificate callGetPodCertificate() throws ApiException {
+    return this.podApi.v1PodcertGet();
+  }
+
+  @Override
+  protected String getAuthenticationBasePath() {
     return authenticationApi.getApiClient().getBasePath();
   }
 
   @Override
-  protected PodCertificate callGetPodCertificate() throws ApiException {
-    return this.podApi.v1PodcertGet();
+  protected String getPodCertificateBasePath() {
+    return podApi.getApiClient().getBasePath();
   }
 
   /**

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/impl/AbstractExtensionAppAuthenticatorTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/auth/impl/AbstractExtensionAppAuthenticatorTest.java
@@ -46,7 +46,12 @@ class AbstractExtensionAppAuthenticatorTest {
     }
 
     @Override
-    protected String getBasePath() {
+    protected String getPodCertificateBasePath() {
+      return "localhost.symphony.com";
+    }
+
+    @Override
+    protected String getAuthenticationBasePath() {
       return "localhost.symphony.com";
     }
 


### PR DESCRIPTION
### Description
Closes #670 
ExtensionAppAuthenticatorRsaImpl class has 2 different api clients: login and pod api clients with different base paths. The overridden method getBasePath() always returns login pod api base path. 
When the api call to get pod certificate fails and gets retried, the getBasePath() is called to provide more info in the error message. In this case, the login pod api client base path is injected while the pod api client is the one being used. 

In this PR we separate both apis base path with 2 different methods to avoid confusion: 

Added two methods, one to get the basepath used to get pod certificate and another one to get the basepath used to authenticate and retrieve tokens.