### PR TITLE
Legacy 1.3.9

### DIFF
--- a/symphony-api-client-java/src/main/java/model/AdminNewUser.java
+++ b/symphony-api-client-java/src/main/java/model/AdminNewUser.java
@@ -1,7 +1,10 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AdminNewUser {
 
     private AdminUserAttributes userAttributes;

--- a/symphony-api-client-java/src/main/java/model/AdminStreamFilter.java
+++ b/symphony-api-client-java/src/main/java/model/AdminStreamFilter.java
@@ -1,7 +1,10 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AdminStreamFilter {
 
     private List<String> streamTypes;

--- a/symphony-api-client-java/src/main/java/model/AdminUserInfoList.java
+++ b/symphony-api-client-java/src/main/java/model/AdminUserInfoList.java
@@ -1,6 +1,9 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.ArrayList;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AdminUserInfoList extends ArrayList<AdminUserInfo> {
 }

--- a/symphony-api-client-java/src/main/java/model/AppAuthResponse.java
+++ b/symphony-api-client-java/src/main/java/model/AppAuthResponse.java
@@ -1,5 +1,8 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AppAuthResponse {
     private String appToken;
     private String symphonyToken;

--- a/symphony-api-client-java/src/main/java/model/Application.java
+++ b/symphony-api-client-java/src/main/java/model/Application.java
@@ -1,7 +1,10 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Application {
 
     private ApplicationInfo applicationInfo;

--- a/symphony-api-client-java/src/main/java/model/ApplicationEntitlementList.java
+++ b/symphony-api-client-java/src/main/java/model/ApplicationEntitlementList.java
@@ -1,6 +1,9 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.ArrayList;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ApplicationEntitlementList extends ArrayList<ApplicationEntitlement> {
 }

--- a/symphony-api-client-java/src/main/java/model/ApplicationInfo.java
+++ b/symphony-api-client-java/src/main/java/model/ApplicationInfo.java
@@ -1,5 +1,8 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ApplicationInfo {
 
     private String appId;

--- a/symphony-api-client-java/src/main/java/model/ApplicationProduct.java
+++ b/symphony-api-client-java/src/main/java/model/ApplicationProduct.java
@@ -1,5 +1,8 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ApplicationProduct {
 
     private String appId;

--- a/symphony-api-client-java/src/main/java/model/AvatarList.java
+++ b/symphony-api-client-java/src/main/java/model/AvatarList.java
@@ -1,6 +1,9 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.ArrayList;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AvatarList extends ArrayList<Avatar> {
 }

--- a/symphony-api-client-java/src/main/java/model/DropdownMenuOption.java
+++ b/symphony-api-client-java/src/main/java/model/DropdownMenuOption.java
@@ -1,5 +1,8 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DropdownMenuOption {
     private String value;
     private String display;

--- a/symphony-api-client-java/src/main/java/model/FeatureEntitlement.java
+++ b/symphony-api-client-java/src/main/java/model/FeatureEntitlement.java
@@ -1,5 +1,8 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class FeatureEntitlement {
 
     private String entitlment;

--- a/symphony-api-client-java/src/main/java/model/FeatureEntitlementList.java
+++ b/symphony-api-client-java/src/main/java/model/FeatureEntitlementList.java
@@ -1,6 +1,9 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.ArrayList;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class FeatureEntitlementList extends ArrayList<FeatureEntitlement> {
 }

--- a/symphony-api-client-java/src/main/java/model/InboundImportMessage.java
+++ b/symphony-api-client-java/src/main/java/model/InboundImportMessage.java
@@ -1,5 +1,8 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class InboundImportMessage {
 
     private String messageId;

--- a/symphony-api-client-java/src/main/java/model/InboundImportMessageList.java
+++ b/symphony-api-client-java/src/main/java/model/InboundImportMessageList.java
@@ -1,6 +1,9 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.ArrayList;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class InboundImportMessageList extends ArrayList<InboundImportMessage> {
 }

--- a/symphony-api-client-java/src/main/java/model/InboundMessageList.java
+++ b/symphony-api-client-java/src/main/java/model/InboundMessageList.java
@@ -1,6 +1,9 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.ArrayList;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class InboundMessageList extends ArrayList<InboundMessage> {
 }

--- a/symphony-api-client-java/src/main/java/model/MemberList.java
+++ b/symphony-api-client-java/src/main/java/model/MemberList.java
@@ -1,6 +1,9 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.ArrayList;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class MemberList extends ArrayList<RoomMember> {
 }

--- a/symphony-api-client-java/src/main/java/model/OutboundImportMessage.java
+++ b/symphony-api-client-java/src/main/java/model/OutboundImportMessage.java
@@ -1,5 +1,8 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class OutboundImportMessage {
     private String message;
     private String data;

--- a/symphony-api-client-java/src/main/java/model/OutboundImportMessageList.java
+++ b/symphony-api-client-java/src/main/java/model/OutboundImportMessageList.java
@@ -1,6 +1,9 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.ArrayList;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class OutboundImportMessageList extends ArrayList<OutboundImportMessage> {
 }

--- a/symphony-api-client-java/src/main/java/model/OutboundShare.java
+++ b/symphony-api-client-java/src/main/java/model/OutboundShare.java
@@ -1,5 +1,8 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class OutboundShare {
 
     private String articleId;

--- a/symphony-api-client-java/src/main/java/model/Password.java
+++ b/symphony-api-client-java/src/main/java/model/Password.java
@@ -1,5 +1,8 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Password {
     private String hhSalt;
     private String hhPassword;

--- a/symphony-api-client-java/src/main/java/model/PodCert.java
+++ b/symphony-api-client-java/src/main/java/model/PodCert.java
@@ -1,5 +1,8 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PodCert {
     String certificate;
 

--- a/symphony-api-client-java/src/main/java/model/SessionToken.java
+++ b/symphony-api-client-java/src/main/java/model/SessionToken.java
@@ -1,5 +1,8 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SessionToken {
     private String sessionToken;
 

--- a/symphony-api-client-java/src/main/java/model/SignalList.java
+++ b/symphony-api-client-java/src/main/java/model/SignalList.java
@@ -1,6 +1,9 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.ArrayList;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SignalList extends ArrayList<Signal> {
 }

--- a/symphony-api-client-java/src/main/java/model/SignalSubscriber.java
+++ b/symphony-api-client-java/src/main/java/model/SignalSubscriber.java
@@ -1,5 +1,8 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SignalSubscriber {
 
     private boolean pushed;

--- a/symphony-api-client-java/src/main/java/model/SignalSubscriberList.java
+++ b/symphony-api-client-java/src/main/java/model/SignalSubscriberList.java
@@ -1,7 +1,10 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SignalSubscriberList {
 
     private int offset;

--- a/symphony-api-client-java/src/main/java/model/Status.java
+++ b/symphony-api-client-java/src/main/java/model/Status.java
@@ -1,5 +1,8 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Status {
     private String status;
 

--- a/symphony-api-client-java/src/main/java/model/Stream.java
+++ b/symphony-api-client-java/src/main/java/model/Stream.java
@@ -12,6 +12,7 @@ public class Stream {
     private List<User> members;
     private Boolean external;
     private Boolean crossPod;
+    private List<Integer> recipientTenantIds;
 
     public String getStreamId() {
         return streamId;
@@ -59,5 +60,13 @@ public class Stream {
 
     public void setCrossPod(Boolean crossPod) {
         this.crossPod = crossPod;
+    }
+
+    public List<Integer> getRecipientTenantIds() {
+      return recipientTenantIds;
+    }
+
+    public void setRecipientTenantIds(List<Integer> recipientTenantIds) {
+      this.recipientTenantIds = recipientTenantIds;
     }
 }

--- a/symphony-api-client-java/src/main/java/model/StreamInfoList.java
+++ b/symphony-api-client-java/src/main/java/model/StreamInfoList.java
@@ -1,6 +1,9 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.ArrayList;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamInfoList extends ArrayList<StreamListItem> {
 }

--- a/symphony-api-client-java/src/main/java/model/UserFilter.java
+++ b/symphony-api-client-java/src/main/java/model/UserFilter.java
@@ -1,5 +1,8 @@
 package model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class UserFilter {
 
     private String title;

--- a/symphony-api-client-java/src/main/java/model/datafeed/DatafeedV2.java
+++ b/symphony-api-client-java/src/main/java/model/datafeed/DatafeedV2.java
@@ -2,11 +2,12 @@ package model.datafeed;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-@JsonIgnoreProperties()
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DatafeedV2 {
 
     private String id;
     private Long createdAt;
+    private String type;
 
     public String getId() {
         return id;
@@ -22,5 +23,13 @@ public class DatafeedV2 {
 
     public void setCreatedAt(Long createdAt) {
         this.createdAt = createdAt;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public void setType(String type) {
+      this.type = type;
     }
 }

--- a/symphony-api-client-java/src/main/java/model/events/AdminStreamInfoList.java
+++ b/symphony-api-client-java/src/main/java/model/events/AdminStreamInfoList.java
@@ -1,9 +1,12 @@
 package model.events;
 
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import model.AdminStreamFilter;
 import model.AdminStreamInfo;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AdminStreamInfoList {
 
     private int count;

--- a/symphony-api-client-java/src/main/java/model/events/SymphonyElementsAction.java
+++ b/symphony-api-client-java/src/main/java/model/events/SymphonyElementsAction.java
@@ -1,19 +1,21 @@
 package model.events;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import model.Stream;
+
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SymphonyElementsAction {
     private Map<String, String> formStream;
-    private Map<String, String> stream;
+    private Stream stream;
     private String formId;
     private Map<String, Object> formValues;
     private String formMessageId;
 
     public String getStreamId() {
-        if (stream != null && stream.get("streamId") != null) {
-            return stream.get("streamId");
+        if (stream != null && stream.getStreamId() != null) {
+            return stream.getStreamId();
         }
         if (formStream != null && formStream.get("streamId") != null) {
             return formStream.get("streamId")
@@ -25,17 +27,14 @@ public class SymphonyElementsAction {
     }
 
     public String getStreamType() {
-        if (stream != null && stream.get("streamType") != null) {
-            return stream.get("streamType");
-        }
-        return null;
+        return stream.getStreamType();
     }
 
     public void setFormStream(Map<String, String> formStream) {
         this.formStream = formStream;
     }
 
-    public void setStream(Map<String, String> stream) {
+    public void setStream(Stream stream) {
         this.stream = stream;
     }
 

--- a/symphony-bdk-bot-sdk-java/src/main/java/com/symphony/bdk/bot/sdk/event/model/StreamDetails.java
+++ b/symphony-bdk-bot-sdk-java/src/main/java/com/symphony/bdk/bot/sdk/event/model/StreamDetails.java
@@ -24,6 +24,7 @@ public class StreamDetails {
   private List<UserDetails> members;
   private Boolean external;
   private Boolean crossPod;
+  private List<Integer> recipientTenantIds;
 
   public StreamDetails(Stream stream) {
     this.streamType = StreamType.value(stream.getStreamType().toUpperCase());
@@ -32,6 +33,7 @@ public class StreamDetails {
         : stream.getMembers().stream().map(UserDetails::new).collect(Collectors.toList());
     this.external = stream.getExternal();
     this.crossPod = stream.getCrossPod();
+    this.recipientTenantIds = stream.getRecipientTenantIds();
   }
 
 }


### PR DESCRIPTION
Agent 24.2 added a new property recipientTenantIds. This broke SymphonyElementsAction as it had stream object mapped to a Map of Strings instead of the Stream object and recipientTenantIds is an array of Integers.

- Changed Stream mapping from Map of Strings to Stream Object in SymphonyElementsAction
- Added recipientTenantIds to Stream object

DatafeedV2 had JsonIgnoreProperties incorrectly defined causing DF2 to be unusable as there is a type property.

- Added type property
- Fixed JsonIgnoreProperties

As Legacy SDK is deprecated any addition of properties could break it. Added JsonIgnoreProperties to remaining model classes that do not have it already set.