### PR TITLE
#680: not set bot username as Datafeed tag

### DIFF
--- a/docs/datafeed.md
+++ b/docs/datafeed.md
@@ -8,9 +8,9 @@
 The datafeed loop is a service used for handling the [_Real Time
 Events_](https://docs.developers.symphony.com/building-bots-on-symphony/datafeed/real-time-events). When a user makes an interaction within the IM,
 MIM or Room chat like sending a message, joining or leaving a room chat..., when a connection request is sent, when a
-wall post is published or when a user replies an Symphony element, an event will be sent to the datafeed. The bot can
+wall post is published or when a user replies to a Symphony element, an event will be sent to the datafeed. The bot can
 create a datafeed, list all created datafeeds or retrieve all the Real Time Events within a datafeed through datafeed
-API. The datafeed loop is a core service built on top of the Datafeed API and provide a dedicated contract to bot
+API. The datafeed loop is a core service built on top of the Datafeed API and provides a dedicated contract to bot
 developers to work with datafeed.
 
 For more advanced interactions between users and bots, you can also read [Activity API](./activity-api.md).
@@ -62,11 +62,10 @@ datafeed:
         maxIntervalMillis: 10000 # limit of the interval between two attempts
 ```
 
-The minimal configuration for the datafeed service is the version of the datafeed which will be chosen to be use in the
-BDK. For the moment, not all the customers have the datafeed version 2 available on their systems, that's why bot
-developers are able to choose the datafeed version that they wish to use on their bot. If the bot developers want to use
-the datafeed version 2 in their bot, the version configuration have to be specified as `v2`. Otherwise, the datafeed
-version 1 will be used by default.
+The minimal configuration for the datafeed service is the version to be used in the
+BDK. For the moment, not all customers have datafeed 2 available on their systems, that's why bot
+developers are able to choose the version that they wish to use on their bot. If the bot developers want to use
+datafeed 2, the version configuration have to be specified as `v2`. Otherwise, datafeed 1 will be used by default.
 
 Bot developers can also configure a dedicated retry mechanism which will be used only by the datafeed service.
 Basically, the datafeed service retry configuration has the field same as the global retry configuration with the fields
@@ -180,7 +179,7 @@ public class Example {
 ```
 
 An example of the usage of the Datahose service can be
-found [here](../symphony-bdk-examples/bdk-core-examples/src/main/java/com/symphony/bdk/examples/DatahoseExampleMain.java).
+found [here](https://github.com/finos/symphony-bdk-java/blob/main/symphony-bdk-examples/bdk-core-examples/src/main/java/com/symphony/bdk/examples/DatahoseExampleMain.java).
 
 ## Datahose Configuration
 
@@ -298,7 +297,7 @@ event twice. This can be achieved by maintaining a short time lived cache of the
 ## Running multiple instances of a bot (DF v2 and datahose only)
 
 An example using datafeed v2 is provided in
-[bdk-multi-instances-example](../symphony-bdk-examples/bdk-multi-instances-example) module.
+[bdk-multi-instances-example](https://github.com/finos/symphony-bdk-java/blob/main/symphony-bdk-examples/bdk-multi-instances-example/README.md) module.
 
 With datafeed v2, it is possible to run multiple instances of a bot. Each instance will receive events in turn. The
 examples also makes use of Hazelcast to keep a distributed cache of already processed events and avoid replying to a

--- a/docs/datafeed.md
+++ b/docs/datafeed.md
@@ -54,7 +54,7 @@ Datafeed Service can be configured by the datafeed field in the configuration fi
 
 ```yaml
 datafeed:
-    version: 'v1' # specify datafeed version 'v1' or 'v2'
+    version: 'v2' # specify datafeed version 'v1' or 'v2'
     retry:
         maxAttempts: 6 # maximum number of retry attempts
         initialIntervalMillis: 2000 # initial interval between two attempts
@@ -65,7 +65,7 @@ datafeed:
 The minimal configuration for the datafeed service is the version to be used in the
 BDK. For the moment, not all customers have datafeed 2 available on their systems, that's why bot
 developers are able to choose the version that they wish to use on their bot. If the bot developers want to use
-datafeed 2, the version configuration have to be specified as `v2`. Otherwise, datafeed 1 will be used by default.
+datafeed 1, the version configuration have to be specified as `v1`. Otherwise, datafeed 2 will be used by default.
 
 Bot developers can also configure a dedicated retry mechanism which will be used only by the datafeed service.
 Basically, the datafeed service retry configuration has the field same as the global retry configuration with the fields

--- a/symphony-bdk-config/src/main/java/com/symphony/bdk/core/config/model/BdkDatafeedConfig.java
+++ b/symphony-bdk-config/src/main/java/com/symphony/bdk/core/config/model/BdkDatafeedConfig.java
@@ -15,6 +15,7 @@ public class BdkDatafeedConfig {
 
   private String version = "v2";
   private String idFilePath;
+  private String tag;
   private BdkRetryConfig retry = new BdkRetryConfig(BdkRetryConfig.INFINITE_MAX_ATTEMPTS);
 
   public void setVersion(String version) {

--- a/symphony-bdk-config/src/main/java/com/symphony/bdk/core/config/model/BdkDatafeedConfig.java
+++ b/symphony-bdk-config/src/main/java/com/symphony/bdk/core/config/model/BdkDatafeedConfig.java
@@ -15,7 +15,6 @@ public class BdkDatafeedConfig {
 
   private String version = "v2";
   private String idFilePath;
-  private String tag;
   private BdkRetryConfig retry = new BdkRetryConfig(BdkRetryConfig.INFINITE_MAX_ATTEMPTS);
 
   public void setVersion(String version) {

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2.java
@@ -59,13 +59,16 @@ public class DatafeedLoopV2 extends AbstractAckIdEventLoop {
   private final RetryWithRecovery<V5Datafeed> retrieveDatafeed;
   private final RetryWithRecovery<V5Datafeed> createDatafeed;
   private final RetryWithRecovery<Void> deleteDatafeed;
-  private final String tag;
+  private String tag = null;
 
   private V5Datafeed datafeed;
 
   public DatafeedLoopV2(DatafeedApi datafeedApi, AuthSession authSession, BdkConfig config, UserV2 botInfo) {
     super(datafeedApi, authSession, config, botInfo);
-    this.tag = StringUtils.truncate(config.getBot().getUsername(), DATAFEED_TAG_MAX_LENGTH);
+
+    if (StringUtils.isNotBlank(config.getDatafeed().getTag())) {
+      this.tag = StringUtils.truncate(config.getDatafeed().getTag(), DATAFEED_TAG_MAX_LENGTH);
+    }
 
     this.retryWithRecoveryBuilder = new RetryWithRecoveryBuilder<>()
         .basePath(datafeedApi.getApiClient().getBasePath())
@@ -115,10 +118,16 @@ public class DatafeedLoopV2 extends AbstractAckIdEventLoop {
 
   private V5Datafeed doCreateDatafeed() throws ApiException {
     this.ackId = INITIAL_ACK_ID;
+
+    V5DatafeedCreateBody datafeedCreateBody = new V5DatafeedCreateBody();
+    if (StringUtils.isNotBlank(this.tag)) {
+      datafeedCreateBody.setTag(this.tag);
+    }
+
     return this.datafeedApi.createDatafeed(
         this.authSession.getSessionToken(),
         this.authSession.getKeyManagerToken(),
-        new V5DatafeedCreateBody().tag(this.tag)
+        datafeedCreateBody
     );
   }
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2Test.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2Test.java
@@ -64,10 +64,8 @@ class DatafeedLoopV2Test {
 
   private static final String DATAFEED_ID = "abc_f_def";
   private static final String TOKEN = "1234";
-  private static final String USERNAME = "tibot";
 
   private DatafeedLoopV2 datafeedService;
-  private ApiClient datafeedApiClient;
   private DatafeedApi datafeedApi;
   private AuthSession authSession;
   private UserV2 botInfo;
@@ -84,14 +82,14 @@ class DatafeedLoopV2Test {
 
     this.botInfo = Mockito.mock(UserV2.class);
     this.authSession = Mockito.mock(AuthSessionImpl.class);
+    ApiClient datafeedApiClient = mock(ApiClient.class);
+
     when(this.authSession.getSessionToken()).thenReturn(TOKEN);
     when(this.authSession.getKeyManagerToken()).thenReturn(TOKEN);
-
-    this.datafeedApiClient = mock(ApiClient.class);
-    when(this.datafeedApiClient.getBasePath()).thenReturn("/agent/");
+    when(datafeedApiClient.getBasePath()).thenReturn("/agent/");
 
     this.datafeedApi = mock(DatafeedApi.class);
-    when(this.datafeedApi.getApiClient()).thenReturn(this.datafeedApiClient);
+    when(this.datafeedApi.getApiClient()).thenReturn(datafeedApiClient);
 
     this.datafeedService = new DatafeedLoopV2(
         this.datafeedApi,
@@ -371,7 +369,7 @@ class DatafeedLoopV2Test {
   }
 
   private ArgumentMatcher<AckId> eqAckId(String ackId) {
-    return argument -> argument.getAckId().equals(ackId);
+    return argument -> argument.getAckId() != null && argument.getAckId().equals(ackId);
   }
 
   @Test
@@ -381,7 +379,7 @@ class DatafeedLoopV2Test {
     datafeedConfig.setVersion("v2");
     bdkConfig.setDatafeed(datafeedConfig);
     bdkConfig.setRetry(ofMinimalInterval(2));
-    // set a super long bot's username, tag should be shorter
+    // set a super long bot username, tag should be shorter
     bdkConfig.getDatafeed().setTag((StringUtils.repeat('a', 200)));
 
     DatafeedLoopV2 customConfigService = new DatafeedLoopV2(


### PR DESCRIPTION
### Description
The Datafeed tag is an internal feature and the tag property is optional in the configuration. So far, when no tag is configured, the bot username was used as a tag. This leads to production issues when the tag is an old hanging one. In this PR, we only set the tag in Datafeed calls when it is provided in configuration, otherwise a null value is put. For the same occasion, I corrected the Datafeed documentation with some links returning a 404 page error. The tag property is not documented as it is only internal feature.