### PR TITLE
Fix jekyll code formatting in migration docs

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -426,6 +426,7 @@ In Java SDK 1.0, the bot had to implement 3 listeners classes:
 - one for IM (1 to 1 conversation)
 - one for MIM (room)
 - one for Symphony elements
+
 ```java
 @Slf4j
 @Service


### PR DESCRIPTION
### Description
Fix jekyll code formatting in migration docs

![Demo](https://user-images.githubusercontent.com/7151832/188401883-6669d970-39e8-4f93-aca2-1899c080f366.png)
