### PR TITLE
SEARCH-3102 : introduces semantic search support

### DIFF
--- a/allow-list.xml
+++ b/allow-list.xml
@@ -48,4 +48,29 @@
         <vulnerabilityName>GHSA-7rx3-28cr-v5wh</vulnerabilityName>
         <vulnerabilityName>GHSA-442j-39wm-28r2</vulnerabilityName>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+          CVE-2026-53914 is an unsafe-deserialization flaw in the Kotlin *compiler's* build-cache
+          metadata (a build-time tool), not in the kotlin-stdlib runtime jar. The NVD CPE
+          (jetbrains:kotlin) over-matches every kotlin artifact; we only ship kotlin-stdlib
+          transitively from Spring Boot (1.9.25) at runtime, and do not run the Kotlin compiler.
+          The stated fix version (2.4.20) is not published on Maven Central, so no override is
+          possible. Same CPE-over-match class as the CVE-2020-29582 suppression above.
+          ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-stdlib(-jdk7|-jdk8|-common)?@.*$</packageUrl>
+        <cve>CVE-2026-53914</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+          CVE-2026-54515 (case-insensitive deserialization reopening @JsonIgnoreProperties).
+          Spring Boot 3.5.16 pins the Jackson 2.x platform at 2.21.4. The advisory's 2.x fixes
+          (2.21.5 and 2.18.9) are NOT yet published on Maven Central (both return "Could not find"),
+          so the com.fasterxml.jackson.core 2.x line has no available patch. The only released fix
+          is 3.1.4 under the relocated tools.jackson.core coordinates (Jackson 3.x), which is a
+          breaking major migration, not a drop-in bump. Suppressing pending an upstream 2.x release
+          (2.21.5) or a Spring Boot upgrade that ships it.
+          ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-databind@.*$</packageUrl>
+        <cve>CVE-2026-54515</cve>
+    </suppress>
 </suppressions>

--- a/allow-list.xml
+++ b/allow-list.xml
@@ -73,4 +73,19 @@
         <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-databind@.*$</packageUrl>
         <cve>CVE-2026-54515</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+          False positive (CPE over-match). CVE-2026-54399 is a DoS in the HttpComponents Core *5.x*
+          HTTP/1.1 message parser (vendor-affected: httpcore5 <= 5.4.2 and 5.5-beta1; reports are all
+          against org.apache.httpcomponents.core5:httpcore5 5.3.x). Our jar is the separate, EOL 4.x
+          codebase org.apache.httpcomponents:httpcore 4.4.16 (transitive via
+          jersey-apache-connector -> httpclient 4.5.14), which has a different parser and is not in
+          the affected range. NVD's apache:httpcomponents_core CPE does not split the 4.x/5.x lines,
+          so dependency-check matches 4.4.16 against a 5.x-only CVE. 4.4.16 is the final 4.x release,
+          so there is no 4.x fix version. A genuine 5.x hit would carry the httpcore5 coordinates and
+          is not affected by this suppression.
+          ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents/httpcore@.*$</packageUrl>
+        <cve>CVE-2026-54399</cve>
+    </suppress>
 </suppressions>

