### PR TITLE
Remove CE health check from the indicator

### DIFF
--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/service/SymphonyBdkHealthIndicator.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/service/SymphonyBdkHealthIndicator.java
@@ -55,11 +55,10 @@ public class SymphonyBdkHealthIndicator extends AbstractHealthIndicator {
     V3HealthStatus dfStatus = services.get(DF).getStatus();
     V3HealthStatus kmStatus = services.get(KM).getStatus();
     V3HealthStatus agtStatus = users.get(AGT).getStatus();
-    V3HealthStatus ceStatus = users.get(CE).getStatus();
     V3HealthStatus datafeedLoop = healthService.datafeedHealthCheck();
 
     boolean global = podStatus == V3HealthStatus.UP && dfStatus == V3HealthStatus.UP && kmStatus == V3HealthStatus.UP
-        && agtStatus == V3HealthStatus.UP && ceStatus == V3HealthStatus.UP && datafeedLoop == V3HealthStatus.UP;
+        && agtStatus == V3HealthStatus.UP && datafeedLoop == V3HealthStatus.UP;
 
     builder.status(global ? Status.UP.getCode() : "WARNING")
         .withDetail(POD, services.get(POD))

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/service/SymphonyBdkHealthIndicatorTest.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/service/SymphonyBdkHealthIndicatorTest.java
@@ -42,7 +42,7 @@ class SymphonyBdkHealthIndicatorTest {
   }
 
   @Test
-  void doHealthCheck_warning() throws Exception {
+  void doHealthCheck_withCEDown_up() throws Exception {
     V3Health health = new V3Health();
     health.putServicesItem("pod", new V3HealthComponent().status(V3HealthStatus.UP));
     health.putServicesItem("datafeed", new V3HealthComponent().status(V3HealthStatus.UP));
@@ -54,7 +54,7 @@ class SymphonyBdkHealthIndicatorTest {
     Health.Builder builder = new Health.Builder();
     healthIndicator.doHealthCheck(builder);
     Health build = builder.build();
-    assertThat(build.getStatus().getCode()).isEqualTo("WARNING");
+    assertThat(build.getStatus().getCode()).isEqualTo("UP");
   }
 
   @Test
@@ -78,7 +78,7 @@ class SymphonyBdkHealthIndicatorTest {
         + "  },\n"
         + "  \"users\": {\n"
         + "    \"agentservice\": {\n"
-        + "      \"status\": \"UP\"\n"
+        + "      \"status\": \"DOWN\"\n"
         + "    },\n"
         + "    \"ceservice\": {\n"
         + "      \"status\": \"DOWN\",\n"


### PR DESCRIPTION
CE health status is optional, should not impact the BDK bot global health status, remove it from the check list.

### Description
Closes #[[742](https://github.com/finos/symphony-bdk-java/issues/742)]

Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced an issue in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
