### PR TITLE
Change tracing filter's order in the registration

### DIFF
--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/config/BdkExtAppTracingFilterConfig.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/config/BdkExtAppTracingFilterConfig.java
@@ -20,7 +20,7 @@ public class BdkExtAppTracingFilterConfig {
 
     registrationBean.setFilter(new TracingFilter());
     registrationBean.addUrlPatterns(getUrlPatterns(properties));
-    registrationBean.setOrder(Ordered.LOWEST_PRECEDENCE);
+    registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE);
 
     return registrationBean;
   }

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/config/BdkExtAppTracingFilterConfigTest.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/config/BdkExtAppTracingFilterConfigTest.java
@@ -17,6 +17,6 @@ class BdkExtAppTracingFilterConfigTest {
         new BdkExtAppTracingFilterConfig().tracingFilter(new SymphonyBdkAppProperties());
 
     assertEquals("/*", tracingFilterRegistration.getUrlPatterns().stream().findFirst().get());
-    assertEquals(Ordered.LOWEST_PRECEDENCE, tracingFilterRegistration.getOrder());
+    assertEquals(Ordered.HIGHEST_PRECEDENCE, tracingFilterRegistration.getOrder());
   }
 }


### PR DESCRIPTION
Make the tracing filter order as highest so it will generate the tracing id at the very beginning of the request process.

### Description
Closes #[[743](https://github.com/finos/symphony-bdk-java/issues/743)]

Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced an issue in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
