### PR TITLE
Fix the event timestamp value is not accessible bug

### DIFF
--- a/allow-list.xml
+++ b/allow-list.xml
@@ -67,4 +67,11 @@
       <gav>org.json:json:20220320</gav>
       <cve>CVE-2022-45688</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+          No fix available
+          ]]></notes>
+        <gav>net.minidev:json-smart:2.4.8</gav>
+        <cve>CVE-2023-1370</cve>
+    </suppress>
 </suppressions>

--- a/docs/datafeed.md
+++ b/docs/datafeed.md
@@ -32,7 +32,7 @@ public class Example {
         final RealTimeEventListener listener = new RealTimeEventListener() {
             @Override
             public void onMessageSent(V4Initiator initiator, V4MessageSent event) {
-                log.info("Message sent");
+                log.info("Message sent at {}", ((EventPayload) event).getEventTimestamp());
             }
         };
 

--- a/docs/test.md
+++ b/docs/test.md
@@ -37,20 +37,20 @@ module.
 
 @SymphonyBdkSpringBootTest(properties = {"bot.id=1", "bot.username=my-bot", "bot.display-name=my bot"})
 public class SampleSpringAppIntegrationTest {
-  private final V4User initiator = new V4User().displayName("user").userId(2L);
-  private final V4Stream stream = new V4Stream().streamId("my-room");
+    private final V4User initiator = new V4User().displayName("user").userId(2L);
+    private final V4Stream stream = new V4Stream().streamId("my-room");
 
-  @Test
-  void echo_command_replyWithMessage(@Autowired MessageService messageService, @Autowired UserV2 botInfo) {
-    // (1)  given
-    when(messageService.send(anyString(), any(Message.class))).thenReturn(mock(V4Message.class));
+    @Test
+    void echo_command_replyWithMessage(@Autowired MessageService messageService, @Autowired UserV2 botInfo) {
+        // (1)  given
+        when(messageService.send(anyString(), any(Message.class))).thenReturn(mock(V4Message.class));
 
-    // (2)  when
-    pushMessageToDF(initiator, stream, "/echo arg", botInfo);
+        // (2)  when
+        pushMessageToDF(initiator, stream, "/echo arg", botInfo);
 
-    // (3)  then
-    verify(messageService).send(eq("my-room"), eq("Received argument: arg"));
-  }
+        // (3)  then
+        verify(messageService).send(eq("my-room"), eq("Received argument: arg"));
+    }
 }
 ```
 
@@ -63,6 +63,12 @@ message has received.
 
 **Step 3**. at the end we verify that a replied message has been sent back to the room through BDK `messsageService`.
 
+### Inheritance
+
+The `@SymphonyBdkSpringBootTest` annotation is inheritable. Developers may have one parent test class with this
+annotation, so that the child test classes will inherit the annotation and its properties.
+
+### Utils
 The `SymphonyBdkTestUtils.java` is a very handy helper class allowing to inject Symphony events to the DataFeed, so that
 the registered activities and slash commands should react on these received events.
 
@@ -90,10 +96,10 @@ void test(){
     pushEventToDataFeed(new V4Event()
         .initiator(new V4Initiator().user(initiator))
         .payload(new V4Payload().symphonyElementsAction(
-              new V4SymphonyElementsAction().formId("gif-category-form")
-              .formMessageId("form-message-id")
-              .formValues(values)
-              .stream(stream)))
+            new V4SymphonyElementsAction().formId("gif-category-form")
+                .formMessageId("form-message-id")
+                .formValues(values)
+                .stream(stream)))
         .type(V4EventType.SYMPHONYELEMENTSACTION.name()));
 }
 ```

--- a/symphony-bdk-core/build.gradle
+++ b/symphony-bdk-core/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     implementation 'org.mapstruct:mapstruct:1.4.2.Final'
+    implementation 'net.bytebuddy:byte-buddy:1.12.19'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.2.Final'
 
     api 'org.apiguardian:apiguardian-api'

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/AbstractActivity.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/AbstractActivity.java
@@ -3,6 +3,7 @@ package com.symphony.bdk.core.activity;
 import com.symphony.bdk.core.activity.model.ActivityInfo;
 import com.symphony.bdk.core.service.datafeed.DatafeedLoop;
 import com.symphony.bdk.core.service.datafeed.EventException;
+import com.symphony.bdk.core.service.datafeed.EventPayload;
 import com.symphony.bdk.core.service.datafeed.RealTimeEventListener;
 import com.symphony.bdk.gen.api.model.V4Initiator;
 
@@ -123,6 +124,9 @@ public abstract class AbstractActivity<E, C extends ActivityContext<E>> {
   @SuppressWarnings("unchecked")
   protected C createContextInstance(V4Initiator initiator, E event) {
     final Class<C> clz = (Class<C>) ((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments()[0];
+    if (EventPayload.class.isAssignableFrom(event.getClass())) {
+      return clz.getConstructor(V4Initiator.class, event.getClass().getSuperclass()).newInstance(initiator, event);
+    }
     return clz.getConstructor(V4Initiator.class, event.getClass()).newInstance(initiator, event);
   }
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/ActivityContext.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/activity/ActivityContext.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.core.activity;
 
+import com.symphony.bdk.core.service.datafeed.EventPayload;
 import com.symphony.bdk.gen.api.model.V4Initiator;
 
 import lombok.Getter;
@@ -29,4 +30,20 @@ public abstract class ActivityContext<E> {
    * </ul>
    */
   private final E sourceEvent;
+
+  /**
+   * The original event triggered timestamp
+   */
+  private final Long eventTimestamp;
+
+  public ActivityContext(V4Initiator initiator, E sourceEvent) {
+    this.initiator = initiator;
+    this.sourceEvent = sourceEvent;
+    if (EventPayload.class.isAssignableFrom(sourceEvent.getClass())) {
+      this.eventTimestamp = ((EventPayload) sourceEvent).getEventTimestamp();
+    } else {
+      this.eventTimestamp = null;
+    }
+  }
+
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/EventPayload.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/EventPayload.java
@@ -1,0 +1,18 @@
+package com.symphony.bdk.core.service.datafeed;
+
+import org.apiguardian.api.API;
+
+/**
+ * The real time event payload type. All events read through datafeed should implement this type.
+ */
+@API(status = API.Status.EXPERIMENTAL)
+public interface EventPayload {
+  /**
+   * the real event timestamp, when the event is generated from the platform before pushing to datafeed.
+   *
+   * @return timestamp in long
+   */
+  Long getEventTimestamp();
+
+  void setEventTimestamp(Long eventTimestamp);
+}

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/RealTimeEventType.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/RealTimeEventType.java
@@ -1,8 +1,18 @@
 package com.symphony.bdk.core.service.datafeed.impl;
 
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+
+import com.symphony.bdk.core.service.datafeed.EventPayload;
 import com.symphony.bdk.core.service.datafeed.RealTimeEventListener;
 import com.symphony.bdk.gen.api.model.V4Event;
 
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.ClassFileVersion;
+import net.bytebuddy.description.modifier.Visibility;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.implementation.FieldAccessor;
+import net.bytebuddy.implementation.MethodCall;
+import net.bytebuddy.matcher.ElementMatchers;
 import org.apiguardian.api.API;
 
 import java.util.Optional;
@@ -16,52 +26,56 @@ import java.util.function.BiConsumer;
 enum RealTimeEventType {
 
   MESSAGESENT((listener, event) -> {
-    listener.onMessageSent(event.getInitiator(), event.getPayload().getMessageSent());
+    listener.onMessageSent(event.getInitiator(), proxy(event.getPayload().getMessageSent(), event));
   }),
   MESSAGESUPPRESSED((listener, event) -> {
-    listener.onMessageSuppressed(event.getInitiator(), event.getPayload().getMessageSuppressed());
+    listener.onMessageSuppressed(event.getInitiator(), proxy(event.getPayload().getMessageSuppressed(), event));
   }),
   SYMPHONYELEMENTSACTION((listener, event) -> {
-    listener.onSymphonyElementsAction(event.getInitiator(), event.getPayload().getSymphonyElementsAction());
+    listener.onSymphonyElementsAction(event.getInitiator(),
+        proxy(event.getPayload().getSymphonyElementsAction(), event));
   }),
   SHAREDPOST((listener, event) -> {
-    listener.onSharedPost(event.getInitiator(), event.getPayload().getSharedPost());
+    listener.onSharedPost(event.getInitiator(), proxy(event.getPayload().getSharedPost(), event));
   }),
   INSTANTMESSAGECREATED((listener, event) -> {
-    listener.onInstantMessageCreated(event.getInitiator(), event.getPayload().getInstantMessageCreated());
+    listener.onInstantMessageCreated(event.getInitiator(), proxy(event.getPayload().getInstantMessageCreated(), event));
   }),
   ROOMCREATED((listener, event) -> {
-    listener.onRoomCreated(event.getInitiator(), event.getPayload().getRoomCreated());
+    listener.onRoomCreated(event.getInitiator(), proxy(event.getPayload().getRoomCreated(), event));
   }),
   ROOMUPDATED((listener, event) -> {
-    listener.onRoomUpdated(event.getInitiator(), event.getPayload().getRoomUpdated());
+    listener.onRoomUpdated(event.getInitiator(), proxy(event.getPayload().getRoomUpdated(), event));
   }),
   ROOMDEACTIVATED((listener, event) -> {
-    listener.onRoomDeactivated(event.getInitiator(), event.getPayload().getRoomDeactivated());
+    listener.onRoomDeactivated(event.getInitiator(), proxy(event.getPayload().getRoomDeactivated(), event));
   }),
   ROOMREACTIVATED((listener, event) -> {
-    listener.onRoomReactivated(event.getInitiator(), event.getPayload().getRoomReactivated());
+    listener.onRoomReactivated(event.getInitiator(), proxy(event.getPayload().getRoomReactivated(), event));
   }),
   USERJOINEDROOM((listener, event) -> {
-    listener.onUserJoinedRoom(event.getInitiator(), event.getPayload().getUserJoinedRoom());
+    listener.onUserJoinedRoom(event.getInitiator(), proxy(event.getPayload().getUserJoinedRoom(), event));
   }),
   USERLEFTROOM((listener, event) -> {
-    listener.onUserLeftRoom(event.getInitiator(), event.getPayload().getUserLeftRoom());
+    listener.onUserLeftRoom(event.getInitiator(), proxy(event.getPayload().getUserLeftRoom(), event));
   }),
   USERREQUESTEDTOJOINROOM((listener, event) -> {
-    listener.onUserRequestedToJoinRoom(event.getInitiator(), event.getPayload().getUserRequestedToJoinRoom());
+    listener.onUserRequestedToJoinRoom(event.getInitiator(),
+        proxy(event.getPayload().getUserRequestedToJoinRoom(), event));
   }),
   ROOMMEMBERPROMOTEDTOOWNER((listener, event) -> {
-    listener.onRoomMemberPromotedToOwner(event.getInitiator(), event.getPayload().getRoomMemberPromotedToOwner());
+    listener.onRoomMemberPromotedToOwner(event.getInitiator(),
+        proxy(event.getPayload().getRoomMemberPromotedToOwner(), event));
   }),
   ROOMMEMBERDEMOTEDFROMOWNER((listener, event) -> {
-    listener.onRoomMemberDemotedFromOwner(event.getInitiator(), event.getPayload().getRoomMemberDemotedFromOwner());
+    listener.onRoomMemberDemotedFromOwner(event.getInitiator(),
+        proxy(event.getPayload().getRoomMemberDemotedFromOwner(), event));
   }),
   CONNECTIONACCEPTED((listener, event) -> {
-    listener.onConnectionAccepted(event.getInitiator(), event.getPayload().getConnectionAccepted());
+    listener.onConnectionAccepted(event.getInitiator(), proxy(event.getPayload().getConnectionAccepted(), event));
   }),
   CONNECTIONREQUESTED((listener, event) -> {
-    listener.onConnectionRequested(event.getInitiator(), event.getPayload().getConnectionRequested());
+    listener.onConnectionRequested(event.getInitiator(), proxy(event.getPayload().getConnectionRequested(), event));
   });
 
   private final BiConsumer<RealTimeEventListener, V4Event> execConsumer;
@@ -86,4 +100,33 @@ enum RealTimeEventType {
   public void dispatch(RealTimeEventListener listener, V4Event event) {
     this.execConsumer.accept(listener, event);
   }
+
+  /**
+   * Build a dynamic proxy on the received event, add two more fields to the new proxy class as a decorator pattern.
+   * So that the event original timestamp, and event id are accessible from the new fields.
+   * Other method calls will be delegated to the original event object instance.
+   *
+   * @param event     original event, the type will be used to build the proxy
+   * @param realEvent the parent V4Event, from where the event id and timestamp can be read
+   * @param <T>       event type
+   * @return the new created event proxy instance
+   */
+  private static <T> T proxy(T event, V4Event realEvent) {
+    try {
+      T proxyEvent = (T) new ByteBuddy(ClassFileVersion.JAVA_V8)
+          .subclass(event.getClass())
+          .method(ElementMatchers.any().and(isPublic()))
+          .intercept(MethodCall.invokeSelf().on(event).withAllArguments())
+          .defineField("eventTimestamp", Long.class, Visibility.PRIVATE)
+          .implement(EventPayload.class).intercept(FieldAccessor.ofBeanProperty())
+          .make()
+          .load(event.getClass().getClassLoader(), ClassLoadingStrategy.Default.INJECTION)
+          .getLoaded().newInstance();
+      ((EventPayload) proxyEvent).setEventTimestamp(realEvent.getTimestamp());
+      return proxyEvent;
+    } catch (InstantiationException | IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
 }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/AbstractActivityTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/activity/AbstractActivityTest.java
@@ -4,11 +4,15 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.symphony.bdk.core.activity.form.TestFormReplyActivity;
 import com.symphony.bdk.core.service.datafeed.EventException;
+import com.symphony.bdk.core.service.datafeed.EventPayload;
 import com.symphony.bdk.gen.api.model.V4Initiator;
 import com.symphony.bdk.gen.api.model.V4Stream;
 import com.symphony.bdk.gen.api.model.V4SymphonyElementsAction;
 
+import lombok.experimental.Delegate;
 import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
 
 /**
  * Test class for the {@link AbstractActivity}.
@@ -84,6 +88,25 @@ class AbstractActivityTest {
     });
 
     assertThrows(EventException.class,
-        () -> act.processEvent(new V4Initiator(), new V4SymphonyElementsAction()));
+        () -> act.processEvent(new V4Initiator(), new V4SymphonyElementsActionEvent(new V4SymphonyElementsAction())));
+  }
+
+  static class V4SymphonyElementsActionEvent extends V4SymphonyElementsAction implements EventPayload {
+    @Delegate
+    V4SymphonyElementsAction elementsAction;
+
+    public V4SymphonyElementsActionEvent(V4SymphonyElementsAction elementsAction) {
+      this.elementsAction = elementsAction;
+    }
+
+    @Override
+    public Long getEventTimestamp() {
+      return Instant.now().toEpochMilli();
+    }
+
+    @Override
+    public void setEventTimestamp(Long eventTimestamp) {
+
+    }
   }
 }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV1Test.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV1Test.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -51,7 +52,6 @@ import com.symphony.bdk.gen.api.model.V4UserLeftRoom;
 import com.symphony.bdk.gen.api.model.V4UserRequestedToJoinRoom;
 import com.symphony.bdk.http.api.ApiClient;
 import com.symphony.bdk.http.api.ApiException;
-
 import com.symphony.bdk.http.api.tracing.DistributedTracingContext;
 
 import org.apache.commons.io.FileUtils;
@@ -151,7 +151,8 @@ class DatafeedLoopV1Test {
   }
 
   private List<V4Event> getMessageSentEvent() {
-    final V4Event event = new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())
+    final V4Event event = new V4Event().type(RealTimeEventType.MESSAGESENT.name())
+        .payload(new V4Payload().messageSent(new V4MessageSent()))
         .initiator(new V4Initiator().user(new V4User().username("username").userId(123456789L)));
     return Collections.singletonList(event);
   }
@@ -481,8 +482,8 @@ class DatafeedLoopV1Test {
     events.add(new V4Event().type("unknown-type").payload(payload));
     events.add(new V4Event().type(null));
     events.add(new V4Event().type(types[0].name()).initiator(
-        new V4Initiator().user(
-            new V4User().username(this.bdkConfig.getBot().getUsername()).userId(123456789L))
+            new V4Initiator().user(
+                new V4User().username(this.bdkConfig.getBot().getUsername()).userId(123456789L))
         )
     );
 
@@ -501,21 +502,21 @@ class DatafeedLoopV1Test {
     this.datafeedService.subscribe(spiedListener);
     this.datafeedService.handleV4EventList(events);
 
-    verify(spiedListener).onMessageSent(initiator, payload.getMessageSent());
-    verify(spiedListener).onMessageSuppressed(initiator, payload.getMessageSuppressed());
-    verify(spiedListener).onSymphonyElementsAction(initiator, payload.getSymphonyElementsAction());
-    verify(spiedListener).onSharedPost(initiator, payload.getSharedPost());
-    verify(spiedListener).onInstantMessageCreated(initiator, payload.getInstantMessageCreated());
-    verify(spiedListener).onRoomCreated(initiator, payload.getRoomCreated());
-    verify(spiedListener).onRoomUpdated(initiator, payload.getRoomUpdated());
-    verify(spiedListener).onRoomDeactivated(initiator, payload.getRoomDeactivated());
-    verify(spiedListener).onRoomReactivated(initiator, payload.getRoomReactivated());
-    verify(spiedListener).onConnectionRequested(initiator, payload.getConnectionRequested());
-    verify(spiedListener).onConnectionAccepted(initiator, payload.getConnectionAccepted());
-    verify(spiedListener).onRoomMemberDemotedFromOwner(initiator, payload.getRoomMemberDemotedFromOwner());
-    verify(spiedListener).onRoomMemberPromotedToOwner(initiator, payload.getRoomMemberPromotedToOwner());
-    verify(spiedListener).onUserLeftRoom(initiator, payload.getUserLeftRoom());
-    verify(spiedListener).onUserJoinedRoom(initiator, payload.getUserJoinedRoom());
-    verify(spiedListener).onUserRequestedToJoinRoom(initiator, payload.getUserRequestedToJoinRoom());
+    verify(spiedListener).onMessageSent(eq(initiator), any(V4MessageSent.class));
+    verify(spiedListener).onMessageSuppressed(eq(initiator), any(V4MessageSuppressed.class));
+    verify(spiedListener).onSymphonyElementsAction(eq(initiator), any(V4SymphonyElementsAction.class));
+    verify(spiedListener).onSharedPost(eq(initiator), any(V4SharedPost.class));
+    verify(spiedListener).onInstantMessageCreated(eq(initiator), any(V4InstantMessageCreated.class));
+    verify(spiedListener).onRoomCreated(eq(initiator), any(V4RoomCreated.class));
+    verify(spiedListener).onRoomUpdated(eq(initiator), any(V4RoomUpdated.class));
+    verify(spiedListener).onRoomDeactivated(eq(initiator), any(V4RoomDeactivated.class));
+    verify(spiedListener).onRoomReactivated(eq(initiator), any(V4RoomReactivated.class));
+    verify(spiedListener).onConnectionRequested(eq(initiator), any(V4ConnectionRequested.class));
+    verify(spiedListener).onConnectionAccepted(eq(initiator), any(V4ConnectionAccepted.class));
+    verify(spiedListener).onRoomMemberDemotedFromOwner(eq(initiator), any(V4RoomMemberDemotedFromOwner.class));
+    verify(spiedListener).onRoomMemberPromotedToOwner(eq(initiator), any(V4RoomMemberPromotedToOwner.class));
+    verify(spiedListener).onUserLeftRoom(eq(initiator), any(V4UserLeftRoom.class));
+    verify(spiedListener).onUserJoinedRoom(eq(initiator), any(V4UserJoinedRoom.class));
+    verify(spiedListener).onUserRequestedToJoinRoom(eq(initiator), any(V4UserRequestedToJoinRoom.class));
   }
 }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2Test.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2Test.java
@@ -1,18 +1,5 @@
 package com.symphony.bdk.core.service.datafeed.impl;
 
-import static com.symphony.bdk.core.test.BdkRetryConfigTestHelper.ofMinimalInterval;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.core.auth.exception.AuthUnauthorizedException;
 import com.symphony.bdk.core.auth.impl.AuthSessionImpl;
@@ -57,6 +44,19 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.ws.rs.ProcessingException;
+
+import static com.symphony.bdk.core.test.BdkRetryConfigTestHelper.ofMinimalInterval;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class DatafeedLoopV2Test {
 
@@ -115,7 +115,8 @@ class DatafeedLoopV2Test {
     AckId ackId = new AckId().ackId(datafeedService.getAckId());
     when(datafeedApi.readDatafeed(DATAFEED_ID, TOKEN, TOKEN, ackId))
         .thenReturn(new V5EventList().addEventsItem(
-            new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id"));
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name())
+                .payload(new V4Payload().messageSent(new V4MessageSent()))).ackId("ack-id"));
 
     this.datafeedService.start();
 
@@ -134,7 +135,8 @@ class DatafeedLoopV2Test {
     AckId ackId = new AckId().ackId(datafeedService.getAckId());
     when(datafeedApi.readDatafeed(DATAFEED_ID, TOKEN, TOKEN, ackId))
         .thenReturn(new V5EventList().addEventsItem(
-            new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id"));
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name())
+                .payload(new V4Payload().messageSent(new V4MessageSent()))).ackId("ack-id"));
 
     this.datafeedService.start();
 
@@ -155,7 +157,8 @@ class DatafeedLoopV2Test {
     AckId ackId = new AckId().ackId(datafeedService.getAckId());
     when(datafeedApi.readDatafeed(validExistingFeedId, TOKEN, TOKEN, ackId))
         .thenReturn(new V5EventList().addEventsItem(
-            new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id"));
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name())
+                .payload(new V4Payload().messageSent(new V4MessageSent()))).ackId("ack-id"));
 
     this.datafeedService.start();
 
@@ -173,14 +176,17 @@ class DatafeedLoopV2Test {
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null)).thenReturn(datafeeds);
     when(datafeedApi.readDatafeed(eq(DATAFEED_ID), eq(TOKEN), eq(TOKEN), argThat(eqAckId(""))))
         .thenReturn(new V5EventList().addEventsItem(
-            new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id"))
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name())
+                .payload(new V4Payload().messageSent(new V4MessageSent()))).ackId("ack-id"))
         .thenReturn(null); // the first df loop run should not fail
     when(datafeedApi.readDatafeed(eq(DATAFEED_ID), eq(TOKEN), eq(TOKEN), argThat(eqAckId("ack-id"))))
         .thenReturn(new V5EventList().addEventsItem(
-            new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id2"));
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name())
+                .payload(new V4Payload().messageSent(new V4MessageSent()))).ackId("ack-id2"));
     when(datafeedApi.readDatafeed(eq(DATAFEED_ID), eq(TOKEN), eq(TOKEN), argThat(eqAckId("ack-id2"))))
         .thenReturn(new V5EventList().addEventsItem(
-            new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id2"));
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name())
+                .payload(new V4Payload().messageSent(new V4MessageSent()))).ackId("ack-id2"));
 
     // remove default listener that stops the DF loop
     datafeedService.unsubscribe(listener);
@@ -246,11 +252,13 @@ class DatafeedLoopV2Test {
     when(datafeedApi.readDatafeed(eq(DATAFEED_ID), eq(TOKEN), eq(TOKEN),
         argThat(eqAckId(""))))
         .thenReturn(new V5EventList().addEventsItem(
-            new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id"));
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name())
+                .payload(new V4Payload().messageSent(new V4MessageSent()))).ackId("ack-id"));
     when(datafeedApi.readDatafeed(eq(DATAFEED_ID), eq(TOKEN), eq(TOKEN),
         argThat(eqAckId("ack-id"))))
         .thenReturn(new V5EventList().addEventsItem(
-            new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id2"));
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name())
+                .payload(new V4Payload().messageSent(new V4MessageSent()))).ackId("ack-id2"));
 
     this.datafeedService.unsubscribe(listener);
     AtomicBoolean firstCall = new AtomicBoolean(true);
@@ -289,10 +297,12 @@ class DatafeedLoopV2Test {
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null)).thenReturn(datafeeds);
     when(datafeedApi.readDatafeed(eq(DATAFEED_ID), eq(TOKEN), eq(TOKEN), argThat(eqAckId(""))))
         .thenReturn(new V5EventList().addEventsItem(
-            new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id"));
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name())
+                .payload(new V4Payload().messageSent(new V4MessageSent()))).ackId("ack-id"));
     when(datafeedApi.readDatafeed(eq(DATAFEED_ID), eq(TOKEN), eq(TOKEN), argThat(eqAckId("ack-id"))))
         .thenReturn(new V5EventList().addEventsItem(
-            new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id2"));
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name())
+                .payload(new V4Payload().messageSent(new V4MessageSent()))).ackId("ack-id2"));
 
     this.datafeedService.unsubscribe(listener);
     AtomicBoolean firstCall = new AtomicBoolean(true);
@@ -335,7 +345,8 @@ class DatafeedLoopV2Test {
     final String secondAckId = "ack-id";
     when(datafeedApi.readDatafeed(DATAFEED_ID, TOKEN, TOKEN, initialAckId))
         .thenReturn(new V5EventList().addEventsItem(
-            new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId(secondAckId));
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name())
+                .payload(new V4Payload().messageSent(new V4MessageSent()))).ackId(secondAckId));
 
     this.datafeedService.start();
 
@@ -365,7 +376,8 @@ class DatafeedLoopV2Test {
         new V5Datafeed().id(secondDatafeedId));
     when(datafeedApi.readDatafeed(secondDatafeedId, TOKEN, TOKEN, initialAckId))
         .thenReturn(new V5EventList().addEventsItem(
-            new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id-2"));
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name())
+                .payload(new V4Payload().messageSent(new V4MessageSent()))).ackId("ack-id-2"));
 
     this.datafeedService.start();
 
@@ -385,7 +397,8 @@ class DatafeedLoopV2Test {
     AckId ackId = new AckId().ackId(datafeedService.getAckId());
     when(datafeedApi.readDatafeed(DATAFEED_ID, TOKEN, TOKEN, ackId))
         .thenReturn(new V5EventList()
-            .addEventsItem(new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload()))
+            .addEventsItem(new V4Event().type(RealTimeEventType.MESSAGESENT.name())
+                .payload(new V4Payload().messageSent(new V4MessageSent())))
             .ackId("ack-id"));
 
     this.datafeedService.unsubscribe(this.listener);
@@ -447,7 +460,8 @@ class DatafeedLoopV2Test {
     AckId ackId = new AckId().ackId(datafeedService.getAckId());
     when(datafeedApi.readDatafeed(DATAFEED_ID, TOKEN, TOKEN, ackId))
         .thenReturn(new V5EventList().addEventsItem(
-            new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id"));
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name())
+                .payload(new V4Payload().messageSent(new V4MessageSent()))).ackId("ack-id"));
 
     this.datafeedService.start();
 
@@ -500,7 +514,8 @@ class DatafeedLoopV2Test {
     when(datafeedApi.readDatafeed(DATAFEED_ID, TOKEN, TOKEN, ackId)).thenThrow(new ApiException(400, "client-error"));
     when(datafeedApi.readDatafeed("recreate-df-id", TOKEN, TOKEN, ackId))
         .thenReturn(new V5EventList().addEventsItem(
-            new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id"));
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name())
+                .payload(new V4Payload().messageSent(new V4MessageSent()))).ackId("ack-id"));
 
     this.datafeedService.start();
     verify(datafeedApi, times(1)).listDatafeed(TOKEN, TOKEN, null);
@@ -605,7 +620,8 @@ class DatafeedLoopV2Test {
     when(datafeedApi.readDatafeed(DATAFEED_ID, TOKEN, TOKEN, ackId)).thenThrow(new ApiException(400, "client-error"));
     when(datafeedApi.readDatafeed("recreate-df-id", TOKEN, TOKEN, ackId))
         .thenReturn(new V5EventList().addEventsItem(
-            new V4Event().type(RealTimeEventType.MESSAGESENT.name()).payload(new V4Payload())).ackId("ack-id"));
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name())
+                .payload(new V4Payload().messageSent(new V4MessageSent()))).ackId("ack-id"));
     when(datafeedApi.deleteDatafeed(DATAFEED_ID, TOKEN, TOKEN)).thenThrow(new ApiException(400, "client-error"));
 
     this.datafeedService.start();

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatahoseLoopTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatahoseLoopTest.java
@@ -356,7 +356,13 @@ class DatahoseLoopTest {
   }
 
   private V5EventList buildV5Events(RealTimeEventType eventType, String ackId) {
-    return new V5EventList().ackId(ackId).addEventsItem(new V4Event().type(eventType.name()).payload(new V4Payload()));
+    if (RealTimeEventType.MESSAGESENT == eventType) {
+      return new V5EventList().ackId(ackId)
+          .addEventsItem(
+              new V4Event().type(eventType.name()).payload(new V4Payload().messageSent(new V4MessageSent())));
+    }
+    return new V5EventList().ackId(ackId)
+        .addEventsItem(new V4Event().type(eventType.name()).payload(new V4Payload().roomCreated(new V4RoomCreated())));
   }
 
   private void assertEventsReadBody(V5EventsReadBody actualBody, String expectedTag, String expectedAckId) {

--- a/symphony-bdk-examples/bdk-core-examples/src/main/java/com/symphony/bdk/examples/DatafeedExampleMain.java
+++ b/symphony-bdk-examples/bdk-core-examples/src/main/java/com/symphony/bdk/examples/DatafeedExampleMain.java
@@ -3,6 +3,7 @@ package com.symphony.bdk.examples;
 import static com.symphony.bdk.core.config.BdkConfigLoader.loadFromSymphonyDir;
 
 import com.symphony.bdk.core.SymphonyBdk;
+import com.symphony.bdk.core.service.datafeed.EventPayload;
 import com.symphony.bdk.core.service.datafeed.RealTimeEventListener;
 import com.symphony.bdk.gen.api.model.V4Initiator;
 import com.symphony.bdk.gen.api.model.V4MessageSent;
@@ -20,6 +21,7 @@ public class DatafeedExampleMain {
 
       @Override
       public void onMessageSent(V4Initiator initiator, V4MessageSent event) {
+        log.info("event was triggered at {}", ((EventPayload) event).getEventTimestamp());
         bdk.messages().send(event.getMessage().getStream(), "<messageML>Hello, World!</messageML>");
       }
     });

--- a/symphony-bdk-examples/bdk-spring-boot-example/src/main/java/com/symphony/bdk/examples/spring/EchoActivity.java
+++ b/symphony-bdk-examples/bdk-spring-boot-example/src/main/java/com/symphony/bdk/examples/spring/EchoActivity.java
@@ -11,6 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.time.Instant;
+
 /**
  * This is to show how to use @Slash annotations with arguments
  */
@@ -23,12 +25,15 @@ public class EchoActivity {
 
   @Slash("/echo {argument}")
   public void echo(CommandContext context, String argument) {
-    this.messageService.send(context.getStreamId(), "Received argument: " + argument);
+    Instant timestamp = Instant.ofEpochMilli(context.getEventTimestamp());
+    log.info("{}", timestamp);
+    this.messageService.send(context.getStreamId(), String.format("Received argument: %s at %s", argument, timestamp));
   }
 
   @Slash("/echo {@mention}")
   public void echo(CommandContext context, Mention mention) {
-    this.messageService.send(context.getStreamId(), "Received mention: " + mention.getUserDisplayName() + " of id: " + mention.getUserId());
+    this.messageService.send(context.getStreamId(),
+        "Received mention: " + mention.getUserDisplayName() + " of id: " + mention.getUserId());
   }
 
   @Slash("/echo {#hashtag}")
@@ -43,7 +48,8 @@ public class EchoActivity {
 
   @Slash("/echo {argument} {$cashtag}")
   public void echo(CommandContext context, String argument, Cashtag cashtag) {
-    this.messageService.send(context.getStreamId(), "Received argument: " + argument + " and cashtag: " + cashtag.getValue());
+    this.messageService.send(context.getStreamId(),
+        "Received argument: " + argument + " and cashtag: " + cashtag.getValue());
   }
 
 }

--- a/symphony-bdk-examples/bdk-spring-boot-example/src/main/java/com/symphony/bdk/examples/spring/RealTimeEventsDemo.java
+++ b/symphony-bdk-examples/bdk-spring-boot-example/src/main/java/com/symphony/bdk/examples/spring/RealTimeEventsDemo.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.examples.spring;
 
+import com.symphony.bdk.core.service.datafeed.EventPayload;
 import com.symphony.bdk.gen.api.model.V4MessageSent;
 import com.symphony.bdk.gen.api.model.V4UserJoinedRoom;
 import com.symphony.bdk.gen.api.model.V4UserLeftRoom;
@@ -18,7 +19,7 @@ public class RealTimeEventsDemo {
 
   @EventListener
   public void onMessageSent(RealTimeEvent<V4MessageSent> event) {
-    log.info(event.toString());
+    log.info("{} received at {}", event.toString(), ((EventPayload) event.getSource()).getEventTimestamp());
   }
 
   @EventListener

--- a/symphony-bdk-examples/bdk-spring-boot-example/src/test/java/com/symphony/bdk/examples/spring/SampleSpringAppIntegrationTest.java
+++ b/symphony-bdk-examples/bdk-spring-boot-example/src/test/java/com/symphony/bdk/examples/spring/SampleSpringAppIntegrationTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -50,7 +51,7 @@ public class SampleSpringAppIntegrationTest {
     pushMessageToDF(initiator, stream, "/echo arg", botInfo);
 
     // then
-    verify(messageService).send(eq("my-room"), eq("Received argument: arg"));
+    verify(messageService).send(eq("my-room"), contains("Received argument: arg at"));
   }
 
   @Test
@@ -76,7 +77,7 @@ public class SampleSpringAppIntegrationTest {
     Map<String, Object> values = new HashMap<>();
     values.put("action", "submit");
     values.put("category", "bdk");
-    pushEventToDataFeed(new V4Event()
+    pushEventToDataFeed(new V4Event().id("id").timestamp(Instant.now().toEpochMilli())
                      .initiator(new V4Initiator().user(initiator))
                      .payload(new V4Payload().symphonyElementsAction(
                         new V4SymphonyElementsAction().formId("gif-category-form")


### PR DESCRIPTION
The event timestamp is filled at the event wrapper level only, which is the one when the event is read from datafeed. However only the raw event is pushed to the real time listeners, that's the reason why we loose this event timestamp.

This commit fix this issue by constructing an event proxy at runtime, all events implements EventPayload interface, the timestamp value is now accessible through this interface. User has to cast the raw event to EventPayload to read the value. This big advantage is we do not bring in any breaking changes in any stable APIs, the change is totally transparent for the BDK developers.

### Description
Closes #[741](https://github.com/finos/symphony-bdk-java/issues/741)

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced an issue in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
