### PR TITLE
Update health check status code strategy

### DIFF
--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/config/BdkHealthIndicatorConfig.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/main/java/com/symphony/bdk/app/spring/config/BdkHealthIndicatorConfig.java
@@ -1,11 +1,8 @@
 package com.symphony.bdk.app.spring.config;
 
 import com.symphony.bdk.app.spring.service.SymphonyBdkHealthIndicator;
-import com.symphony.bdk.app.spring.service.SymphonyBdkHealthIndicator.CustomStatusCodeMapper;
 import com.symphony.bdk.core.service.health.HealthService;
 
-import org.springframework.boot.actuate.health.HttpCodeStatusMapper;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -20,9 +17,4 @@ public class BdkHealthIndicatorConfig {
     return new SymphonyBdkHealthIndicator(healthService);
   }
 
-  @Bean
-  @ConditionalOnBean(name = "bot")
-  public HttpCodeStatusMapper customStatusCodeMapper() {
-    return new CustomStatusCodeMapper();
-  }
 }

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/config/BdkHealthIndicatorConfigTest.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/config/BdkHealthIndicatorConfigTest.java
@@ -4,7 +4,7 @@ import com.symphony.bdk.core.service.health.HealthService;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 class BdkHealthIndicatorConfigTest {
@@ -15,7 +15,5 @@ class BdkHealthIndicatorConfigTest {
     final HealthService healthService = mock(HealthService.class);
 
     assertNotNull(config.symphonyBdkHealthIndicator(healthService));
-
-    assertNotNull(config.customStatusCodeMapper());
   }
 }

--- a/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/service/SymphonyBdkHealthIndicatorTest.java
+++ b/symphony-bdk-spring/symphony-bdk-app-spring-boot-starter/src/test/java/com/symphony/bdk/app/spring/service/SymphonyBdkHealthIndicatorTest.java
@@ -1,6 +1,5 @@
 package com.symphony.bdk.app.spring.service;
 
-import com.symphony.bdk.app.spring.service.SymphonyBdkHealthIndicator.CustomStatusCodeMapper;
 import com.symphony.bdk.core.service.health.HealthService;
 import com.symphony.bdk.gen.api.model.V3Health;
 import com.symphony.bdk.gen.api.model.V3HealthComponent;
@@ -8,21 +7,19 @@ import com.symphony.bdk.gen.api.model.V3HealthStatus;
 import com.symphony.bdk.http.api.ApiException;
 import com.symphony.bdk.http.api.ApiRuntimeException;
 
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.actuate.health.Health;
-import org.springframework.boot.actuate.health.HttpCodeStatusMapper;
 import org.springframework.boot.actuate.health.Status;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,20 +31,29 @@ class SymphonyBdkHealthIndicatorTest {
   @Mock HealthService healthService;
   @InjectMocks SymphonyBdkHealthIndicator healthIndicator;
 
-  @Test
-  void doHealthCheck_successful() throws Exception {
+  @ParameterizedTest
+  @MethodSource("datafeedHealthTestArguments")
+  void doHealthCheck_datafeedStatus_expectedStatusCode(V3HealthStatus dfl, V3HealthStatus df, String globalCode) throws Exception {
     V3Health health = new V3Health();
     health.putServicesItem("pod", new V3HealthComponent().status(V3HealthStatus.UP));
-    health.putServicesItem("datafeed", new V3HealthComponent().status(V3HealthStatus.UP));
+    health.putServicesItem("datafeed", new V3HealthComponent().status(df));
     health.putServicesItem("key_manager", new V3HealthComponent().status(V3HealthStatus.UP));
     health.putUsersItem("agentservice", new V3HealthComponent().status(V3HealthStatus.UP));
     health.putUsersItem("ceservice", new V3HealthComponent().status(V3HealthStatus.UP));
     when(healthService.healthCheckExtended()).thenReturn(health);
-    when(healthService.datafeedHealthCheck()).thenReturn(V3HealthStatus.UP);
+    when(healthService.datafeedHealthCheck()).thenReturn(dfl);
     Health.Builder builder = new Health.Builder();
     healthIndicator.doHealthCheck(builder);
     Health build = builder.build();
-    assertThat(build.getStatus().getCode()).isEqualTo("UP");
+    assertThat(build.getStatus().getCode()).isEqualTo(globalCode);
+  }
+
+  private static Stream<Arguments> datafeedHealthTestArguments() {
+    return Stream.of(
+        Arguments.of(V3HealthStatus.UP, V3HealthStatus.UP, Status.UP.getCode()),
+        Arguments.of(V3HealthStatus.DOWN, V3HealthStatus.UP, Status.OUT_OF_SERVICE.getCode()),
+        Arguments.of(V3HealthStatus.UP, V3HealthStatus.DOWN, "WARNING")
+    );
   }
 
   @Test
@@ -78,7 +84,7 @@ class SymphonyBdkHealthIndicatorTest {
             + "      \"message\": \"Ceservice authentication credentials missing or misconfigured\"\n" + "    }\n"
             + "  }\n" + "}";
 
-    doThrow(new ApiRuntimeException(new ApiException(503, "message", Collections.EMPTY_MAP, body))).when(healthService)
+    doThrow(new ApiRuntimeException(new ApiException(503, "message", Map.of(), body))).when(healthService)
         .healthCheckExtended();
     when(healthService.datafeedHealthCheck()).thenReturn(V3HealthStatus.UP);
     Health.Builder builder = new Health.Builder();
@@ -92,7 +98,7 @@ class SymphonyBdkHealthIndicatorTest {
     final String body = "<html>\n" + "<head><title>502 Bad Gateway</title></head>\n" + "<body>\n"
         + "<center><h1>502 Bad Gateway</h1></center>\n" + "</body>\n" + "</html>";
 
-    doThrow(new ApiRuntimeException(new ApiException(502, "message", Collections.EMPTY_MAP, body))).when(healthService)
+    doThrow(new ApiRuntimeException(new ApiException(502, "message", Map.of(), body))).when(healthService)
         .healthCheckExtended();
     Health.Builder builder = new Health.Builder();
     healthIndicator.doHealthCheck(builder);
@@ -100,24 +106,4 @@ class SymphonyBdkHealthIndicatorTest {
     assertThat(build.getStatus().getCode()).isEqualTo("DOWN");
   }
 
-  @Nested
-  class CustomStatusCodeMapperTest {
-
-    HttpCodeStatusMapper mapper = new CustomStatusCodeMapper();
-
-    @ParameterizedTest
-    @MethodSource("getStatusArguments")
-    void getStatusCode_status_code(Status status, int code) {
-      assertThat(mapper.getStatusCode(status)).isEqualTo(code);
-    }
-
-    private static Stream<Arguments> getStatusArguments() {
-      return Stream.of(
-          Arguments.of(Status.UP, 200),
-          Arguments.of(Status.DOWN, 500),
-          Arguments.of(new Status("WARNING"), 500),
-          Arguments.of(Status.OUT_OF_SERVICE, 503),
-          Arguments.of(Status.UNKNOWN, 500));
-    }
-  }
 }


### PR DESCRIPTION
Separate DataFeedLoop health check from the other components, set the global status to out of service only if DataFeedLoop is down. In this case, when calling health check endpoint, the response http code is 503, otherwise if any other components is down, set the global status to "WARNING", the http code of the response stays as 200.

This will avoid unnecessary BDK Bot restarting when other components are not healthy.

Remove the custom status code mapper, and use the default mapping behaviour of Spring Boot.

### Description
Closes #[ISSUE NUMBER]

Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced an issue in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
