### PR TITLE
AGNT-598: support GENERICSYSTEMEVENTs in listeners

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/RealTimeEventListener.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/RealTimeEventListener.java
@@ -208,4 +208,15 @@ public interface RealTimeEventListener {
   default void onSymphonyElementsAction(V4Initiator initiator, V4SymphonyElementsAction event) throws EventException {
   }
 
+  /**
+   * Called when a GENERICSYSTEMEVENT event is received.
+   *
+   * @param initiator Event initiator.
+   * @param event     Generic system event payload.
+   * @throws EventException Throw this exception if this method should fail the current events processing
+   *                        and re-queue the events in datafeed. Other exceptions will be caught silently.
+   */
+  default void onGenericSystemEvent(V4Initiator initiator, V4GenericSystemEvent event) throws EventException {
+  }
+
 }

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/RealTimeEventType.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/RealTimeEventType.java
@@ -80,7 +80,11 @@ enum RealTimeEventType {
   }),
   CONNECTIONREQUESTED((listener, event) -> {
     listener.onConnectionRequested(event.getInitiator(), proxy(event.getPayload().getConnectionRequested(), event));
+  }),
+  GENERICSYSTEMEVENT((listener, event) -> {
+    listener.onGenericSystemEvent(event.getInitiator(), proxy(event.getPayload().getGenericSystemEvent(), event));
   });
+
 
   private final BiConsumer<RealTimeEventListener, V4Event> execConsumer;
 

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV1Test.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV1Test.java
@@ -18,6 +18,7 @@ import com.symphony.bdk.gen.api.model.UserV2;
 import com.symphony.bdk.gen.api.model.V4ConnectionAccepted;
 import com.symphony.bdk.gen.api.model.V4ConnectionRequested;
 import com.symphony.bdk.gen.api.model.V4Event;
+import com.symphony.bdk.gen.api.model.V4GenericSystemEvent;
 import com.symphony.bdk.gen.api.model.V4Initiator;
 import com.symphony.bdk.gen.api.model.V4InstantMessageCreated;
 import com.symphony.bdk.gen.api.model.V4MessageSent;
@@ -469,7 +470,8 @@ class DatafeedLoopV1Test {
         .roomMemberPromotedToOwner(new V4RoomMemberPromotedToOwner())
         .userLeftRoom(new V4UserLeftRoom())
         .userJoinedRoom(new V4UserJoinedRoom())
-        .userRequestedToJoinRoom(new V4UserRequestedToJoinRoom());
+        .userRequestedToJoinRoom(new V4UserRequestedToJoinRoom())
+        .genericSystemEvent(new V4GenericSystemEvent());
 
     final V4Initiator initiator = new V4Initiator().user(new V4User().username("username").userId(123456789L));
     for (RealTimeEventType type : types) {
@@ -516,5 +518,6 @@ class DatafeedLoopV1Test {
     verify(spiedListener).onUserLeftRoom(eq(initiator), any(V4UserLeftRoom.class));
     verify(spiedListener).onUserJoinedRoom(eq(initiator), any(V4UserJoinedRoom.class));
     verify(spiedListener).onUserRequestedToJoinRoom(eq(initiator), any(V4UserRequestedToJoinRoom.class));
+    verify(spiedListener).onGenericSystemEvent(eq(initiator), any(V4GenericSystemEvent.class));
   }
 }

--- a/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/events/RealTimeEventsDispatcher.java
+++ b/symphony-bdk-spring/symphony-bdk-core-spring-boot-starter/src/main/java/com/symphony/bdk/spring/events/RealTimeEventsDispatcher.java
@@ -4,6 +4,7 @@ import com.symphony.bdk.core.service.datafeed.DatafeedLoop;
 import com.symphony.bdk.core.service.datafeed.RealTimeEventListener;
 import com.symphony.bdk.gen.api.model.V4ConnectionAccepted;
 import com.symphony.bdk.gen.api.model.V4ConnectionRequested;
+import com.symphony.bdk.gen.api.model.V4GenericSystemEvent;
 import com.symphony.bdk.gen.api.model.V4Initiator;
 import com.symphony.bdk.gen.api.model.V4InstantMessageCreated;
 import com.symphony.bdk.gen.api.model.V4MessageSent;
@@ -150,4 +151,10 @@ public class RealTimeEventsDispatcher implements RealTimeEventListener {
   public void onSymphonyElementsAction(V4Initiator initiator, V4SymphonyElementsAction event) {
     this.publisher.publishEvent(new RealTimeEvent<>(initiator, event));
   }
+
+  @Override
+  public void onGenericSystemEvent(V4Initiator initiator, V4GenericSystemEvent event) {
+    this.publisher.publishEvent(new RealTimeEvent<>(initiator, event));
+  }
+
 }

--- a/symphony-bdk-test/symphony-bdk-test-jupiter/src/main/java/com/symphony/bdk/test/SymphonyBdkTestUtils.java
+++ b/symphony-bdk-test/symphony-bdk-test-jupiter/src/main/java/com/symphony/bdk/test/SymphonyBdkTestUtils.java
@@ -202,6 +202,11 @@ public class SymphonyBdkTestUtils {
       assert event.getPayload() != null;
       assert event.getPayload().getConnectionRequested() != null : "ConnectionRequested event must not null";
       listener.onConnectionRequested(event.getInitiator(), proxy(event.getPayload().getConnectionRequested(), event));
+    }),
+    GENERICSYSTEMEVENT((listener, event) -> {
+      assert event.getPayload() != null;
+      assert event.getPayload().getGenericSystemEvent() != null : "GenericSystemEvent event must not null";
+      listener.onGenericSystemEvent(event.getInitiator(), proxy(event.getPayload().getGenericSystemEvent(), event));
     });
 
     private final BiConsumer<RealTimeEventListener, V4Event> execConsumer;


### PR DESCRIPTION
### Description
Starting with Agent 24.6.1, a new type of event called `GENERICSYSTEMEVENT` may be received via datafeed.
Goal of this change is to support them in Spring event listener to ease their consumption.

### Dependencies
None
