### PR TITLE
Fix byte-buddy class loading failure

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939
         with:
           ruby-version: '3.1'
           bundler-cache: true

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -9,4 +9,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4

--- a/buildSrc/src/main/groovy/bdk.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bdk.java-common-conventions.gradle
@@ -28,7 +28,9 @@ java {
 jar {
     manifest {
         attributes("Implementation-Title": project.name,
-                "Implementation-Version": project.version)
+                "Implementation-Version": project.version,
+                "Automatic-Module-Name": project.name
+        )
     }
 }
 


### PR DESCRIPTION
The byte-buddy default classloading strategy requires the access to Java internal methods, which are sealed by JPMS since Jdk11. The fix is to change the strategy from default one to UsingLookup, according to the recommendation of byte-buddy doc.

Add "Automatic-Module-Name" attribute in main MANIFEST.MF entry.

### Description
Closes #[ISSUE NUMBER]

Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced an issue in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
