### PR TITLE
upgrade spring boot from 3.3.6 to 3.3.7 to fix vulnerability

### DIFF
--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     // import Spring Boot's BOM
-    api platform('org.springframework.boot:spring-boot-dependencies:3.3.6')
+    api platform('org.springframework.boot:spring-boot-dependencies:3.3.7')
     // import Jackson's BOM
     api platform('com.fasterxml.jackson:jackson-bom:2.18.2')
     // import Jersey's BOM


### PR DESCRIPTION
### Description
Upgrade spring-book-starter-tomcat from 3.3.6 to 3.3.7 to fix https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHETOMCATEMBED-8523186
