### PR TITLE
Add update message in OboMessageService

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/MessageService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/MessageService.java
@@ -306,6 +306,7 @@ public class MessageService implements OboMessageService, OboService<OboMessageS
    * @return a {@link V4Message} object containing the details of the sent message
    * @see <a href="https://developers.symphony.com/restapi/reference#update-message-v4">Create Update v4</a>
    */
+  @Override
   @API(status = API.Status.EXPERIMENTAL)
   public V4Message update(@Nonnull V4Message messageToUpdate, @Nonnull Message content) {
     return this.update(messageToUpdate.getStream().getStreamId(), messageToUpdate.getMessageId(), content);
@@ -320,6 +321,7 @@ public class MessageService implements OboMessageService, OboService<OboMessageS
    * @return a {@link V4Message} object containing the details of the sent message
    * @see <a href="https://developers.symphony.com/restapi/reference#update-message-v4">Create Update v4</a>
    */
+  @Override
   @API(status = API.Status.EXPERIMENTAL)
   public V4Message update(@Nonnull String streamId, @Nonnull String messageId, @Nonnull Message content) {
     return this.executeAndRetry("update", messagesApi.getApiClient().getBasePath(), () ->  {

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/OboMessageService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/OboMessageService.java
@@ -69,6 +69,27 @@ public interface OboMessageService {
   V4Message send(@Nonnull String streamId, @Nonnull Message message);
 
   /**
+   * Update an existing message. The existing message must be a valid social message, that has not been deleted.
+   *
+   * @param messageToUpdate the message to be updated
+   * @param content the update content (attachments are not supported yet)
+   * @return a {@link V4Message} object containing the details of the sent message
+   * @see <a href="https://developers.symphony.com/restapi/reference#update-message-v4">Create Update v4</a>
+   */
+  V4Message update(@Nonnull V4Message messageToUpdate, @Nonnull Message content);
+
+  /**
+   * Update an existing message. The existing message must be a valid social message, that has not been deleted.
+   *
+   * @param streamId the ID of the stream where the message to be updated comes from
+   * @param messageId the ID of the message to be updated
+   * @param content the update content (attachments are not supported yet)
+   * @return a {@link V4Message} object containing the details of the sent message
+   * @see <a href="https://developers.symphony.com/restapi/reference#update-message-v4">Create Update v4</a>
+   */
+  V4Message update(@Nonnull String streamId, @Nonnull String messageId, @Nonnull Message content);
+
+  /**
    * Suppresses a users message based on the messageID pass in parameter.
    *
    * @param messageId   the ID of the message to suppress


### PR DESCRIPTION
This commit updates the OboMessageService so that a BDK bot can update a message on behalf of someone (along with OBO message send and OBO message delete).