### PR TITLE
Upgrade SpringBoot version to latest 2.7.3 

### DIFF
--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     // import Spring Boot's BOM
-    api platform('org.springframework.boot:spring-boot-dependencies:2.6.8')
+    api platform('org.springframework.boot:spring-boot-dependencies:2.7.3')
     // import Jackson's BOM
     api platform('com.fasterxml.jackson:jackson-bom:2.13.2.20220328')
     // define all our dependencies versions

--- a/symphony-bdk-examples/bdk-app-spring-boot-example/build.gradle
+++ b/symphony-bdk-examples/bdk-app-spring-boot-example/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'bdk.java-common-conventions'
-    id 'org.springframework.boot' version "2.6.8"
+    id 'org.springframework.boot' version "2.7.3"
 }
 
 description = 'Symphony Java BDK Examples for the SpringBoot integration'

--- a/symphony-bdk-examples/bdk-spring-boot-example/build.gradle
+++ b/symphony-bdk-examples/bdk-spring-boot-example/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'bdk.java-common-conventions'
-    id 'org.springframework.boot' version "2.6.8"
+    id 'org.springframework.boot' version "2.7.3"
 }
 
 description = 'Symphony Java BDK Examples for the SpringBoot integration'


### PR DESCRIPTION
### Description
Upgrade SpringBoot version to latest 2.7.3 in order to fix some security vulnerabilities related to jetty.http2