--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -16,11 +16,11 @@ repositories {
 
 dependencies {
     // import Spring Boot's BOM
-    api platform('org.springframework.boot:spring-boot-dependencies:3.5.15')
+    api platform('org.springframework.boot:spring-boot-dependencies:3.5.16')
     // import Jackson's BOM
-    api platform('com.fasterxml.jackson:jackson-bom:2.18.2')
+    api platform('com.fasterxml.jackson:jackson-bom:2.18.8')
     // import Jersey's BOM
-    api platform('org.glassfish.jersey:jersey-bom:3.1.9')
+    api platform('org.glassfish.jersey:jersey-bom:3.1.12')
     // import Log4j's BOM
     api platform('org.apache.logging.log4j:log4j-bom:2.26.0')
 

--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -43,6 +43,13 @@ dependencies {
 
         // External dependencies
 
+        // Security override: Spring Boot 3.5.16 pins Tomcat 10.1.55, vulnerable to
+        // CVE-2026-53434, CVE-2026-55276, CVE-2026-53404, CVE-2026-55955, CVE-2026-55956,
+        // CVE-2026-50229 — all fixed in 10.1.56. This higher constraint wins conflict resolution.
+        api 'org.apache.tomcat.embed:tomcat-embed-core:10.1.56'
+        api 'org.apache.tomcat.embed:tomcat-embed-websocket:10.1.56'
+        api 'org.apache.tomcat.embed:tomcat-embed-el:10.1.56'
+
         api 'org.apiguardian:apiguardian-api:1.1.2'
 
         api 'org.slf4j:slf4j-api:2.0.9'

--- a/symphony-bdk-core/build.gradle
+++ b/symphony-bdk-core/build.gradle
@@ -78,7 +78,7 @@ dependencies {
 }
 
 // OpenAPI code generation
-def apiBaseUrl = "https://raw.githubusercontent.com/finos/symphony-api-spec/d369d95254d6df3451d053340b1b25478b95e57b"
+def apiBaseUrl = "https://raw.githubusercontent.com/sebastientosello/symphony-api-spec/ad6ca08cf383e75761aa453c34b4a08d16c933ac"
 def generatedFolder = "$buildDir/generated/openapi"
 def apisToGenerate = [
         Agent: 'agent/agent-api-public-deprecated.yaml',

--- a/symphony-bdk-core/build.gradle
+++ b/symphony-bdk-core/build.gradle
@@ -78,7 +78,7 @@ dependencies {
 }
 
 // OpenAPI code generation
-def apiBaseUrl = "https://raw.githubusercontent.com/sebastientosello/symphony-api-spec/ad6ca08cf383e75761aa453c34b4a08d16c933ac"
+def apiBaseUrl = "https://raw.githubusercontent.com/finos/symphony-api-spec/baf01bee3bd00612d57d2df481ea54aab9404017"
 def generatedFolder = "$buildDir/generated/openapi"
 def apisToGenerate = [
         Agent: 'agent/agent-api-public-deprecated.yaml',

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/MessageService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/MessageService.java
@@ -27,6 +27,7 @@ import com.symphony.bdk.gen.api.model.MessageReceiptDetailResponse;
 import com.symphony.bdk.gen.api.model.MessageSearchQuery;
 import com.symphony.bdk.gen.api.model.MessageStatus;
 import com.symphony.bdk.gen.api.model.MessageSuppressionResponse;
+import com.symphony.bdk.gen.api.model.SemanticSearchQuery;
 import com.symphony.bdk.gen.api.model.StreamAttachmentItem;
 import com.symphony.bdk.gen.api.model.V4ImportResponse;
 import com.symphony.bdk.gen.api.model.V4ImportedMessage;
@@ -262,6 +263,38 @@ public class MessageService implements OboMessageService, OboService<OboMessageS
     if (query.getText() != null && query.getStreamId() == null) {
       throw new IllegalArgumentException("Message text queries require a streamId to be provided.");
     }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public List<V4Message> searchMessagesSemantic(@Nonnull String query) {
+    return searchMessagesSemantic(query, null, null);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public List<V4Message> searchMessagesSemantic(@Nonnull String query, @Nullable PaginationAttribute pagination) {
+    return searchMessagesSemantic(query, null, pagination);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public List<V4Message> searchMessagesSemantic(@Nonnull String query, @Nullable String streamId,
+      @Nullable PaginationAttribute pagination) {
+    final SemanticSearchQuery searchQuery = new SemanticSearchQuery()
+        .text(query)
+        .threadId(streamId != null ? toUrlSafeIdIfNeeded(streamId) : null);
+    return executeAndRetry("searchMessagesSemantic", messagesApi.getApiClient().getBasePath(),
+        () -> messagesApi.v4MessageSearchSemanticPost(
+            pagination != null ? pagination.getSkip() : null,
+            pagination != null ? pagination.getLimit() : null,
+            authSession.getSessionToken(), authSession.getKeyManagerToken(), searchQuery));
   }
 
   /**

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/OboMessageService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/OboMessageService.java
@@ -14,6 +14,7 @@ import java.time.Instant;
 import java.util.List;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Service interface exposing OBO-enabled endpoints to manage messages.
@@ -209,4 +210,41 @@ public interface OboMessageService {
    * @see <a href="https://developers.symphony.com/restapi/reference#get-message-v1">Get Message v1</a>
    */
   V4Message getMessage(@Nonnull String messageId);
+
+  /**
+   * Searches for messages using a natural-language semantic query. Unlike the keyword based
+   * {@code /v1/message/search} endpoint, the query is interpreted by meaning rather than matched as
+   * {@code field:value} pairs.
+   *
+   * @param query the natural-language search query.
+   * @return the list of matching messages.
+   * @see <a href="https://developers.symphony.com/restapi/reference/semantic-search-messages">Semantic search messages</a>
+   */
+  List<V4Message> searchMessagesSemantic(@Nonnull String query);
+
+  /**
+   * Searches for messages using a natural-language semantic query. Unlike the keyword based
+   * {@code /v1/message/search} endpoint, the query is interpreted by meaning rather than matched as
+   * {@code field:value} pairs.
+   *
+   * @param query      the natural-language search query.
+   * @param pagination the skip and limit for pagination.
+   * @return the list of matching messages.
+   * @see <a href="https://developers.symphony.com/restapi/reference/semantic-search-messages">Semantic search messages</a>
+   */
+  List<V4Message> searchMessagesSemantic(@Nonnull String query, @Nullable PaginationAttribute pagination);
+
+  /**
+   * Searches for messages using a natural-language semantic query. Unlike the keyword based
+   * {@code /v1/message/search} endpoint, the query is interpreted by meaning rather than matched as
+   * {@code field:value} pairs.
+   *
+   * @param query      the natural-language search query.
+   * @param streamId   the stream to restrict the search to. If {@code null}, all accessible streams are searched.
+   * @param pagination the skip and limit for pagination.
+   * @return the list of matching messages.
+   * @see <a href="https://developers.symphony.com/restapi/reference/semantic-search-messages">Semantic search messages</a>
+   */
+  List<V4Message> searchMessagesSemantic(@Nonnull String query, @Nullable String streamId,
+      @Nullable PaginationAttribute pagination);
 }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/MessageServiceTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/MessageServiceTest.java
@@ -77,6 +77,7 @@ class MessageServiceTest {
 
   private static final String V4_STREAM_MESSAGE = "/agent/v4/stream/{sid}/message";
   private static final String V4_SEARCH_MESSAGES = "/agent/v1/message/search";
+  private static final String V4_SEARCH_MESSAGES_SEMANTIC = "/agent/v4/message/search/semantic";
   private static final String V4_STREAM_MESSAGE_CREATE = "/agent/v4/stream/{sid}/message/create";
   private static final String V4_STREAM_MESSAGE_UPDATE = "/agent/v4/stream/{sid}/message/{mid}/update";
   private static final String V4_MESSAGE_IMPORT = "/agent/v4/message/import";
@@ -248,6 +249,65 @@ class MessageServiceTest {
         () -> messageService.searchMessages(query2),
         "text require streamId arg to be provided"
     );
+  }
+
+  @Test
+  void testSearchMessagesSemantic() throws IOException {
+    mockApiClient.onPost(V4_SEARCH_MESSAGES_SEMANTIC,
+        JsonHelper.readFromClasspath("/message/get_message_stream_id.json"));
+
+    final List<V4Message> messages = messageService.searchMessagesSemantic("find the budget discussion");
+
+    assertEquals(2, messages.size());
+    assertEquals(Arrays.asList("messageId1", "messageId2"),
+        messages.stream().map(V4Message::getMessageId).collect(Collectors.toList()));
+  }
+
+  @Test
+  void testSearchMessagesSemanticWithAllParameters() throws IOException {
+    mockApiClient.onPost(V4_SEARCH_MESSAGES_SEMANTIC,
+        JsonHelper.readFromClasspath("/message/get_message_stream_id.json"));
+
+    final List<V4Message> messages = messageService.searchMessagesSemantic("query", STREAM_ID,
+        new PaginationAttribute(0, 10));
+
+    assertEquals(2, messages.size());
+    assertEquals(Arrays.asList("messageId1", "messageId2"),
+        messages.stream().map(V4Message::getMessageId).collect(Collectors.toList()));
+  }
+
+  @Test
+  void testSearchMessagesSemanticSimpleDelegates() {
+    MessageService service = spy(messageService);
+    doReturn(Collections.emptyList()).when(service)
+        .searchMessagesSemantic(anyString(), isNull(), isNull());
+
+    assertNotNull(service.searchMessagesSemantic("query"));
+    verify(service).searchMessagesSemantic("query", null, null);
+  }
+
+  @Test
+  void testSearchMessagesSemanticWithPaginationDelegates() {
+    MessageService service = spy(messageService);
+    doReturn(Collections.emptyList()).when(service)
+        .searchMessagesSemantic(anyString(), isNull(), any(PaginationAttribute.class));
+
+    final PaginationAttribute pagination = new PaginationAttribute(2, 2);
+    assertNotNull(service.searchMessagesSemantic("query", pagination));
+    verify(service).searchMessagesSemantic("query", null, pagination);
+  }
+
+  @Test
+  void testSearchMessagesSemanticObo() throws IOException {
+    mockApiClient.onPost(V4_SEARCH_MESSAGES_SEMANTIC,
+        JsonHelper.readFromClasspath("/message/get_message_stream_id.json"));
+
+    messageService = new MessageService(messagesApi, messageApi, messageSuppressionApi, streamsApi, podApi,
+        attachmentsApi, defaultApi, templateEngine, new RetryWithRecoveryBuilder<>());
+
+    final List<V4Message> messages = messageService.obo(authSession).searchMessagesSemantic("query");
+
+    assertEquals(2, messages.size());
   }
 
   @Test


### PR DESCRIPTION
### Description
introduces /v4/message/search/semantic - Search messages semantically according to the natural-language query provided in the request body.

Disclaimer : Internal use only. This is not officially supported yet.

### Dependencies
this is coupled to https://github.com/finos/symphony-api-spec/pull/221

### Checklist
- [x] Referenced an issue in the PR title or description
- [x] Filled properly the description and dependencies, if any
- [x] Unit/Integration tests updated or added
- [x] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)

