### PR TITLE
Enable empty slash command pattern

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/SlashCommand.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/command/SlashCommand.java
@@ -86,11 +86,6 @@ public class SlashCommand extends CommandActivity<CommandContext> {
    */
   protected SlashCommand(@Nonnull String slashCommandPattern, boolean requiresBotMention,
       @Nonnull Consumer<CommandContext> callback, String description) {
-
-    if (StringUtils.isEmpty(slashCommandPattern)) {
-      throw new IllegalArgumentException("The slash command name cannot be empty.");
-    }
-
     this.slashCommandName = slashCommandPattern;
     this.commandPattern = new SlashCommandPattern(this.slashCommandName);
     this.requiresBotMention = requiresBotMention;

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/parsing/SlashCommandPattern.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/parsing/SlashCommandPattern.java
@@ -7,8 +7,8 @@ import com.symphony.bdk.gen.api.model.V4Message;
 
 import org.apiguardian.api.API;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -114,7 +114,7 @@ public class SlashCommandPattern {
 
   private List<CommandToken> buildTokens(String pattern) {
     if (isBlank(pattern)) {
-      return Collections.emptyList();
+      return new ArrayList<>();
     }
 
     final String[] tokens = pattern.trim().split("\\s+");

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/command/SlashCommandTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/command/SlashCommandTest.java
@@ -2,7 +2,6 @@ package com.symphony.bdk.core.activity.command;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.symphony.bdk.core.activity.model.ActivityInfo;
@@ -34,9 +33,19 @@ class SlashCommandTest {
   private static final String BOT_DISPLAY_NAME = "BotMention";
 
   @Test
-  void testIllegalSlashCommandCreation() {
-    assertThrows(IllegalArgumentException.class, () -> SlashCommand.slash("", c -> {
-    }));
+  void testSlashCommandWithEmptyPatternAndBotMentionSuccess() {
+
+    final AtomicBoolean handlerCalled = new AtomicBoolean(false);
+    final Consumer<CommandContext> handler = c -> handlerCalled.set(true);
+    final RealTimeEventsProvider provider = new RealTimeEventsProvider();
+
+    final String commandPattern = "";
+    final SlashCommand cmd = SlashCommand.slash(commandPattern, handler);
+    cmd.setBotUserId(BOT_USER_ID);
+    cmd.bindToRealTimeEventsSource(provider::setListener);
+
+    provider.trigger(l -> l.onMessageSent(new V4Initiator(), createMessageSentEvent(true, commandPattern)));
+    assertTrue(handlerCalled.get());
   }
 
   @Test


### PR DESCRIPTION
Empty pattern was not allowed in the slash command, however the same is allowed in Python BDK.

This commit is to align with Python BDK, an empty pattern is enabled, a slash command has only the Bot mention is now possible.

### Description
Closes #[ISSUE NUMBER]

Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced an issue in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
