### PR TITLE
Update resilience and spring boot version

### DIFF
--- a/allow-list.xml
+++ b/allow-list.xml
@@ -57,8 +57,9 @@
       <notes><![CDATA[
           No fix available
           ]]></notes>
-      <gav>org.json:json:20230227</gav>
+      <gav>org.json:json:20231013</gav>
       <cve>CVE-2022-45688</cve>
+      <cve>CVE-2023-5072</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
@@ -66,5 +67,12 @@
           ]]></notes>
         <gav>net.minidev:json-smart:2.4.8</gav>
         <cve>CVE-2023-1370</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+          No fix available
+          ]]></notes>
+        <gav>io.netty:netty-bom:4.1.101.Final</gav>
+        <cve>CVE-2023-4586</cve>
     </suppress>
 </suppressions>

--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -16,9 +16,9 @@ repositories {
 
 dependencies {
     // import Spring Boot's BOM
-    api platform('org.springframework.boot:spring-boot-dependencies:3.0.7')
+    api platform('org.springframework.boot:spring-boot-dependencies:3.0.13')
     // import Jackson's BOM
-    api platform('com.fasterxml.jackson:jackson-bom:2.15.0')
+    api platform('com.fasterxml.jackson:jackson-bom:2.15.3')
     // import Jersey's BOM
     api platform('org.glassfish.jersey:jersey-bom:3.1.2')
     // import Log4j's BOM
@@ -64,7 +64,7 @@ dependencies {
         api 'org.bouncycastle:bcpkix-jdk18on:1.74'
         api 'com.google.code.findbugs:jsr305:3.0.2'
 
-        api 'io.github.resilience4j:resilience4j-retry:1.7.1'
+        api 'io.github.resilience4j:resilience4j-retry:2.1.0'
 
         api 'io.swagger:swagger-annotations:1.6.0'
         api 'org.openapitools:jackson-databind-nullable:0.2.2'
@@ -79,7 +79,7 @@ dependencies {
         api 'org.junit.jupiter:junit-jupiter-api:5.9.2'
         api 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
         api 'com.tngtech.archunit:archunit-junit5:0.22.0'
-        api 'org.mock-server:mockserver-netty:5.14.0'
+        api 'org.mock-server:mockserver-netty:5.15.0'
         api 'org.mockito:mockito-core:4.11.0'
         api 'org.mockito:mockito-junit-jupiter:4.11.0'
         api 'org.assertj:assertj-core:3.24.2'

--- a/symphony-bdk-examples/bdk-multi-instances-example/build.gradle
+++ b/symphony-bdk-examples/bdk-multi-instances-example/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation project(':symphony-bdk-core')
     implementation 'org.slf4j:slf4j-api'
 
-    implementation 'com.hazelcast:hazelcast:5.3.0'
+    implementation 'com.hazelcast:hazelcast:5.3.6'
 
     runtimeOnly 'ch.qos.logback:logback-classic'
 }


### PR DESCRIPTION
### Description
 - Update resilience4j to latest version in order to adapt the spring boot 3.x upgrade.
 - Update spring boot to 3.0.x latest version
 - Update hazelcast and jackson-databind version

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced an issue in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
