### PR TITLE
Set spring boot 3.3.6

### DIFF
--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -16,13 +16,13 @@ repositories {
 
 dependencies {
     // import Spring Boot's BOM
-    api platform('org.springframework.boot:spring-boot-dependencies:3.3.4')
+    api platform('org.springframework.boot:spring-boot-dependencies:3.3.6')
     // import Jackson's BOM
-    api platform('com.fasterxml.jackson:jackson-bom:2.18.0')
+    api platform('com.fasterxml.jackson:jackson-bom:2.18.2')
     // import Jersey's BOM
     api platform('org.glassfish.jersey:jersey-bom:3.1.9')
     // import Log4j's BOM
-    api platform('org.apache.logging.log4j:log4j-bom:2.24.1')
+    api platform('org.apache.logging.log4j:log4j-bom:2.24.2')
 
     // define all our dependencies versions
     constraints {
@@ -48,7 +48,7 @@ dependencies {
         api 'org.slf4j:slf4j-api:2.0.9'
         api 'org.slf4j:slf4j-log4j12:2.0.9'
 
-        api 'commons-io:commons-io:2.17.0'
+        api 'commons-io:commons-io:2.18.0'
         api 'commons-codec:commons-codec:1.17.1'
         api 'commons-beanutils:commons-beanutils:1.9.4'
         api 'org.apache.commons:commons-lang3:3.17.0'
@@ -56,12 +56,12 @@ dependencies {
         api 'commons-logging:commons-logging:1.3.4'
         api 'com.brsanthu:migbase64:2.2'
         api 'io.jsonwebtoken:jjwt:0.9.1'
-        api 'org.bouncycastle:bcpkix-jdk18on:1.78'
+        api 'org.bouncycastle:bcpkix-jdk18on:1.79'
         api 'com.google.code.findbugs:jsr305:3.0.2'
 
         api 'io.github.resilience4j:resilience4j-retry:2.2.0'
 
-        api 'io.swagger:swagger-annotations:1.6.12'
+        api 'io.swagger:swagger-annotations:1.6.14'
         api 'org.openapitools:jackson-databind-nullable:0.2.6'
 
         api 'org.projectreactor:reactor-spring:1.0.1.RELEASE'


### PR DESCRIPTION
- cherry pick security vulnerabilities for release 3.0.5 c5d2e886d6a3464d29e99a9697450dc9d43f1d69
- preparation for release 3.1.0