### PR TITLE
EIS-5326: Teams - on-prem - Failed to start app

### DIFF
--- a/buildSrc/src/main/groovy/bdk.java-codegen-conventions.gradle
+++ b/buildSrc/src/main/groovy/bdk.java-codegen-conventions.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation 'javax.annotation:jsr250-api:1.0'
+    implementation 'jakarta.annotation:jakarta.annotation-api:3.0.0'
     implementation 'io.swagger:swagger-annotations'
     implementation 'com.google.code.findbugs:jsr305'
 }
@@ -32,6 +32,9 @@ openApiGenerate {
             supportingFiles: "false"
     ]
     configOptions = [
-            dateLibrary: "java8"
+            dateLibrary: "java8",
+            useSpringBoot3: "true",
+            useJakartaEe: "true",
+            annotationLibrary: "swagger1"
     ]
 }

--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     // import Jackson's BOM
     api platform('com.fasterxml.jackson:jackson-bom:2.16.0')
     // import Jersey's BOM
-    api platform('org.glassfish.jersey:jersey-bom:3.1.5')
+    api platform('org.glassfish.jersey:jersey-bom:4.0.0-M1')
     // import Log4j's BOM
     api platform('org.apache.logging.log4j:log4j-bom:2.22.0')
 

--- a/symphony-bdk-core/build.gradle
+++ b/symphony-bdk-core/build.gradle
@@ -53,8 +53,7 @@ dependencies {
     implementation 'io.github.resilience4j:resilience4j-retry'
     implementation 'io.swagger:swagger-annotations'
     implementation 'com.google.code.findbugs:jsr305'
-    implementation 'javax.annotation:jsr250-api:1.0'
-    implementation 'javax.xml.bind:jaxb-api:2.3.1'
+    implementation 'jakarta.annotation:jakarta.annotation-api:3.0.0'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api'
 
     testImplementation project(':symphony-bdk-http:symphony-bdk-http-jersey2')
@@ -116,7 +115,10 @@ apisToGenerate.each { api, path ->
                 supportingFiles: "false"
         ]
         configOptions = [
-                dateLibrary: "java8"
+                dateLibrary: "java8",
+                useSpringBoot3: "true",
+                useJakartaEe: "true",
+                annotationLibrary: "swagger1"
         ]
     }
 


### PR DESCRIPTION
### Description
Closes #[EIS-5326]
Teams when test on prem failed to start. Reason is due to conflict version between teams vers 2.0.0 and bdk

update pom dependencies version
javax -> jakarta
jersey-bom:3.1.5 -> 4.0.0-M1
add  configOption :
 - useSpringBoot3: "true",
 - useJakartaEe: "true",
 - annotationLibrary: "swagger1"


### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [x ] Referenced an issue in the PR title or description
- [x ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
