### PR TITLE
Add actuator health endpoint to app starter

### DIFF
--- a/allow-list.xml
+++ b/allow-list.xml
@@ -46,4 +46,11 @@
         <gav>org.springframework:spring-web:5.3.24</gav>
         <cve>CVE-2016-1000027</cve>
     </suppress>
+    <suppress base="true">
+        <notes><![CDATA[
+       FP per issue #5121 - fix for commons
+       ]]></notes>
+      <packageUrl regex="true">^(?!pkg:maven/commons-net/commons-net).*$</packageUrl>
+      <cpe>cpe:/a:apache:commons_net</cpe>
+    </suppress>
 </suppressions>

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "io.codearte.nexus-staging" version "0.22.0"
-    id "org.owasp.dependencycheck" version "7.3.2"
+    id "org.owasp.dependencycheck" version "7.4.0"
 }
 
 ext.projectVersion = '2.12.0-SNAPSHOT'

--- a/docs/health.md
+++ b/docs/health.md
@@ -24,3 +24,20 @@ public class Example {
   }
 }
 ```
+
+The service also provides the datafeed loop connectivity health status.
+
+```java
+@Slf4j
+public class Example {
+  public static void main(String[] args) throws Exception {
+    // Create BDK entry point
+    final SymphonyBdk bdk = new SymphonyBdk(loadFromClasspath("/config.yaml"));
+
+    // Get health check extended status
+    HealthService health = bdk.health();
+    V3HealthStatus v3HealthStatus = health.datafeedHealthCheck();
+    log.info("Health status: " + v3HealthStatus);
+  }
+}
+```

--- a/docs/spring-boot/app-starter.md
+++ b/docs/spring-boot/app-starter.md
@@ -4,6 +4,7 @@ The Symphony BDK for Java provides a _Starter_ module that aims to ease extensio
  
 ## Features
 - Configure extension app through `application.yaml`
+- Application health info through Spring Boot standard actuator endpoint
 - Expose a REST API to perform [Circle of Trust authentication](https://docs.developers.symphony.com/building-extension-applications-on-symphony/app-authentication/circle-of-trust-authentication).
 
 ## Installation
@@ -126,3 +127,23 @@ public class ExtAppSpringApplication {
 By configuring the property `bdk-app.auth.enabled=true`, the Application backend will provide Apis for performing
 the [Circle of Trust](https://docs.developers.symphony.com/building-extension-applications-on-symphony/app-authentication/circle-of-trust-authentication) of Symphony:
 [Circle of Trust API](https://editor.swagger.io/?url=https://raw.githubusercontent.com/SymphonyPlatformSolutions/symphony-api-client-java/master/docs/spring-boot/circle-of-trust.yaml)
+
+
+## Application health status
+The starter exposes the core components health status through the actuator endpoint from Spring Boot, for instance,
+http://localhost:8080/${root_path}/actuator/health/, which gives a global application health status, or
+http://localhost:8080/${root_path}/actuator/health/symphonyBdk, which specifically gives the Symphony components
+health status only.
+
+By default, the components health details are not exposed by Spring Boot. In order to see the details, the following
+configuration must set in the `application.xml`
+
+```
+management:
+  endpoint:
+    web:
+      exposure:
+        include: 'symphonyBdk'
+    health:
+      show-details: "ALWAYS"
+```      

--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -81,7 +81,7 @@ dependencies {
         api 'org.projectreactor:reactor-spring:1.0.1.RELEASE'
 
         api 'org.freemarker:freemarker:2.3.31'
-        api 'com.github.jknack:handlebars:4.3.0'
+        api 'com.github.jknack:handlebars:4.3.1'
         api 'org.reflections:reflections:0.9.12'
 
         api 'org.junit.jupiter:junit-jupiter:5.8.2'
@@ -90,7 +90,7 @@ dependencies {
         api 'org.mock-server:mockserver-netty:5.14.0'
         api 'org.mockito:mockito-core:4.5.1'
         api 'org.mockito:mockito-junit-jupiter:4.5.1'
-        api 'org.assertj:assertj-core:3.22.0'
+        api 'org.assertj:assertj-core:3.23.1'
     }
 }
 

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/SymphonyBdk.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/SymphonyBdk.java
@@ -127,7 +127,6 @@ public class SymphonyBdk {
     this.connectionService = serviceFactory != null ? serviceFactory.getConnectionService() : null;
     this.signalService = serviceFactory != null ? serviceFactory.getSignalService() : null;
     this.applicationService = serviceFactory != null ? serviceFactory.getApplicationService() : null;
-    this.healthService = serviceFactory != null ? serviceFactory.getHealthService() : null;
     this.messageService = serviceFactory != null ? serviceFactory.getMessageService() : null;
     this.disclaimerService = serviceFactory != null ? serviceFactory.getDisclaimerService() : null;
 
@@ -136,6 +135,10 @@ public class SymphonyBdk {
 
     this.datafeedLoop = serviceFactory != null ? serviceFactory.getDatafeedLoop(this.botInfo) : null;
     this.datahoseLoop = serviceFactory != null ? serviceFactory.getDatahoseLoop(this.botInfo) : null;
+    this.healthService = serviceFactory != null ? serviceFactory.getHealthService() : null;
+    if (healthService != null) {
+      this.healthService.setDatafeedLoop(this.datafeedLoop);
+    }
 
     // setup activities
     this.activityRegistry = this.datafeedLoop != null ? new ActivityRegistry(this.botInfo, this.datafeedLoop) : null;

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/DatafeedLoop.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/DatafeedLoop.java
@@ -37,4 +37,11 @@ public interface DatafeedLoop {
      * @param listener a Datafeed event listener to be unsubscribed
      */
     void unsubscribe(RealTimeEventListener listener);
+
+  /**
+   * The timestamp of the last successful pulling
+   *
+   * @return timestamp value in long
+   */
+  long lastPullTimestamp();
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/health/HealthService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/health/HealthService.java
@@ -2,29 +2,48 @@ package com.symphony.bdk.core.service.health;
 
 import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.core.retry.function.SupplierWithApiException;
+import com.symphony.bdk.core.service.datafeed.DatafeedLoop;
 import com.symphony.bdk.gen.api.SignalsApi;
 import com.symphony.bdk.gen.api.SystemApi;
 import com.symphony.bdk.gen.api.model.AgentInfo;
 import com.symphony.bdk.gen.api.model.V3Health;
+import com.symphony.bdk.gen.api.model.V3HealthStatus;
 import com.symphony.bdk.http.api.ApiException;
 import com.symphony.bdk.http.api.ApiRuntimeException;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apiguardian.api.API;
+
+import java.time.Instant;
+import java.util.function.Supplier;
 
 /**
  * Service class for checking health of the Agent server.
  */
+@Slf4j
 @API(status = API.Status.STABLE)
 public class HealthService {
 
   private final SystemApi systemApi;
   private final SignalsApi signalsApi;
   private final AuthSession authSession;
+  private DatafeedLoop datafeedLoop;
 
   public HealthService(SystemApi systemApi, SignalsApi signalsApi, AuthSession authSession) {
     this.systemApi = systemApi;
     this.signalsApi = signalsApi;
     this.authSession = authSession;
+  }
+
+  public HealthService(SystemApi systemApi, SignalsApi signalsApi, AuthSession authSession, DatafeedLoop datafeedLoop) {
+    this.systemApi = systemApi;
+    this.signalsApi = signalsApi;
+    this.authSession = authSession;
+    this.datafeedLoop = datafeedLoop;
+  }
+
+  public void setDatafeedLoop(DatafeedLoop datafeedLoop) {
+    this.datafeedLoop = datafeedLoop;
   }
 
   /**
@@ -51,6 +70,19 @@ public class HealthService {
   }
 
   /**
+   * Return the connectivity status of the DataFeed long pulling connection.
+   *
+   * @return {@link V3HealthStatus} the connectivity status
+   */
+  public V3HealthStatus datafeedHealthCheck() {
+    if (this.datafeedLoop != null) {
+      return lastRunHealthStatus(this.datafeedLoop::lastPullTimestamp);
+    }
+    log.trace("datafeedloop is not enabled");
+    return V3HealthStatus.DOWN;
+  }
+
+  /**
    * Gets information about the Agent.
    * Available on Agent 2.53.0 and above.
    *
@@ -69,4 +101,10 @@ public class HealthService {
     }
   }
 
+  private V3HealthStatus lastRunHealthStatus(Supplier<Long> supplier) {
+    long lastRun = supplier.get();
+    // AWS SQS has long pulling timeout == 20 secs
+    boolean after = Instant.now().isAfter(Instant.ofEpochMilli(lastRun).plusSeconds(22));
+    return after ? V3HealthStatus.DOWN : V3HealthStatus.UP;
+  }
 }

--- a/symphony-bdk-examples/bdk-app-spring-boot-example/src/main/resources/application.yaml
+++ b/symphony-bdk-examples/bdk-app-spring-boot-example/src/main/resources/application.yaml
@@ -1,6 +1,6 @@
 # BDK Core Configuration
 bdk:
-  host: acme.symphony.com
+  host: acm.symphony.com
   bot:
     username: mybot
     privateKey:
@@ -47,3 +47,11 @@ spring:
     user:
       name: admin
       password: password
+
+management:
+  endpoint:
+    web:
+      exposure:
+        include: 'symphonyBdk'
+    health:
+      show-details: "ALWAYS"

--- a/symphony-bdk-http/symphony-bdk-http-jersey2/build.gradle
+++ b/symphony-bdk-http/symphony-bdk-http-jersey2/build.gradle
@@ -7,7 +7,7 @@ description = 'Symphony Java BDK Core Http Jersey2'
 
 dependencies {
     constraints {
-        implementation('com.google.guava:guava:30.0-jre') {
+        implementation('com.google.guava:guava:31.1-jre') {
             because 'version 28.2-android that is pulled contains security issues'
         }
     }

--- a/symphony-bdk-http/symphony-bdk-http-webclient/build.gradle
+++ b/symphony-bdk-http/symphony-bdk-http-webclient/build.gradle
@@ -20,7 +20,7 @@ jacocoTestCoverageVerification {
 
 dependencies {
     constraints {
-        implementation('com.google.guava:guava:30.0-jre') {
+        implementation('com.google.guava:guava:31.1-jre') {
             because 'version 28.2-android that is pulled contains security issues'
         }
     }

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/build.gradle
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     api project(':symphony-bdk-core')
     api 'org.springframework.boot:spring-boot-starter'
     api 'org.springframework.boot:spring-boot-starter-web'
+    api 'org.springframework.boot:spring-boot-starter-actuator'
     implementation project(':symphony-bdk-spring:symphony-bdk-core-spring-boot-starter')
 
     compileOnly 'org.projectlombok:lombok'

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/config/BdkExtAppControllerConfig.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/config/BdkExtAppControllerConfig.java
@@ -4,10 +4,12 @@ import com.symphony.bdk.app.spring.SymphonyBdkAppProperties;
 import com.symphony.bdk.app.spring.auth.CircleOfTrustController;
 import com.symphony.bdk.app.spring.auth.service.CircleOfTrustService;
 import com.symphony.bdk.app.spring.exception.GlobalControllerExceptionHandler;
+import com.symphony.bdk.app.spring.service.SymphonyBdkHealthIndicator;
 import com.symphony.bdk.core.auth.ExtensionAppAuthenticator;
-
+import com.symphony.bdk.core.service.health.HealthService;
 import com.symphony.bdk.spring.SymphonyBdkCoreProperties;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -18,8 +20,16 @@ import org.springframework.context.annotation.Bean;
 public class BdkExtAppControllerConfig {
 
   @Bean
+  @ConditionalOnProperty("bdk.bot.username")
   @ConditionalOnMissingBean
-  public CircleOfTrustService circleOfTrustService(ExtensionAppAuthenticator authenticator, SymphonyBdkCoreProperties properties) {
+  public SymphonyBdkHealthIndicator symphonyBdkHealthIndicator(HealthService healthService) {
+    return new SymphonyBdkHealthIndicator(healthService);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public CircleOfTrustService circleOfTrustService(ExtensionAppAuthenticator authenticator,
+      SymphonyBdkCoreProperties properties) {
     return new CircleOfTrustService(authenticator, properties);
   }
 

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/service/SymphonyBdkHealthIndicator.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/service/SymphonyBdkHealthIndicator.java
@@ -1,0 +1,72 @@
+package com.symphony.bdk.app.spring.service;
+
+import com.symphony.bdk.core.service.health.HealthService;
+import com.symphony.bdk.gen.api.model.V3Health;
+import com.symphony.bdk.gen.api.model.V3HealthComponent;
+import com.symphony.bdk.gen.api.model.V3HealthStatus;
+import com.symphony.bdk.http.api.ApiRuntimeException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apiguardian.api.API;
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+import java.util.Map;
+
+/**
+ * Symphony BDK custom spring boot actuator health indicator.
+ * <p>
+ * This indicator will provide BDK connected component health status as well as
+ * {@link com.symphony.bdk.core.service.datafeed.DatafeedLoop} and {@link com.symphony.bdk.core.service.datafeed.DatahoseLoop}
+ * connectivity status.
+ */
+@Slf4j
+@API(status = API.Status.INTERNAL)
+public class SymphonyBdkHealthIndicator extends AbstractHealthIndicator {
+
+  private final HealthService healthService;
+
+  private static final String POD = "pod";
+  private static final String DF = "datafeed";
+  private static final String KM = "key_manager";
+  private static final String AGT = "agentservice";
+  private static final String CE = "ceservice";
+  private static final String DFL = "datafeedloop";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  public SymphonyBdkHealthIndicator(HealthService healthService) {
+    this.healthService = healthService;
+  }
+
+  @Override
+  protected void doHealthCheck(Health.Builder builder) throws Exception {
+    V3Health health = null;
+    try {
+      health = healthService.healthCheckExtended();
+    } catch (ApiRuntimeException e) {
+      log.debug("Health check failed.", e);
+      health = MAPPER.readValue(e.getResponseBody(), V3Health.class);
+    }
+    Map<String, V3HealthComponent> services = health.getServices();
+    Map<String, V3HealthComponent> users = health.getUsers();
+    V3HealthStatus podStatus = services.get(POD).getStatus();
+    V3HealthStatus dfStatus = services.get(DF).getStatus();
+    V3HealthStatus kmStatus = services.get(KM).getStatus();
+    V3HealthStatus agtStatus = users.get(AGT).getStatus();
+    V3HealthStatus ceStatus = users.get(CE).getStatus();
+    V3HealthStatus datafeedLoop = healthService.datafeedHealthCheck();
+
+    boolean global = podStatus == V3HealthStatus.UP && dfStatus == V3HealthStatus.UP && kmStatus == V3HealthStatus.UP
+        && agtStatus == V3HealthStatus.UP && ceStatus == V3HealthStatus.UP && datafeedLoop == V3HealthStatus.UP;
+
+    builder.status(global ? Status.UP.getCode() : "WARNING")
+        .withDetail(POD, services.get(POD))
+        .withDetail(DF, services.get(DF))
+        .withDetail(KM, services.get(KM))
+        .withDetail(AGT, users.get(AGT))
+        .withDetail(CE, users.get(CE))
+        .withDetail(DFL, datafeedLoop);
+  }
+}

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/config/BdkExtAppControllerConfigTest.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/config/BdkExtAppControllerConfigTest.java
@@ -5,10 +5,19 @@ import static org.mockito.Mockito.mock;
 
 import com.symphony.bdk.app.spring.SymphonyBdkAppProperties;
 import com.symphony.bdk.app.spring.auth.service.CircleOfTrustService;
+import com.symphony.bdk.core.service.health.HealthService;
 
 import org.junit.jupiter.api.Test;
 
 public class BdkExtAppControllerConfigTest {
+
+  @Test
+  void createSymphonyBdkHealthIndicatorTest() {
+    final BdkExtAppControllerConfig config = new BdkExtAppControllerConfig();
+    final HealthService healthService = mock(HealthService.class);
+
+    assertNotNull(config.symphonyBdkHealthIndicator(healthService));
+  }
 
   @Test
   void createCircleOfTrustControllerTest() {

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/service/SymphonyBdkHealthIndicatorTest.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/service/SymphonyBdkHealthIndicatorTest.java
@@ -1,0 +1,99 @@
+package com.symphony.bdk.app.spring.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import com.symphony.bdk.core.service.health.HealthService;
+import com.symphony.bdk.gen.api.model.V3Health;
+import com.symphony.bdk.gen.api.model.V3HealthComponent;
+import com.symphony.bdk.gen.api.model.V3HealthStatus;
+import com.symphony.bdk.http.api.ApiException;
+import com.symphony.bdk.http.api.ApiRuntimeException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.actuate.health.Health;
+
+import java.util.Collections;
+
+@ExtendWith(MockitoExtension.class)
+class SymphonyBdkHealthIndicatorTest {
+  @Mock HealthService healthService;
+  @InjectMocks SymphonyBdkHealthIndicator healthIndicator;
+
+  @Test
+  void doHealthCheck_successful() throws Exception {
+    V3Health health = new V3Health();
+    health.putServicesItem("pod", new V3HealthComponent().status(V3HealthStatus.UP));
+    health.putServicesItem("datafeed", new V3HealthComponent().status(V3HealthStatus.UP));
+    health.putServicesItem("key_manager", new V3HealthComponent().status(V3HealthStatus.UP));
+    health.putUsersItem("agentservice", new V3HealthComponent().status(V3HealthStatus.UP));
+    health.putUsersItem("ceservice", new V3HealthComponent().status(V3HealthStatus.UP));
+    when(healthService.healthCheckExtended()).thenReturn(health);
+    when(healthService.datafeedHealthCheck()).thenReturn(V3HealthStatus.UP);
+    Health.Builder builder = new Health.Builder();
+    healthIndicator.doHealthCheck(builder);
+    Health build = builder.build();
+    assertThat(build.getStatus().getCode()).isEqualTo("UP");
+  }
+
+  @Test
+  void doHealthCheck_warning() throws Exception {
+    V3Health health = new V3Health();
+    health.putServicesItem("pod", new V3HealthComponent().status(V3HealthStatus.UP));
+    health.putServicesItem("datafeed", new V3HealthComponent().status(V3HealthStatus.UP));
+    health.putServicesItem("key_manager", new V3HealthComponent().status(V3HealthStatus.UP));
+    health.putUsersItem("agentservice", new V3HealthComponent().status(V3HealthStatus.UP));
+    health.putUsersItem("ceservice", new V3HealthComponent().status(V3HealthStatus.DOWN));
+    when(healthService.healthCheckExtended()).thenReturn(health);
+    when(healthService.datafeedHealthCheck()).thenReturn(V3HealthStatus.UP);
+    Health.Builder builder = new Health.Builder();
+    healthIndicator.doHealthCheck(builder);
+    Health build = builder.build();
+    assertThat(build.getStatus().getCode()).isEqualTo("WARNING");
+  }
+
+  @Test
+  void doHealthCheck_exception() throws Exception {
+    final String body = "{\n"
+        + "  \"status\": \"UP\",\n"
+        + "  \"version\": \"2.57.0\",\n"
+        + "  \"services\": {\n"
+        + "    \"pod\": {\n"
+        + "      \"status\": \"UP\",\n"
+        + "      \"version\": \"1.57.0\"\n"
+        + "    },\n"
+        + "    \"datafeed\": {\n"
+        + "      \"status\": \"UP\",\n"
+        + "      \"version\": \"2.1.28\"\n"
+        + "    },\n"
+        + "    \"key_manager\": {\n"
+        + "      \"status\": \"UP\",\n"
+        + "      \"version\": \"1.56.0\"\n"
+        + "    }\n"
+        + "  },\n"
+        + "  \"users\": {\n"
+        + "    \"agentservice\": {\n"
+        + "      \"status\": \"UP\"\n"
+        + "    },\n"
+        + "    \"ceservice\": {\n"
+        + "      \"status\": \"DOWN\",\n"
+        + "      \"message\": \"Ceservice authentication credentials missing or misconfigured\"\n"
+        + "    }\n"
+        + "  }\n"
+        + "}";
+
+
+    doThrow(new ApiRuntimeException(new ApiException(503, "message", Collections.EMPTY_MAP, body))).when(healthService)
+        .healthCheckExtended();
+    when(healthService.datafeedHealthCheck()).thenReturn(V3HealthStatus.UP);
+    Health.Builder builder = new Health.Builder();
+    healthIndicator.doHealthCheck(builder);
+    Health build = builder.build();
+    assertThat(build.getStatus().getCode()).isEqualTo("WARNING");
+  }
+}

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkServiceConfig.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/config/BdkServiceConfig.java
@@ -5,6 +5,7 @@ import com.symphony.bdk.core.config.model.BdkConfig;
 import com.symphony.bdk.core.retry.RetryWithRecoveryBuilder;
 import com.symphony.bdk.core.service.application.ApplicationService;
 import com.symphony.bdk.core.service.connection.ConnectionService;
+import com.symphony.bdk.core.service.datafeed.DatafeedLoop;
 import com.symphony.bdk.core.service.disclaimer.DisclaimerService;
 import com.symphony.bdk.core.service.health.HealthService;
 import com.symphony.bdk.core.service.message.MessageService;
@@ -38,6 +39,7 @@ import com.symphony.bdk.template.api.TemplateEngine;
 import org.apiguardian.api.API;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 
 /**
@@ -101,9 +103,11 @@ public class BdkServiceConfig {
   }
 
   @Bean
+  @ConditionalOnProperty(value = "bdk.datafeed.enabled", havingValue = "true", matchIfMissing = true)
   @ConditionalOnMissingBean
-  public HealthService healthService(SystemApi systemApi, SignalsApi signalsApi, AuthSession botSession) {
-    return new HealthService(systemApi, signalsApi, botSession);
+  public HealthService healthService(SystemApi systemApi, SignalsApi signalsApi, AuthSession botSession,
+      DatafeedLoop datafeedLoop) {
+    return new HealthService(systemApi, signalsApi, botSession, datafeedLoop);
   }
 
   @Bean

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/test/java/com/symphony/bdk/spring/SymphonyBdkAutoConfigurationTest.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/test/java/com/symphony/bdk/spring/SymphonyBdkAutoConfigurationTest.java
@@ -12,6 +12,7 @@ import com.symphony.bdk.core.extension.ExtensionService;
 import com.symphony.bdk.core.service.datafeed.impl.DatafeedLoopV1;
 import com.symphony.bdk.core.service.datafeed.impl.DatafeedLoopV2;
 import com.symphony.bdk.core.service.datafeed.impl.DatahoseLoopImpl;
+import com.symphony.bdk.core.service.health.HealthService;
 import com.symphony.bdk.gen.api.SystemApi;
 import com.symphony.bdk.http.api.ApiClient;
 import com.symphony.bdk.spring.annotation.SlashAnnotationProcessor;
@@ -60,6 +61,7 @@ class SymphonyBdkAutoConfigurationTest {
       // verify that main beans have been injected
       assertThat(context).hasSingleBean(SymphonyBdkAutoConfiguration.class);
       assertThat(context).hasSingleBean(DatafeedLoopV2.class);
+      assertThat(context).hasSingleBean(HealthService.class);
       assertThat(context).hasSingleBean(DatafeedAsyncLauncherService.class);
       assertThat(context).hasSingleBean(RealTimeEventsDispatcher.class);
 
@@ -375,6 +377,7 @@ class SymphonyBdkAutoConfigurationTest {
 
       assertThat(context).doesNotHaveBean(DatafeedLoopV1.class);
       assertThat(context).doesNotHaveBean(DatafeedLoopV2.class);
+      assertThat(context).doesNotHaveBean(HealthService.class);
       assertThat(context).doesNotHaveBean(DatafeedAsyncLauncherService.class);
       assertThat(context).doesNotHaveBean(RealTimeEventsDispatcher.class);
       assertThat(context).doesNotHaveBean(ActivityRegistry.class);


### PR DESCRIPTION
The health endpoint uses the HealthService to provide the core components health status, as well as the DatafeedLoop running process status, if the running process counter is not updated in a fixed time range, the process is considered as 'DOWN'.

### Description
Closes #[ISSUE NUMBER]

Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced an issue in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
