### PR TITLE
Add inline template support in TemplateEngine

### DIFF
--- a/symphony-bdk-template/symphony-bdk-template-api/src/main/java/com/symphony/bdk/template/api/TemplateEngine.java
+++ b/symphony-bdk-template/symphony-bdk-template-api/src/main/java/com/symphony/bdk/template/api/TemplateEngine.java
@@ -31,6 +31,15 @@ public interface TemplateEngine {
    */
   Template newTemplateFromClasspath(String templatePath);
 
+  /**
+   * Create a {@link Template} instance from a string
+   *
+   * @param template inline template string
+   * @return a new {@link Template} instantiated from the provided inline string
+   * @throws TemplateException when template cannot be loaded.
+   */
+  Template newTemplateFromString(String template);
+
   static TemplateEngine getDefaultImplementation() {
     final ServiceLoader<TemplateEngine> engineServiceLoader = ServiceLoader.load(TemplateEngine.class);
 

--- a/symphony-bdk-template/symphony-bdk-template-freemarker/src/main/java/com/symphony/bdk/template/freemarker/FreeMarkerEngine.java
+++ b/symphony-bdk-template/symphony-bdk-template-freemarker/src/main/java/com/symphony/bdk/template/freemarker/FreeMarkerEngine.java
@@ -17,7 +17,7 @@ import java.io.IOException;
  * FreeMarker specific implementation of {@link TemplateEngine}. Instantiates {@link FreeMarkerTemplate} objects.
  *
  * <p>
- *   This class is thread-safe.
+ * This class is thread-safe.
  * </p>
  */
 @API(status = API.Status.INTERNAL)
@@ -50,6 +50,19 @@ public class FreeMarkerEngine implements TemplateEngine {
       return new FreeMarkerTemplate(configuration.getTemplate(templatePath));
     } catch (IOException e) {
       throw new TemplateException("Unable to load template from classpath", e);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Template newTemplateFromString(String template) {
+    try {
+      final Configuration configuration = createConfiguration();
+      return new FreeMarkerTemplate(new freemarker.template.Template(null, template, configuration));
+    } catch (IOException e) {
+      throw new TemplateException("Unable to load template from string", e);
     }
   }
 

--- a/symphony-bdk-template/symphony-bdk-template-freemarker/src/test/java/com/symphony/bdk/template/freemarker/FreeMarkerTemplateTest.java
+++ b/symphony-bdk-template/symphony-bdk-template-freemarker/src/test/java/com/symphony/bdk/template/freemarker/FreeMarkerTemplateTest.java
@@ -91,6 +91,17 @@ public class FreeMarkerTemplateTest {
   }
 
   @Test
+  public void testFromInlineString() {
+    Long userId = 12345678L;
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("userId", userId);
+
+    Template freeMarkerTemplate = new FreeMarkerEngine().newTemplateFromString("<messageML>Hello <mention uid='${userId}'/></messageML>\n");
+    assertTemplateProducesOutput(freeMarkerTemplate, parameters,
+        "<messageML>Hello <mention uid='" + userId + "'/></messageML>\n");
+  }
+
+  @Test
   public void testWithNotFoundResource() {
     assertThrows(TemplateException.class, () -> new FreeMarkerEngine().newTemplateFromClasspath("./not/found.ftl"));
   }

--- a/symphony-bdk-template/symphony-bdk-template-handlebars/src/main/java/com/symphony/bdk/template/handlebars/HandlebarsEngine.java
+++ b/symphony-bdk-template/symphony-bdk-template-handlebars/src/main/java/com/symphony/bdk/template/handlebars/HandlebarsEngine.java
@@ -17,13 +17,15 @@ import java.io.IOException;
  * {@link Handlebars} implementation of the {@link TemplateEngine} interface.
  *
  * <p>
- *   This class is thread-safe.
+ * This class is thread-safe.
  * </p>
  */
 @API(status = API.Status.INTERNAL)
 public class HandlebarsEngine implements TemplateEngine {
 
-  /** Handlebars for classpath loading. Ok for thread-safety. */
+  /**
+   * Handlebars for classpath loading. Ok for thread-safety.
+   */
   private static final Handlebars HANDLEBARS = createHandlebars(new ClassPathTemplateLoader());
 
   /**
@@ -53,6 +55,20 @@ public class HandlebarsEngine implements TemplateEngine {
       throw new TemplateException("Unable to compile Handlebars template from classpath location: " + templatePath, e);
     }
   }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Template newTemplateFromString(String template) {
+    try {
+      return new HandlebarsTemplate(HANDLEBARS.compileInline(template));
+    } catch (IOException e) {
+      throw new TemplateException("Unable to compile Handlebars template from inline string: " + template, e);
+    }
+  }
+
+
 
   /**
    * Creates a new {@link Handlebars} object with suffix set to "" to make this {@link TemplateEngine} implementation

--- a/symphony-bdk-template/symphony-bdk-template-handlebars/src/test/java/com/symphony/bdk/template/handlebars/HandlebarsEngineTest.java
+++ b/symphony-bdk-template/symphony-bdk-template-handlebars/src/test/java/com/symphony/bdk/template/handlebars/HandlebarsEngineTest.java
@@ -50,6 +50,13 @@ class HandlebarsEngineTest {
   }
 
   @Test
+  void should_load_template_from_inline_string() throws Exception {
+    final Template template = this.engine.newTemplateFromString("<messageML>\n{{message}}\n</messageML>\n");
+    final String content = template.process(Collections.singletonMap("message", "hello"));
+    assertEquals(EXPECTED_TEST_HBS, content);
+  }
+
+  @Test
   void should_load_complex_template_from_file(@TempDir Path tempDir) throws Exception {
 
     // copy /base.hbs and /home.hbs from classpath to tempDir


### PR DESCRIPTION
This commit provides the inline template support in TemplateEgine, so that the template can be initiated not only from a file, but could be also from a template string.

### Description
Closes #[ISSUE NUMBER]

Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced an issue in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
