### PR TITLE
Fix Datahose loop 

### DIFF
--- a/docs/datafeed.md
+++ b/docs/datafeed.md
@@ -141,6 +141,8 @@ bdk.datafeed.stop();
 ```
 
 # Datahose
+> :warning: Please note that Datahose is available as beta and will remain as beta until further notice.
+
 Datahose is very similar to datafeed: it enables a bot to receive [_Real Time
 Events_](https://docs.developers.symphony.com/building-bots-on-symphony/datafeed/real-time-events) with the main
 difference that *all* events of the pod are received. The datahose loop is a core service built on top of the events API
@@ -187,9 +189,9 @@ Datahose Service can be configured by the datafeed field in the configuration fi
 ```yaml
 datahose:
     tag: fancyTag # optional tag that will be used when creating or reusing a datahose feed
-    filters: # mandatory field, events you want to receive
-        - SOCIALMESSAGE
-        - CREATE_ROOM
+    eventTypes: # mandatory field, events you want to receive
+        - INSTANTMESSAGECREATED
+        - ROOMCREATED
     retry: # optional
         maxAttempts: 6 # maximum number of retry attempts
         initialIntervalMillis: 2000 # initial interval between two attempts
@@ -197,14 +199,10 @@ datahose:
         maxIntervalMillis: 10000 # limit of the interval between two attempts
 ```
 
-The minimal configuration for the datahose service is the `filters` field. It should contain at least one value chosen
-among the following:
-* SOCIALMESSAGE
-* CREATE_ROOM
-* UPDATE_ROOM
-
-:warning: If you want to use `SOCIALMESSAGE` filter (i.e. consume message sent events), `ceservice` credentials must be
-configured in your Symphony agent.
+The minimal configuration for the datahose service is the `eventTypes` field. It should contain at least one value
+chosen among [_Real Time Events_](https://docs.developers.symphony.com/building-bots-on-symphony/datafeed/real-time-events)
+list and that `MESSAGESENT`, `MESSAGESUPPRESSED` and `SYMPHONYELEMENTSACTION` values can be set only if the ceservice is
+properly configured and running in your Symphony agent.
 
 The `tag` field is optional and is used when creating and reusing datahose feeds. If you have several instances of the
 same bot and want them to use the same datahose feed (so that events are spread over bot instances),

--- a/symphony-bdk-config/src/main/java/com/symphony/bdk/core/config/model/BdkDatahoseConfig.java
+++ b/symphony-bdk-config/src/main/java/com/symphony/bdk/core/config/model/BdkDatahoseConfig.java
@@ -13,5 +13,5 @@ public class BdkDatahoseConfig {
 
   private BdkRetryConfig retry = new BdkRetryConfig(BdkRetryConfig.INFINITE_MAX_ATTEMPTS);
   private String tag = "";
-  private List<String> filters = null;
+  private List<String> eventTypes = null;
 }

--- a/symphony-bdk-core/build.gradle
+++ b/symphony-bdk-core/build.gradle
@@ -72,7 +72,7 @@ dependencies {
 }
 
 // OpenAPI code generation
-def apiBaseUrl = "https://raw.githubusercontent.com/finos/symphony-api-spec/b52eb2a8cb5242bef5f0d24517f364bfcc39328f"
+def apiBaseUrl = "https://raw.githubusercontent.com/finos/symphony-api-spec/30fcab0fe6eaa26dcc46e7dc5909467332ec8d0d"
 def generatedFolder = "$buildDir/generated/openapi"
 def apisToGenerate = [
         Agent: 'agent/agent-api-public-deprecated.yaml',

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatahoseLoopImpl.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatahoseLoopImpl.java
@@ -39,7 +39,7 @@ public class DatahoseLoopImpl extends AbstractAckIdEventLoop implements Datahose
     }
     this.tag = StringUtils.truncate(untruncatedTag, DATAHOSE_TAG_MAX_LENGTH);
 
-    this.filters = config.getDatahose().getFilters();
+    this.filters = config.getDatahose().getEventTypes();
 
     this.readEvents = new RetryWithRecoveryBuilder<>()
         .basePath(datafeedApi.getApiClient().getBasePath())

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatahoseLoopTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatahoseLoopTest.java
@@ -58,12 +58,12 @@ class DatahoseLoopTest {
   private UserV2 botInfo;
   private RealTimeEventListener listener;
   private String tag;
-  private List<String> filters;
+  private List<String> eventTypes;
 
   @BeforeEach
   void setUp() throws BdkConfigException {
 
-    this.filters = Arrays.asList("TYPE_A", "TYPE_B");
+    this.eventTypes = Arrays.asList("TYPE_A", "TYPE_B");
     this.tag = "mytag";
 
     this.botInfo = Mockito.mock(UserV2.class);
@@ -81,7 +81,7 @@ class DatahoseLoopTest {
     this.bdkConfig.setRetry(ofMinimalInterval(2));
 
     BdkDatahoseConfig datahoseConfig = bdkConfig.getDatahose();
-    datahoseConfig.setEventTypes(this.filters);
+    datahoseConfig.setEventTypes(this.eventTypes);
     datahoseConfig.setTag(this.tag);
     datahoseConfig.setRetry(ofMinimalInterval(2));
 
@@ -360,7 +360,7 @@ class DatahoseLoopTest {
   }
 
   private void assertEventsReadBody(V5EventsReadBody actualBody, String expectedTag, String expectedAckId) {
-    assertEquals(filters, actualBody.getEventTypes());
+    assertEquals(eventTypes, actualBody.getEventTypes());
     assertEquals(expectedTag, actualBody.getTag());
     assertEquals(expectedAckId, actualBody.getAckId());
   }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatahoseLoopTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatahoseLoopTest.java
@@ -81,7 +81,7 @@ class DatahoseLoopTest {
     this.bdkConfig.setRetry(ofMinimalInterval(2));
 
     BdkDatahoseConfig datahoseConfig = bdkConfig.getDatahose();
-    datahoseConfig.setFilters(this.filters);
+    datahoseConfig.setEventTypes(this.filters);
     datahoseConfig.setTag(this.tag);
     datahoseConfig.setRetry(ofMinimalInterval(2));
 


### PR DESCRIPTION
In the new update of Datahose api, the field filters has been renamed to eventTypes. In this commit, we apply this update in BDK Python.
The generated code has been updated as well according to the last changes in symphony-api-specs.