### PR TITLE
Downgrade JJWT library version

### DIFF
--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     // import Spring Boot's BOM
-    api platform('org.springframework.boot:spring-boot-dependencies:3.2.2')
+    api platform('org.springframework.boot:spring-boot-dependencies:3.2.3')
     // import Jackson's BOM
     api platform('com.fasterxml.jackson:jackson-bom:2.16.0')
     // import Jersey's BOM

--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -55,7 +55,7 @@ dependencies {
         api 'org.apache.commons:commons-text:1.11.0'
         api 'commons-logging:commons-logging:1.3.0'
         api 'com.brsanthu:migbase64:2.2'
-        api 'io.jsonwebtoken:jjwt:0.12.3'
+        api 'io.jsonwebtoken:jjwt:0.9.1'
         api 'org.bouncycastle:bcpkix-jdk18on:1.77'
         api 'com.google.code.findbugs:jsr305:3.0.2'
 

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/jwt/JwtHelper.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/auth/jwt/JwtHelper.java
@@ -117,8 +117,8 @@ public class JwtHelper {
     final Certificate x509Certificate = parseX509Certificate(certificate);
 
     try {
-      final Claims body = Jwts.parser().verifyWith(x509Certificate.getPublicKey())
-          .build().parseSignedClaims(jwt).getPayload();
+      final Claims body = Jwts.parser().setSigningKey(x509Certificate.getPublicKey())
+        .parseClaimsJws(jwt).getBody();
       return mapper.convertValue(body.get("user"), UserClaim.class);
     } catch (JwtException e) {
       throw new AuthInitializationException("Unable to validate JWT", e);


### PR DESCRIPTION
### Description
We are downgrading the JJWT library to 0.9.1 to prevent JWT validation failure.
The latest JJWT library is enforcing the "sub" claim to be "string" data format (which is according to the RFC standard). This check makes the validation of the extension application JWT to fail because the "sub" claim is of long data type, equal to the Symphony user id. 
This check is not enforced in the JJWT 0.9.1 library version thus we are using that version.

Additionally:
- fix https://spring.io/security/cve-2024-22243

### Dependencies
none

### Checklist
- [ ] Referenced an issue in the PR title or description
- [x] Filled properly the description and dependencies, if any
- [x] Unit/Integration tests updated or added
- [x] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
