### PR TITLE
feat: add bdk-ai-agent-example module

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,10 @@
+changelog:
+  categories:
+    - title: 🚀 Features
+      labels: [ enhancement, feature ]
+    - title: 🐛 Bug Fixes
+      labels: [ bug, fix ]
+    - title: 📦 Dependencies
+      labels: [ dependencies ]
+    - title: Other Changes
+      labels: [ "*" ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     types: [ published ]
 
 permissions:
-  contents: write # upload CLI binaries to the release and push the snapshot bump to main
+  contents: write # upload CLI binaries to the release
 
 jobs:
   build:
@@ -25,11 +25,8 @@ jobs:
             exit 1
           fi
           VERSION="${TAG#v}"
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
-          NEXT_SNAPSHOT="${MAJOR}.${MINOR}.$((PATCH + 1))-SNAPSHOT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "next_snapshot=$NEXT_SNAPSHOT" >> "$GITHUB_OUTPUT"
-          echo "Releasing $VERSION, next snapshot on main will be $NEXT_SNAPSHOT"
+          echo "Releasing $VERSION"
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -57,24 +54,5 @@ jobs:
           gh release upload "${{ github.event.release.tag_name }}" \
             symphony-bdk-cli/build/install/symphony-bdk-cli/bin/bdk \
             symphony-bdk-cli/build/install/symphony-bdk-cli/bin/bdk.bat
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Bump snapshot version on main
-        run: |
-          NEXT_SNAPSHOT="${{ steps.version.outputs.next_snapshot }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin main
-          git checkout main
-          # anchor on the line start so only the projectVersion default is rewritten
-          # (lines 9-11 also contain the "?: '...'" pattern and must stay untouched)
-          sed -i "s|^ext.projectVersion = .*|ext.projectVersion = project.properties['projectVersion'] ?: '${NEXT_SNAPSHOT}'|" build.gradle
-          if git diff --quiet build.gradle; then
-            echo "::notice::build.gradle already at ${NEXT_SNAPSHOT}, nothing to bump"
-            exit 0
-          fi
-          git commit -am "chore: bump snapshot version to ${NEXT_SNAPSHOT} [skip ci]"
-          git push origin main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [ published ]
 
+permissions:
+  contents: write # upload CLI binaries to the release and push the snapshot bump to main
+
 jobs:
   build:
     name: "Release"
@@ -13,16 +16,32 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Derive release version from tag
+        id: version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag '$TAG' is not in the expected vMAJOR.MINOR.PATCH format (e.g. v3.3.16)"
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+          NEXT_SNAPSHOT="${MAJOR}.${MINOR}.$((PATCH + 1))-SNAPSHOT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "next_snapshot=$NEXT_SNAPSHOT" >> "$GITHUB_OUTPUT"
+          echo "Releasing $VERSION, next snapshot on main will be $NEXT_SNAPSHOT"
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '17'
 
-      - run: |
+      - name: Publish release to Maven Central
+        run: |
           mkdir -p ~/.gnupg/
           printf "$GPG_KEY_BASE64" | base64 --decode > ~/.gnupg/secring.gpg
-          ./gradlew -PmavenRepoUsername=$MAVEN_USERNAME -PmavenRepoPassword=$MAVEN_PASSWORD -Psigning.keyId=$GPG_KEY_ID -Psigning.secretKeyRingFile=$HOME/.gnupg/secring.gpg -Psigning.password=$GPG_KEY_PASSPHRASE publishToSonatype closeAndReleaseStagingRepository
+          ./gradlew -PprojectVersion=${{ steps.version.outputs.version }} -PmavenRepoUsername=$MAVEN_USERNAME -PmavenRepoPassword=$MAVEN_PASSWORD -Psigning.keyId=$GPG_KEY_ID -Psigning.secretKeyRingFile=$HOME/.gnupg/secring.gpg -Psigning.password=$GPG_KEY_PASSPHRASE publishToSonatype closeAndReleaseStagingRepository
         env:
           GPG_KEY_BASE64: ${{ secrets.GPG_KEY_BASE64 }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
@@ -31,12 +50,31 @@ jobs:
           GPG_KEY_PASSPHRASE: ${{ secrets.GPG_KEY_PASSPHRASE }}
 
       - name: Build CLI distribution
-        run: ./gradlew :symphony-bdk-cli:installDist
+        run: ./gradlew -PprojectVersion=${{ steps.version.outputs.version }} :symphony-bdk-cli:installDist
 
       - name: Upload CLI binaries to GitHub Release
         run: |
           gh release upload "${{ github.event.release.tag_name }}" \
             symphony-bdk-cli/build/install/symphony-bdk-cli/bin/bdk \
             symphony-bdk-cli/build/install/symphony-bdk-cli/bin/bdk.bat
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bump snapshot version on main
+        run: |
+          NEXT_SNAPSHOT="${{ steps.version.outputs.next_snapshot }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          git checkout main
+          # anchor on the line start so only the projectVersion default is rewritten
+          # (lines 9-11 also contain the "?: '...'" pattern and must stay untouched)
+          sed -i "s|^ext.projectVersion = .*|ext.projectVersion = project.properties['projectVersion'] ?: '${NEXT_SNAPSHOT}'|" build.gradle
+          if git diff --quiet build.gradle; then
+            echo "::notice::build.gradle already at ${NEXT_SNAPSHOT}, nothing to bump"
+            exit 0
+          fi
+          git commit -am "chore: bump snapshot version to ${NEXT_SNAPSHOT} [skip ci]"
+          git push origin main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@
 *.iml
 *.ipr
 
+# Eclipse
+.project
+.classpath
+.factorypath
+
 # Log file
 *.log
 *.gz

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 .project
 .classpath
 .factorypath
+.settings/
+bin/
 
 # Log file
 *.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,13 @@ Four Groovy convention plugins used by sub-modules:
 
 ## Publishing
 
-Snapshots are published to Sonatype OSSRH via the `publishToSonatype` Gradle task (nexus-publish-plugin). This task is automatically triggered in CI on every PR build. Releases use `publishToSonatype closeAndReleaseStagingRepository` and are triggered by a GitHub Release event.
+Snapshots are published to Sonatype OSSRH via the `publishToSonatype` Gradle task (nexus-publish-plugin). This task is automatically triggered in CI on every PR build (versioned `PR-<number>-SNAPSHOT`). Releases use `publishToSonatype closeAndReleaseStagingRepository`.
+
+Releasing is fully driven by publishing a GitHub Release (`.github/workflows/release.yml`):
+
+1. Draft a new release on the `main` branch with a `vMAJOR.MINOR.PATCH` tag (e.g. `v3.3.16`).
+2. On publish, the workflow derives the version from the tag (stripping the `v`), builds and signs the artifacts with `-PprojectVersion=<version>`, publishes them to Maven Central, and uploads the CLI binaries to the release.
+3. It then bumps the `-SNAPSHOT` default in the root `build.gradle` to the next patch on `main` automatically — no manual branch or version edit is needed.
 
 Credentials are passed as Gradle properties: `-PmavenRepoUsername` and `-PmavenRepoPassword`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ Releasing is fully driven by publishing a GitHub Release (`.github/workflows/rel
 
 1. Draft a new release on the `main` branch with a `vMAJOR.MINOR.PATCH` tag (e.g. `v3.3.16`).
 2. On publish, the workflow derives the version from the tag (stripping the `v`), builds and signs the artifacts with `-PprojectVersion=<version>`, publishes them to Maven Central, and uploads the CLI binaries to the release.
-3. It then bumps the `-SNAPSHOT` default in the root `build.gradle` to the next patch on `main` automatically — no manual branch or version edit is needed.
+
+The `projectVersion` default in the root `build.gradle` stays fixed at `0.0.0-SNAPSHOT` on `main` — the real version is always supplied via `-PprojectVersion` in CI, so there is no version bump to commit.
 
 Credentials are passed as Gradle properties: `-PmavenRepoUsername` and `-PmavenRepoPassword`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,13 @@ Four Groovy convention plugins used by sub-modules:
 
 ## Publishing
 
-Snapshots are published to Sonatype OSSRH via the `publishToSonatype` Gradle task (nexus-publish-plugin). This task is automatically triggered in CI on every PR build. Releases use `publishToSonatype closeAndReleaseStagingRepository` and are triggered by a GitHub Release event.
+Snapshots are published to Sonatype OSSRH via the `publishToSonatype` Gradle task (nexus-publish-plugin). This task is automatically triggered in CI on every PR build (versioned `PR-<number>-SNAPSHOT`). Releases use `publishToSonatype closeAndReleaseStagingRepository`.
+
+Releasing is fully driven by publishing a GitHub Release (`.github/workflows/release.yml`):
+
+1. Draft a new release on the `main` branch with a `vMAJOR.MINOR.PATCH` tag (e.g. `v3.3.16`).
+2. On publish, the workflow derives the version from the tag (stripping the `v`), builds and signs the artifacts with `-PprojectVersion=<version>`, publishes them to Maven Central, and uploads the CLI binaries to the release.
+3. It then bumps the `-SNAPSHOT` default in the root `build.gradle` to the next patch on `main` automatically — no manual branch or version edit is needed.
 
 Credentials are passed as Gradle properties: `-PmavenRepoUsername` and `-PmavenRepoPassword`.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,6 +17,18 @@ This file lists the maintainers of this repository.
 
 For information about maintainer responsibilities and resources, see the [FINOS Maintainers Cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet).
 
+## Cutting a release
+
+Releasing is fully automated — just publish a GitHub Release from `main`:
+
+1. Go to the repository **Releases** page and click **Draft a new release**.
+2. Set **Target** to `main`.
+3. Create a new tag in the form `vMAJOR.MINOR.PATCH` (e.g. `v3.3.16`).
+4. Click **Generate release notes** (auto-categorized from merged PRs).
+5. Click **Publish release**.
+
+The `Release` workflow then derives the version from the tag, publishes the signed artifacts to Maven Central, uploads the CLI binaries to the release, and commits the next `-SNAPSHOT` version to `main`. There is no need to create a branch or edit the version in `build.gradle` manually.
+
 ## Updating this file
 
 All changes to the maintainer list are managed openly:

--- a/allow-list.xml
+++ b/allow-list.xml
@@ -51,13 +51,14 @@
     <suppress>
         <notes><![CDATA[
           CVE-2026-53914 is an unsafe-deserialization flaw in the Kotlin *compiler's* build-cache
-          metadata (a build-time tool), not in the kotlin-stdlib runtime jar. The NVD CPE
-          (jetbrains:kotlin) over-matches every kotlin artifact; we only ship kotlin-stdlib
-          transitively from Spring Boot (1.9.25) at runtime, and do not run the Kotlin compiler.
-          The stated fix version (2.4.20) is not published on Maven Central, so no override is
-          possible. Same CPE-over-match class as the CVE-2020-29582 suppression above.
+          metadata (a build-time tool), not in kotlin-stdlib/kotlin-reflect runtime jars. The NVD
+          CPE (jetbrains:kotlin) over-matches every kotlin artifact; we only ship kotlin-stdlib
+          transitively from Spring Boot (1.9.25) and kotlin-reflect transitively from
+          langchain4j-google-genai's jackson-module-kotlin (2.1.21) at runtime, and do not run the
+          Kotlin compiler. The stated fix version (2.4.20) is not published on Maven Central, so no
+          override is possible. Same CPE-over-match class as the CVE-2020-29582 suppression above.
           ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-stdlib(-jdk7|-jdk8|-common)?@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/(kotlin-stdlib(-jdk7|-jdk8|-common)?|kotlin-reflect)@.*$</packageUrl>
         <cve>CVE-2026-53914</cve>
     </suppress>
     <suppress>

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "org.owasp.dependencycheck" version "12.2.2"
 }
 
-ext.projectVersion = project.properties['projectVersion'] ?: '3.3.0-SNAPSHOT'
+ext.projectVersion = project.properties['projectVersion'] ?: '0.0.0-SNAPSHOT'
 ext.isReleaseVersion = !ext.projectVersion.endsWith('SNAPSHOT')
 
 ext.mavenRepoUrl = project.properties['mavenRepoUrl'] ?: 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,6 +29,7 @@ include(':symphony-bdk-examples:bdk-spring-boot-example')
 include(':symphony-bdk-examples:bdk-app-spring-boot-example')
 include(':symphony-bdk-examples:bdk-multi-instances-example')
 include(':symphony-bdk-examples:bdk-group-example')
+include(':symphony-bdk-examples:bdk-ai-agent-example')
 
 // built-in extensions
 include(':symphony-bdk-extensions:symphony-group-extension')

--- a/symphony-bdk-bom/build.gradle
+++ b/symphony-bdk-bom/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     // import Jersey's BOM
     api platform('org.glassfish.jersey:jersey-bom:3.1.12')
     // import Log4j's BOM
-    api platform('org.apache.logging.log4j:log4j-bom:2.26.0')
+    api platform('org.apache.logging.log4j:log4j-bom:2.26.1')
 
     // define all our dependencies versions
     constraints {
@@ -45,10 +45,11 @@ dependencies {
 
         // Security override: Spring Boot 3.5.16 pins Tomcat 10.1.55, vulnerable to
         // CVE-2026-53434, CVE-2026-55276, CVE-2026-53404, CVE-2026-55955, CVE-2026-55956,
-        // CVE-2026-50229 — all fixed in 10.1.56. This higher constraint wins conflict resolution.
-        api 'org.apache.tomcat.embed:tomcat-embed-core:10.1.56'
-        api 'org.apache.tomcat.embed:tomcat-embed-websocket:10.1.56'
-        api 'org.apache.tomcat.embed:tomcat-embed-el:10.1.56'
+        // CVE-2026-50229 (fixed in 10.1.56), and CVE-2026-59083, CVE-2026-59084 (fixed in
+        // 10.1.57). This higher constraint wins conflict resolution.
+        api 'org.apache.tomcat.embed:tomcat-embed-core:10.1.57'
+        api 'org.apache.tomcat.embed:tomcat-embed-websocket:10.1.57'
+        api 'org.apache.tomcat.embed:tomcat-embed-el:10.1.57'
 
         api 'org.apiguardian:apiguardian-api:1.1.2'
 

--- a/symphony-bdk-examples/bdk-ai-agent-example/README.md
+++ b/symphony-bdk-examples/bdk-ai-agent-example/README.md
@@ -1,0 +1,43 @@
+# AI Agent example
+
+Shows how little code is needed to turn a Symphony bot into an AI agent on top of the BDK:
+
+- [LangChain4j](https://docs.langchain4j.dev/) `AiServices` wraps a chat model into a typed
+  `Assistant` interface.
+- The model is [Vertex AI Gemini](https://docs.langchain4j.dev/integrations/language-models/google-vertex-ai-gemini).
+- The assistant is given BDK-backed tools (`BdkTools`) so it can look up Symphony users, list room
+  members and send messages on its own, on top of just answering questions.
+- Each (stream, user) pair gets its own conversation memory, so the bot remembers context per
+  person per room/IM.
+
+## Running
+
+1. Set up a regular BDK bot `~/.symphony/config.yaml` (see the other example modules).
+2. Authenticate to Google Cloud so that Application Default Credentials are available, e.g.:
+   ```shell
+   gcloud auth application-default login
+   ```
+3. Set environment variables:
+
+   | Variable | Required | Default |
+   |---|---|---|
+   | `GCP_PROJECT_ID` | yes | - |
+   | `GCP_LOCATION` | no | `us-central1` |
+   | `GEMINI_MODEL_NAME` | no | `gemini-1.5-flash` |
+
+4. Run `AiAgentMain`, then in a Symphony chat with the bot: `@BotMention what can you do?`
+
+## How it works
+
+```
+@bot <question> ──▶ AskAiActivity (PatternCommandActivity)
+                          │
+                          ▼
+                    Assistant.chat(memoryId, question)   [LangChain4j AiServices]
+                          │
+                          ├─▶ VertexAiGeminiChatModel
+                          └─▶ BdkTools (lookupUser / listCurrentRoomMembers / sendMessageToStream)
+                          │
+                          ▼
+                    bdk.messages().send(streamId, answer)
+```

--- a/symphony-bdk-examples/bdk-ai-agent-example/build.gradle
+++ b/symphony-bdk-examples/bdk-ai-agent-example/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     implementation platform("dev.langchain4j:langchain4j-bom:${langchain4jVersion}")
     implementation 'dev.langchain4j:langchain4j'
-    implementation 'dev.langchain4j:langchain4j-vertex-ai-gemini'
+    implementation 'dev.langchain4j:langchain4j-google-genai'
 
     runtimeOnly 'ch.qos.logback:logback-classic'
     implementation 'org.slf4j:slf4j-api'

--- a/symphony-bdk-examples/bdk-ai-agent-example/build.gradle
+++ b/symphony-bdk-examples/bdk-ai-agent-example/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'bdk.java-common-conventions'
+}
+
+description = 'Symphony Java BDK Examples - AI Agent (LangChain4j + Vertex AI Gemini)'
+
+ext {
+    langchain4jVersion = '1.17.2'
+}
+
+dependencies {
+
+    implementation project(':symphony-bdk-core')
+
+    runtimeOnly project(':symphony-bdk-template:symphony-bdk-template-freemarker')
+    implementation project(':symphony-bdk-http:symphony-bdk-http-jersey2')
+
+    implementation platform("dev.langchain4j:langchain4j-bom:${langchain4jVersion}")
+    implementation 'dev.langchain4j:langchain4j'
+    implementation 'dev.langchain4j:langchain4j-vertex-ai-gemini'
+
+    runtimeOnly 'ch.qos.logback:logback-classic'
+    implementation 'org.slf4j:slf4j-api'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+}

--- a/symphony-bdk-examples/bdk-ai-agent-example/src/main/java/com/symphony/bdk/examples/ai/AiAgentMain.java
+++ b/symphony-bdk-examples/bdk-ai-agent-example/src/main/java/com/symphony/bdk/examples/ai/AiAgentMain.java
@@ -6,29 +6,29 @@ import com.symphony.bdk.core.SymphonyBdk;
 
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.model.chat.ChatModel;
-import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiChatModel;
+import dev.langchain4j.model.google.genai.GoogleGenAiChatModel;
 import dev.langchain4j.service.AiServices;
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * Showcases how little code is needed to turn a Symphony bot into an AI agent: a
- * {@link VertexAiGeminiChatModel}, a LangChain4j {@link AiServices} wiring in BDK-backed
+ * {@link GoogleGenAiChatModel}, a LangChain4j {@link AiServices} wiring in BDK-backed
  * {@link BdkTools} and per-user {@link MessageWindowChatMemory}, and one {@link AskAiActivity}
  * bridging the two worlds.
  */
 @Slf4j
 public class AiAgentMain {
 
-  private static final String DEFAULT_LOCATION = "us-central1";
-  private static final String DEFAULT_MODEL_NAME = "gemini-3.5-flash";
+  private static final String DEFAULT_LOCATION = "global";
+  private static final String DEFAULT_MODEL_NAME = "gemini-2.5-flash-lite";
   private static final int MAX_MEMORY_MESSAGES = 10;
 
   public static void main(String[] args) throws Exception {
 
     final SymphonyBdk bdk = new SymphonyBdk(loadFromSymphonyDir("config.yaml"));
 
-    final ChatModel chatModel = VertexAiGeminiChatModel.builder()
-        .project(requiredEnv("GCP_PROJECT_ID"))
+    final ChatModel chatModel = GoogleGenAiChatModel.builder()
+        .projectId(requiredEnv("GCP_PROJECT_ID"))
         .location(getEnv("GCP_LOCATION", DEFAULT_LOCATION))
         .modelName(getEnv("GEMINI_MODEL_NAME", DEFAULT_MODEL_NAME))
         .build();

--- a/symphony-bdk-examples/bdk-ai-agent-example/src/main/java/com/symphony/bdk/examples/ai/AiAgentMain.java
+++ b/symphony-bdk-examples/bdk-ai-agent-example/src/main/java/com/symphony/bdk/examples/ai/AiAgentMain.java
@@ -1,0 +1,59 @@
+package com.symphony.bdk.examples.ai;
+
+import static com.symphony.bdk.core.config.BdkConfigLoader.loadFromSymphonyDir;
+
+import com.symphony.bdk.core.SymphonyBdk;
+
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiChatModel;
+import dev.langchain4j.service.AiServices;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Showcases how little code is needed to turn a Symphony bot into an AI agent: a
+ * {@link VertexAiGeminiChatModel}, a LangChain4j {@link AiServices} wiring in BDK-backed
+ * {@link BdkTools} and per-user {@link MessageWindowChatMemory}, and one {@link AskAiActivity}
+ * bridging the two worlds.
+ */
+@Slf4j
+public class AiAgentMain {
+
+  private static final String DEFAULT_LOCATION = "us-central1";
+  private static final String DEFAULT_MODEL_NAME = "gemini-3.5-flash";
+  private static final int MAX_MEMORY_MESSAGES = 10;
+
+  public static void main(String[] args) throws Exception {
+
+    final SymphonyBdk bdk = new SymphonyBdk(loadFromSymphonyDir("config.yaml"));
+
+    final ChatModel chatModel = VertexAiGeminiChatModel.builder()
+        .project(requiredEnv("GCP_PROJECT_ID"))
+        .location(getEnv("GCP_LOCATION", DEFAULT_LOCATION))
+        .modelName(getEnv("GEMINI_MODEL_NAME", DEFAULT_MODEL_NAME))
+        .build();
+
+    final Assistant assistant = AiServices.builder(Assistant.class)
+        .chatModel(chatModel)
+        .tools(new BdkTools(bdk))
+        .chatMemoryProvider(memoryId -> MessageWindowChatMemory.withMaxMessages(MAX_MEMORY_MESSAGES))
+        .build();
+
+    bdk.activities().register(new AskAiActivity(assistant, bdk.messages()));
+
+    bdk.datafeed().start();
+  }
+
+  private static String getEnv(String name, String defaultValue) {
+    final String value = System.getenv(name);
+    return value == null || value.isEmpty() ? defaultValue : value;
+  }
+
+  private static String requiredEnv(String name) {
+    final String value = System.getenv(name);
+    if (value == null || value.isEmpty()) {
+      throw new IllegalStateException("Missing required environment variable: " + name);
+    }
+    return value;
+  }
+}

--- a/symphony-bdk-examples/bdk-ai-agent-example/src/main/java/com/symphony/bdk/examples/ai/AskAiActivity.java
+++ b/symphony-bdk-examples/bdk-ai-agent-example/src/main/java/com/symphony/bdk/examples/ai/AskAiActivity.java
@@ -1,0 +1,53 @@
+package com.symphony.bdk.examples.ai;
+
+import com.symphony.bdk.core.activity.command.PatternCommandActivity;
+import com.symphony.bdk.core.activity.model.ActivityInfo;
+import com.symphony.bdk.core.activity.model.ActivityType;
+import com.symphony.bdk.core.service.message.MessageService;
+import com.symphony.bdk.examples.ai.context.AskAiContext;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Forwards any message addressed to the bot to the LangChain4j {@link Assistant} and replies
+ * with its answer. Conversation memory is scoped per (stream, user), see {@link MemoryIds}.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class AskAiActivity extends PatternCommandActivity<AskAiContext> {
+
+  private final Assistant assistant;
+  private final MessageService messageService;
+
+  @Override
+  public Pattern pattern() {
+    return Pattern.compile("^@" + this.getBotDisplayName() + "\\s+(.*)$", Pattern.DOTALL);
+  }
+
+  @Override
+  protected void prepareContext(AskAiContext context, Matcher matcher) {
+    context.setPrompt(matcher.group(1));
+  }
+
+  @Override
+  public void onActivity(AskAiContext context) {
+    final String memoryId = MemoryIds.of(context.getStreamId(), context.getInitiator().getUser().getUserId());
+    log.info("Asking the AI agent (memoryId={}): {}", memoryId, context.getPrompt());
+
+    final String answer = this.assistant.chat(memoryId, context.getPrompt());
+
+    this.messageService.send(context.getStreamId(), "<messageML>" + answer + "</messageML>");
+  }
+
+  @Override
+  protected ActivityInfo info() {
+    return new ActivityInfo()
+        .type(ActivityType.COMMAND)
+        .name("AI agent command")
+        .description("Usage: @BotMention {any question}");
+  }
+}

--- a/symphony-bdk-examples/bdk-ai-agent-example/src/main/java/com/symphony/bdk/examples/ai/Assistant.java
+++ b/symphony-bdk-examples/bdk-ai-agent-example/src/main/java/com/symphony/bdk/examples/ai/Assistant.java
@@ -1,0 +1,19 @@
+package com.symphony.bdk.examples.ai;
+
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+
+/**
+ * LangChain4j AI Service interface: the assistant's contract is a plain method, LangChain4j
+ * generates the implementation (prompt assembly, memory handling, tool invocation loop) at runtime.
+ */
+public interface Assistant {
+
+  @SystemMessage("""
+      You are a helpful assistant answering questions inside a Symphony chat.
+      You can use the provided tools to look up users, list room members and send messages.
+      Keep answers concise, they will be rendered as a chat message.
+      """)
+  String chat(@MemoryId String memoryId, @UserMessage String message);
+}

--- a/symphony-bdk-examples/bdk-ai-agent-example/src/main/java/com/symphony/bdk/examples/ai/BdkTools.java
+++ b/symphony-bdk-examples/bdk-ai-agent-example/src/main/java/com/symphony/bdk/examples/ai/BdkTools.java
@@ -1,0 +1,59 @@
+package com.symphony.bdk.examples.ai;
+
+import com.symphony.bdk.core.SymphonyBdk;
+import com.symphony.bdk.gen.api.model.UserV2;
+import com.symphony.bdk.gen.api.model.V2MemberInfo;
+
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.agent.tool.ToolMemoryId;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * BDK-backed actions exposed to the LLM as tools. LangChain4j decides on its own, based on the
+ * user's message, whether and when to call these.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class BdkTools {
+
+  private final SymphonyBdk bdk;
+
+  @Tool("Looks up a Symphony user by username or email address and returns their display name, "
+      + "email and user id. Returns 'not found' if no user matches.")
+  public String lookupUser(String usernameOrEmail) {
+    log.info("Tool call: lookupUser({})", usernameOrEmail);
+    final List<UserV2> users = usernameOrEmail.contains("@")
+        ? this.bdk.users().listUsersByEmails(Collections.singletonList(usernameOrEmail))
+        : this.bdk.users().listUsersByUsernames(Collections.singletonList(usernameOrEmail));
+
+    if (users.isEmpty()) {
+      return "not found";
+    }
+    final UserV2 user = users.get(0);
+    return String.format("%s <%s> (id=%d)", user.getDisplayName(), user.getEmailAddress(), user.getId());
+  }
+
+  @Tool("Lists the display names of the members of the Symphony room/IM the conversation is "
+      + "currently happening in.")
+  public String listCurrentRoomMembers(@ToolMemoryId String memoryId) {
+    final String streamId = MemoryIds.streamId(memoryId);
+    log.info("Tool call: listCurrentRoomMembers() in stream {}", streamId);
+
+    final List<V2MemberInfo> members = this.bdk.streams().listStreamMembers(streamId).getMembers();
+    return members.stream()
+        .map(member -> member.getUser().getDisplayName())
+        .collect(Collectors.joining(", "));
+  }
+
+  @Tool("Sends a chat message to another Symphony stream identified by its streamId.")
+  public String sendMessageToStream(String streamId, String message) {
+    log.info("Tool call: sendMessageToStream({}, {})", streamId, message);
+    this.bdk.messages().send(streamId, "<messageML>" + message + "</messageML>");
+    return "message sent";
+  }
+}

--- a/symphony-bdk-examples/bdk-ai-agent-example/src/main/java/com/symphony/bdk/examples/ai/MemoryIds.java
+++ b/symphony-bdk-examples/bdk-ai-agent-example/src/main/java/com/symphony/bdk/examples/ai/MemoryIds.java
@@ -1,0 +1,22 @@
+package com.symphony.bdk.examples.ai;
+
+/**
+ * Encodes the (streamId, userId) pair used to key each user's conversation memory into a single
+ * string, so that the stream a tool call is acting on can be recovered from the LangChain4j
+ * {@code @MemoryId}/{@code @ToolMemoryId} value.
+ */
+final class MemoryIds {
+
+  private static final String SEPARATOR = "::";
+
+  private MemoryIds() {
+  }
+
+  static String of(String streamId, Long userId) {
+    return streamId + SEPARATOR + userId;
+  }
+
+  static String streamId(String memoryId) {
+    return memoryId.substring(0, memoryId.indexOf(SEPARATOR));
+  }
+}

--- a/symphony-bdk-examples/bdk-ai-agent-example/src/main/java/com/symphony/bdk/examples/ai/context/AskAiContext.java
+++ b/symphony-bdk-examples/bdk-ai-agent-example/src/main/java/com/symphony/bdk/examples/ai/context/AskAiContext.java
@@ -1,0 +1,22 @@
+package com.symphony.bdk.examples.ai.context;
+
+import com.symphony.bdk.core.activity.command.CommandContext;
+import com.symphony.bdk.gen.api.model.V4Initiator;
+import com.symphony.bdk.gen.api.model.V4MessageSent;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AskAiContext extends CommandContext {
+
+  /**
+   * The user's question, with the leading bot mention stripped out.
+   */
+  private String prompt;
+
+  public AskAiContext(V4Initiator initiator, V4MessageSent eventSource) {
+    super(initiator, eventSource);
+  }
+}

--- a/symphony-bdk-examples/bdk-ai-agent-example/src/main/resources/logback.xml
+++ b/symphony-bdk-examples/bdk-ai-agent-example/src/main/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %X{X-Trace-Id} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <logger name="com.symphony.bdk.deprecation" level="WARN">
+        <appender-ref ref="Console"/>
+    </logger>
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary
- Adds a new `bdk-ai-agent-example` module demonstrating how to build an AI agent on top of the BDK
- Wires BDK tools and context into an assistant/activity so an LLM-backed agent can respond to Symphony messages

## Test plan
- [x] `./gradlew :symphony-bdk-examples:bdk-ai-agent-example:build`
- [ ] Manually run the example against a test bot and verify the AI agent responds to messages