### PR TITLE
Make DF recreation retry when client error

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2.java
@@ -79,6 +79,7 @@ public class DatafeedLoopV2 extends AbstractAckIdEventLoop {
     this.createDatafeed = RetryWithRecoveryBuilder.<V5Datafeed>from(retryWithRecoveryBuilder)
         .name("Create Datafeed V2")
         .supplier(this::doCreateDatafeed)
+        .retryOnException(RetryWithRecoveryBuilder::isNetworkIssueOrMinorErrorOrClientError)
         .build();
 
     this.deleteDatafeed = RetryWithRecoveryBuilder.<Void>from(retryWithRecoveryBuilder)


### PR DESCRIPTION
When reading DF events fails with client error 400, the API call is doing a retry by recreating the DF, the DF recreation API call unfortunately does not have a retry on client error.

This commit fixed this bug.

### Description
Closes #[ISSUE NUMBER]

Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced an issue in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
