### PR TITLE
Fix health info parsing bug

### DIFF
--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/service/SymphonyBdkHealthIndicatorTest.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/service/SymphonyBdkHealthIndicatorTest.java
@@ -96,4 +96,22 @@ class SymphonyBdkHealthIndicatorTest {
     Health build = builder.build();
     assertThat(build.getStatus().getCode()).isEqualTo("WARNING");
   }
+
+  @Test
+  void doHealthCheck_badGw_exception() throws Exception {
+    final String body = "<html>\n"
+        + "<head><title>502 Bad Gateway</title></head>\n"
+        + "<body>\n"
+        + "<center><h1>502 Bad Gateway</h1></center>\n"
+        + "</body>\n"
+        + "</html>";
+
+
+    doThrow(new ApiRuntimeException(new ApiException(502, "message", Collections.EMPTY_MAP, body))).when(healthService)
+        .healthCheckExtended();
+    Health.Builder builder = new Health.Builder();
+    healthIndicator.doHealthCheck(builder);
+    Health build = builder.build();
+    assertThat(build.getStatus().getCode()).isEqualTo("DOWN");
+  }
 }


### PR DESCRIPTION
When extended health info api returns 5xx, the response body cannot be parsed into json model, in this case, we should consider all compoments are down.

### Description
Closes #[ISSUE NUMBER]

Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced an issue in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
