### PR TITLE
feat: complete stream CLI commands (room and membership management)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -110,6 +110,16 @@ bdk message list abc123StreamId --since 2026-06-01T00:00:00Z --limit 20
 | `bdk stream list [--limit N] [--skip N]` | List the streams the bot is a member of (JSON array). |
 | `bdk stream members <streamId>` | List the members of a stream. |
 | `bdk stream get <streamId>` | Get a stream's details (`3` if it does not exist). |
+| `bdk stream create-room <name> [--description <text>] [--public\|--private] [--discoverable] [--members-can-invite] [--read-only] [--view-history] [--cross-pod]` | Create a chatroom. |
+| `bdk stream update-room <roomId> [same options as create-room]` | Update a chatroom's attributes; only explicitly-passed options are changed (`3` if the room does not exist). |
+| `bdk stream get-room <roomId>` | Get a chatroom's full detail — attributes and system info (`3` if it does not exist). |
+| `bdk stream activate-room <roomId>` | Reactivate a deactivated chatroom. |
+| `bdk stream deactivate-room <roomId>` | Deactivate a chatroom. |
+| `bdk stream create-im <userId>...` | Create an IM (one user id) or MIM (several user ids), bot included. |
+| `bdk stream add-member <roomId> <userId>` | Add a member to a room (`3` if the room does not exist). |
+| `bdk stream remove-member <roomId> <userId>` | Remove a member from a room. |
+| `bdk stream promote-owner <roomId> <userId>` | Promote a room member to owner. |
+| `bdk stream demote-owner <roomId> <userId>` | Demote a room owner to participant. |
 
 ### `bdk user`
 

--- a/openspec/changes/archive/2026-07-20-complete-stream-cli-commands/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-20-complete-stream-cli-commands/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-20

--- a/openspec/changes/archive/2026-07-20-complete-stream-cli-commands/design.md
+++ b/openspec/changes/archive/2026-07-20-complete-stream-cli-commands/design.md
@@ -1,0 +1,35 @@
+## Context
+
+`symphony-bdk-cli` follows a strict container/leaf command structure (`ContainerCommand` for noun groups like `bdk stream`, `BaseCommand` for verb leaves) with one class per verb, JSON output via `emit()`, and exit codes mapped centrally by `BdkCliExecutionExceptionHandler`. `StreamService` already implements every operation this change exposes; no `symphony-bdk-core` changes are needed. The existing `stream` group (`get`, `list`, `members`) only covers reads.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add one leaf command per targeted `StreamService` write/read-detail operation, following the existing `stream get`/`list`/`members` conventions exactly (positional params for required ids, `@Option` for optional attributes, `emit()` for output, `NotFoundException` for null lookups).
+- Keep each command a thin pass-through to `StreamService` — no new business logic in the CLI layer.
+- Cover room lifecycle (create, update, get full detail, activate, deactivate) and membership/roles (create IM/MIM, add/remove member, promote/demote owner).
+
+**Non-Goals:**
+- Admin (`*Admin`) endpoints, enterprise-wide stream listing, room/stream search, content sharing, and IM attribute updates are explicitly out of scope (see proposal "Out of scope").
+- No changes to `symphony-bdk-core` or `StreamService`.
+- No interactive/multi-step flows (e.g. no confirmation prompts) — the CLI stays a one-shot, scriptable tool consistent with its stated design.
+
+## Decisions
+
+- **Command naming**: use hyphenated verb-noun leaf names (`create-room`, `update-room`, `get-room`, `activate-room`, `deactivate-room`, `create-im`, `add-member`, `remove-member`, `promote-owner`, `demote-owner`) rather than nested sub-groups (e.g. no `stream room create`). Rationale: matches the flat leaf style already used elsewhere in the CLI (e.g. `user search`, `message send`) and keeps `bdk stream --help` a single flat list, avoiding an extra container layer for only a handful of room-specific verbs.
+- **Room attributes as repeatable options, not a request-body file**: `create-room`/`update-room` expose `V3RoomAttributes` fields as individual `@Option`s (`--description`, `--public`/`--private`, `--discoverable`, `--members-can-invite`, `--read-only`, `--view-history`, `--cross-pod`). Rationale: consistent with how every other CLI command surfaces parameters; avoids introducing a new "JSON body from file" input mechanism for this one command family. Boolean options are tri-state (unset = don't send / use API default) — implemented by using boxed `Boolean` fields (not primitive `boolean`) left `null` unless the flag is passed, so `update-room` only sends fields the user explicitly set. Picocli supports this via `@Option(names = "--public", arity = "0..1")`-style boolean options or negatable option pairs.
+- **`update-room` semantics**: since `V3RoomAttributes` has no partial-update/PATCH semantics at the API level (`updateRoom` replaces the full attributes object), the command first calls `getRoomInfo(roomId)` to seed the current attributes, applies only the options the user explicitly passed on top, then calls `updateRoom`. Rationale: matches user expectation of "update just this field" rather than requiring every field to be re-specified on every update.
+- **`create-im` takes 1..N positional user ids**: `bdk stream create-im <userId>...` maps directly to `StreamService.create(List<Long>)` (bot included, IM if 1 id, MIM if ≥2). The admin-exclusive variant (`createInstantMessageAdmin`) is intentionally not exposed (matches non-goals).
+- **Membership/role commands take `<roomId> <userId>` positionals** (not options), mirroring the existing `stream members <streamId>` positional style and `StreamService`'s own `(userId, roomId)` parameter order reversed for CLI readability (`<roomId>` first, consistent with all other stream commands taking the room/stream id as the first positional).
+- **`get-room` vs existing `get`**: kept as a separate command rather than replacing `stream get` because `getStream` (generic, `V2StreamAttributes`) and `getRoomInfo` (room-specific, `V3RoomDetail` with system info) return different shapes and `getStream` also works for non-room streams (IMs/MIMs). Renaming or merging would be a breaking change to `stream get`.
+- **Activate/deactivate as separate verbs** rather than a single `set-active --active=true|false` command: mirrors natural CLI phrasing and avoids a boolean-flag command whose name doesn't convey direction.
+
+## Risks / Trade-offs
+
+- [Risk] `update-room`'s "fetch-then-merge" approach makes two API calls per update and has a (small) TOCTOU window between `getRoomInfo` and `updateRoom` if the room is concurrently modified. → Mitigation: acceptable for a one-shot CLI tool; document the behavior in the command's `--help` description so scripted callers are aware.
+- [Risk] Boolean tri-state options add minor complexity vs. plain `boolean` fields used elsewhere in the CLI (e.g. `UserSearchCommand`'s `--local`). → Mitigation: scope this pattern only to `create-room`/`update-room`; other new commands (membership, roles, IM creation, activate/deactivate) have no optional booleans and keep the simple style.
+- [Risk] Ten new leaf classes increase `StreamCommand`'s subcommand list significantly, which could clutter `bdk stream --help`. → Mitigation: picocli groups/sorts subcommands alphabetically by default and each has a one-line description; no further grouping needed given the CLI's existing flat style.
+
+## Open Questions
+
+None — scope and conventions are fully determined by the existing CLI patterns and `StreamService`'s current API surface.

--- a/openspec/changes/archive/2026-07-20-complete-stream-cli-commands/proposal.md
+++ b/openspec/changes/archive/2026-07-20-complete-stream-cli-commands/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The `bdk stream` CLI command group only exposes read operations (`get`, `list`, `members`), while `StreamService` also supports creating rooms and IMs, updating and (de)activating rooms, managing membership, and promoting/demoting owners. Bot operators currently have to write custom BDK code for these operations even though the BDK already implements them, making the CLI an incomplete substitute for scripting these day-to-day admin tasks.
+
+## What Changes
+
+- Add `bdk stream create-room <name> [options]` — creates a chatroom via `StreamService.create(V3RoomAttributes)`, exposing the common room attributes (description, public/private, discoverable, members-can-invite, read-only, view-history, cross-pod) as CLI options.
+- Add `bdk stream update-room <roomId> [options]` — updates an existing room's attributes via `StreamService.updateRoom`, using the same option set as `create-room` (only supplied options are applied).
+- Add `bdk stream get-room <roomId>` — fetches full room detail (attributes + system info) via `StreamService.getRoomInfo`, complementing the existing generic `stream get` (which returns `V2StreamAttributes`).
+- Add `bdk stream activate-room <roomId>` / `bdk stream deactivate-room <roomId>` — toggles a room's active state via `StreamService.setRoomActive`.
+- Add `bdk stream create-im <userId>...` — creates an IM or MIM (bot included) via `StreamService.create(List<Long>)`, accepting one or more user ids.
+- Add `bdk stream add-member <roomId> <userId>` — adds a member to a room via `StreamService.addMemberToRoom`.
+- Add `bdk stream remove-member <roomId> <userId>` — removes a member from a room via `StreamService.removeMemberFromRoom`.
+- Add `bdk stream promote-owner <roomId> <userId>` — promotes a room member to owner via `StreamService.promoteUserToRoomOwner`.
+- Add `bdk stream demote-owner <roomId> <userId>` — demotes a room owner to participant via `StreamService.demoteUserToRoomParticipant`.
+
+Out of scope (left for a future change, not needed to make the CLI cover the common day-to-day room/membership workflows): admin-only endpoints (`*Admin` variants, enterprise-wide stream listing), IM-specific update (`updateInstantMessage`/`getInstantMessageInfo`, currently limited to pinning a message), room/stream search (`searchRooms`), and content sharing (`share`).
+
+## Capabilities
+
+### New Capabilities
+- `stream-room-management-cli`: CLI commands to create, update, activate/deactivate, and fetch full detail for chatrooms.
+- `stream-membership-cli`: CLI commands to create IMs/MIMs, add/remove room members, and promote/demote room owners.
+
+### Modified Capabilities
+(none — this change only adds new CLI subcommands; no existing CLI command's behavior changes)
+
+## Impact
+
+- Affected code: `symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/` (new command classes: `StreamCreateRoomCommand`, `StreamUpdateRoomCommand`, `StreamGetRoomCommand`, `StreamActivateRoomCommand`, `StreamDeactivateRoomCommand`, `StreamCreateImCommand`, `StreamAddMemberCommand`, `StreamRemoveMemberCommand`, `StreamPromoteOwnerCommand`, `StreamDemoteOwnerCommand`) and `StreamCommand.java` (register new subcommands).
+- Tests: `symphony-bdk-cli/src/test/java/com/symphony/bdk/cli/CommandTest.java` (or a new dedicated test class) gains coverage for each new command, mocking `StreamService`.
+- No changes to `symphony-bdk-core` — all new commands are thin wrappers over existing `StreamService` methods.
+- No breaking changes; purely additive CLI surface.

--- a/openspec/changes/archive/2026-07-20-complete-stream-cli-commands/specs/stream-membership-cli/spec.md
+++ b/openspec/changes/archive/2026-07-20-complete-stream-cli-commands/specs/stream-membership-cli/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Create an IM or MIM
+The CLI SHALL provide a `bdk stream create-im <userId>...` command that creates an instant message (one other user id) or multi-party instant message (multiple other user ids) including the bot, via `StreamService.create(List<Long>)`, accepting one or more positional user ids.
+
+#### Scenario: Create an IM with a single user
+- **WHEN** the user runs `bdk stream create-im 12345`
+- **THEN** the CLI calls `StreamService.create(List.of(12345L))` and emits the resulting `Stream` as JSON with exit code 0
+
+#### Scenario: Create a MIM with multiple users
+- **WHEN** the user runs `bdk stream create-im 111 222 333`
+- **THEN** the CLI calls `StreamService.create(List.of(111L, 222L, 333L))` and emits the resulting `Stream` as JSON with exit code 0
+
+### Requirement: Add a member to a room
+The CLI SHALL provide a `bdk stream add-member <roomId> <userId>` command that adds a user to a room via `StreamService.addMemberToRoom`.
+
+#### Scenario: Add a member successfully
+- **WHEN** the user runs `bdk stream add-member ROOM1 12345`
+- **THEN** the CLI calls `StreamService.addMemberToRoom(12345L, "ROOM1")` and, on success, emits a JSON confirmation object with exit code 0
+
+#### Scenario: Add a member to a non-existent room
+- **WHEN** the user runs `bdk stream add-member UNKNOWN 12345` and the underlying API responds with HTTP 404
+- **THEN** the CLI exits with code 3
+
+### Requirement: Remove a member from a room
+The CLI SHALL provide a `bdk stream remove-member <roomId> <userId>` command that removes a user from a room via `StreamService.removeMemberFromRoom`.
+
+#### Scenario: Remove a member successfully
+- **WHEN** the user runs `bdk stream remove-member ROOM1 12345`
+- **THEN** the CLI calls `StreamService.removeMemberFromRoom(12345L, "ROOM1")` and, on success, emits a JSON confirmation object with exit code 0
+
+### Requirement: Promote a room member to owner
+The CLI SHALL provide a `bdk stream promote-owner <roomId> <userId>` command that promotes a room member to owner via `StreamService.promoteUserToRoomOwner`.
+
+#### Scenario: Promote a member to owner
+- **WHEN** the user runs `bdk stream promote-owner ROOM1 12345`
+- **THEN** the CLI calls `StreamService.promoteUserToRoomOwner(12345L, "ROOM1")` and, on success, emits a JSON confirmation object with exit code 0
+
+### Requirement: Demote a room owner to participant
+The CLI SHALL provide a `bdk stream demote-owner <roomId> <userId>` command that demotes a room owner to participant via `StreamService.demoteUserToRoomParticipant`.
+
+#### Scenario: Demote an owner to participant
+- **WHEN** the user runs `bdk stream demote-owner ROOM1 12345`
+- **THEN** the CLI calls `StreamService.demoteUserToRoomParticipant(12345L, "ROOM1")` and, on success, emits a JSON confirmation object with exit code 0

--- a/openspec/changes/archive/2026-07-20-complete-stream-cli-commands/specs/stream-room-management-cli/spec.md
+++ b/openspec/changes/archive/2026-07-20-complete-stream-cli-commands/specs/stream-room-management-cli/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Create a chatroom
+The CLI SHALL provide a `bdk stream create-room <name>` command that creates a new chatroom via `StreamService.create(V3RoomAttributes)`, accepting `--description`, `--public`/`--private`, `--discoverable`, `--members-can-invite`, `--read-only`, `--view-history`, and `--cross-pod` options to populate the room attributes, and emits the resulting room detail as JSON on success.
+
+#### Scenario: Create a room with only a name
+- **WHEN** the user runs `bdk stream create-room "Trading Desk"` with no other options
+- **THEN** the CLI calls `StreamService.create` with a `V3RoomAttributes` whose name is `"Trading Desk"` and all unspecified fields left unset, and emits the created room's `V3RoomDetail` as JSON with exit code 0
+
+#### Scenario: Create a room with attribute options
+- **WHEN** the user runs `bdk stream create-room "Trading Desk" --description "Desk chat" --public --discoverable`
+- **THEN** the CLI populates the corresponding fields on `V3RoomAttributes` before calling `StreamService.create`, and emits the created room detail as JSON with exit code 0
+
+### Requirement: Update a chatroom's attributes
+The CLI SHALL provide a `bdk stream update-room <roomId> [options]` command that updates only the attributes explicitly passed by the user, leaving all other attributes at their current value, via `StreamService.updateRoom`.
+
+#### Scenario: Update a single attribute
+- **WHEN** the user runs `bdk stream update-room ROOM1 --description "New description"`
+- **THEN** the CLI fetches the room's current attributes via `StreamService.getRoomInfo("ROOM1")`, overrides only the description field, calls `StreamService.updateRoom("ROOM1", ...)` with the merged attributes, and emits the updated room detail as JSON with exit code 0
+
+#### Scenario: Update a room that does not exist
+- **WHEN** the user runs `bdk stream update-room UNKNOWN --description "x"` and the underlying API responds with HTTP 404
+- **THEN** the CLI exits with code 3
+
+### Requirement: Get full room detail
+The CLI SHALL provide a `bdk stream get-room <roomId>` command that fetches a room's full detail (attributes and system info) via `StreamService.getRoomInfo` and emits it as JSON.
+
+#### Scenario: Get an existing room's detail
+- **WHEN** the user runs `bdk stream get-room ROOM1` and the room exists
+- **THEN** the CLI emits the `V3RoomDetail` returned by `StreamService.getRoomInfo("ROOM1")` as JSON with exit code 0
+
+#### Scenario: Get a room that does not exist
+- **WHEN** the user runs `bdk stream get-room UNKNOWN` and the underlying API responds with HTTP 404
+- **THEN** the CLI exits with code 3
+
+### Requirement: Activate and deactivate a chatroom
+The CLI SHALL provide `bdk stream activate-room <roomId>` and `bdk stream deactivate-room <roomId>` commands that toggle a room's active state via `StreamService.setRoomActive`.
+
+#### Scenario: Deactivate a room
+- **WHEN** the user runs `bdk stream deactivate-room ROOM1`
+- **THEN** the CLI calls `StreamService.setRoomActive("ROOM1", false)` and emits the resulting `RoomDetail` as JSON with exit code 0
+
+#### Scenario: Activate a room
+- **WHEN** the user runs `bdk stream activate-room ROOM1`
+- **THEN** the CLI calls `StreamService.setRoomActive("ROOM1", true)` and emits the resulting `RoomDetail` as JSON with exit code 0

--- a/openspec/changes/archive/2026-07-20-complete-stream-cli-commands/tasks.md
+++ b/openspec/changes/archive/2026-07-20-complete-stream-cli-commands/tasks.md
@@ -1,0 +1,31 @@
+## 1. Room lifecycle commands
+
+- [x] 1.1 Implement `StreamCreateRoomCommand` (`bdk stream create-room <name> [--description] [--public|--private] [--discoverable] [--members-can-invite] [--read-only] [--view-history] [--cross-pod]`), building `V3RoomAttributes` from the supplied options and calling `StreamService.create(V3RoomAttributes)`.
+- [x] 1.2 Implement `StreamUpdateRoomCommand` (`bdk stream update-room <roomId> [same options as create-room]`): fetch current attributes via `getRoomInfo`, apply only explicitly-passed options, call `StreamService.updateRoom`.
+- [x] 1.3 Implement `StreamGetRoomCommand` (`bdk stream get-room <roomId>`) calling `StreamService.getRoomInfo`, throwing `NotFoundException` if the result is null.
+- [x] 1.4 Implement `StreamActivateRoomCommand` (`bdk stream activate-room <roomId>`) calling `StreamService.setRoomActive(roomId, true)`.
+- [x] 1.5 Implement `StreamDeactivateRoomCommand` (`bdk stream deactivate-room <roomId>`) calling `StreamService.setRoomActive(roomId, false)`.
+
+## 2. Membership and role commands
+
+- [x] 2.1 Implement `StreamCreateImCommand` (`bdk stream create-im <userId>...`, one or more positional user ids) calling `StreamService.create(List<Long>)`.
+- [x] 2.2 Implement `StreamAddMemberCommand` (`bdk stream add-member <roomId> <userId>`) calling `StreamService.addMemberToRoom`.
+- [x] 2.3 Implement `StreamRemoveMemberCommand` (`bdk stream remove-member <roomId> <userId>`) calling `StreamService.removeMemberFromRoom`.
+- [x] 2.4 Implement `StreamPromoteOwnerCommand` (`bdk stream promote-owner <roomId> <userId>`) calling `StreamService.promoteUserToRoomOwner`.
+- [x] 2.5 Implement `StreamDemoteOwnerCommand` (`bdk stream demote-owner <roomId> <userId>`) calling `StreamService.demoteUserToRoomParticipant`.
+
+## 3. Wiring and registration
+
+- [x] 3.1 Register all 10 new leaf commands as `subcommands` on `StreamCommand`.
+- [x] 3.2 For the `void`-returning `StreamService` methods (`addMemberToRoom`, `removeMemberFromRoom`, `promoteUserToRoomOwner`, `demoteUserToRoomParticipant`), define and emit a small JSON confirmation payload (e.g. `{"roomId": ..., "userId": ..., "status": "..."}`) consistent across the four commands.
+
+## 4. Tests
+
+- [x] 4.1 Add tests for `create-room` and `update-room`, covering: name-only creation, creation/update with attribute options, update-not-found (404 → exit 3), and verifying only explicitly-passed options are merged into `updateRoom`'s payload.
+- [x] 4.2 Add tests for `get-room` (found and not-found/404 cases), `activate-room`, and `deactivate-room`.
+- [x] 4.3 Add tests for `create-im` (single user id → IM, multiple ids → MIM).
+- [x] 4.4 Add tests for `add-member`, `remove-member`, `promote-owner`, `demote-owner`, including a not-found (404 → exit 3) case for at least one of them.
+
+## 5. Documentation
+
+- [x] 5.1 Update any CLI usage documentation/README listing available `bdk stream` subcommands to include the 10 new commands.

--- a/openspec/specs/stream-membership-cli/spec.md
+++ b/openspec/specs/stream-membership-cli/spec.md
@@ -1,0 +1,44 @@
+# Stream-Membership-Cli Specification
+
+### Requirement: Create an IM or MIM
+The CLI SHALL provide a `bdk stream create-im <userId>...` command that creates an instant message (one other user id) or multi-party instant message (multiple other user ids) including the bot, via `StreamService.create(List<Long>)`, accepting one or more positional user ids.
+
+#### Scenario: Create an IM with a single user
+- **WHEN** the user runs `bdk stream create-im 12345`
+- **THEN** the CLI calls `StreamService.create(List.of(12345L))` and emits the resulting `Stream` as JSON with exit code 0
+
+#### Scenario: Create a MIM with multiple users
+- **WHEN** the user runs `bdk stream create-im 111 222 333`
+- **THEN** the CLI calls `StreamService.create(List.of(111L, 222L, 333L))` and emits the resulting `Stream` as JSON with exit code 0
+
+### Requirement: Add a member to a room
+The CLI SHALL provide a `bdk stream add-member <roomId> <userId>` command that adds a user to a room via `StreamService.addMemberToRoom`.
+
+#### Scenario: Add a member successfully
+- **WHEN** the user runs `bdk stream add-member ROOM1 12345`
+- **THEN** the CLI calls `StreamService.addMemberToRoom(12345L, "ROOM1")` and, on success, emits a JSON confirmation object with exit code 0
+
+#### Scenario: Add a member to a non-existent room
+- **WHEN** the user runs `bdk stream add-member UNKNOWN 12345` and the underlying API responds with HTTP 404
+- **THEN** the CLI exits with code 3
+
+### Requirement: Remove a member from a room
+The CLI SHALL provide a `bdk stream remove-member <roomId> <userId>` command that removes a user from a room via `StreamService.removeMemberFromRoom`.
+
+#### Scenario: Remove a member successfully
+- **WHEN** the user runs `bdk stream remove-member ROOM1 12345`
+- **THEN** the CLI calls `StreamService.removeMemberFromRoom(12345L, "ROOM1")` and, on success, emits a JSON confirmation object with exit code 0
+
+### Requirement: Promote a room member to owner
+The CLI SHALL provide a `bdk stream promote-owner <roomId> <userId>` command that promotes a room member to owner via `StreamService.promoteUserToRoomOwner`.
+
+#### Scenario: Promote a member to owner
+- **WHEN** the user runs `bdk stream promote-owner ROOM1 12345`
+- **THEN** the CLI calls `StreamService.promoteUserToRoomOwner(12345L, "ROOM1")` and, on success, emits a JSON confirmation object with exit code 0
+
+### Requirement: Demote a room owner to participant
+The CLI SHALL provide a `bdk stream demote-owner <roomId> <userId>` command that demotes a room owner to participant via `StreamService.demoteUserToRoomParticipant`.
+
+#### Scenario: Demote an owner to participant
+- **WHEN** the user runs `bdk stream demote-owner ROOM1 12345`
+- **THEN** the CLI calls `StreamService.demoteUserToRoomParticipant(12345L, "ROOM1")` and, on success, emits a JSON confirmation object with exit code 0

--- a/openspec/specs/stream-room-management-cli/spec.md
+++ b/openspec/specs/stream-room-management-cli/spec.md
@@ -1,0 +1,45 @@
+# Stream-Room-Management-Cli Specification
+
+### Requirement: Create a chatroom
+The CLI SHALL provide a `bdk stream create-room <name>` command that creates a new chatroom via `StreamService.create(V3RoomAttributes)`, accepting `--description`, `--public`/`--private`, `--discoverable`, `--members-can-invite`, `--read-only`, `--view-history`, and `--cross-pod` options to populate the room attributes, and emits the resulting room detail as JSON on success.
+
+#### Scenario: Create a room with only a name
+- **WHEN** the user runs `bdk stream create-room "Trading Desk"` with no other options
+- **THEN** the CLI calls `StreamService.create` with a `V3RoomAttributes` whose name is `"Trading Desk"` and all unspecified fields left unset, and emits the created room's `V3RoomDetail` as JSON with exit code 0
+
+#### Scenario: Create a room with attribute options
+- **WHEN** the user runs `bdk stream create-room "Trading Desk" --description "Desk chat" --public --discoverable`
+- **THEN** the CLI populates the corresponding fields on `V3RoomAttributes` before calling `StreamService.create`, and emits the created room detail as JSON with exit code 0
+
+### Requirement: Update a chatroom's attributes
+The CLI SHALL provide a `bdk stream update-room <roomId> [options]` command that updates only the attributes explicitly passed by the user, leaving all other attributes at their current value, via `StreamService.updateRoom`.
+
+#### Scenario: Update a single attribute
+- **WHEN** the user runs `bdk stream update-room ROOM1 --description "New description"`
+- **THEN** the CLI fetches the room's current attributes via `StreamService.getRoomInfo("ROOM1")`, overrides only the description field, calls `StreamService.updateRoom("ROOM1", ...)` with the merged attributes, and emits the updated room detail as JSON with exit code 0
+
+#### Scenario: Update a room that does not exist
+- **WHEN** the user runs `bdk stream update-room UNKNOWN --description "x"` and the underlying API responds with HTTP 404
+- **THEN** the CLI exits with code 3
+
+### Requirement: Get full room detail
+The CLI SHALL provide a `bdk stream get-room <roomId>` command that fetches a room's full detail (attributes and system info) via `StreamService.getRoomInfo` and emits it as JSON.
+
+#### Scenario: Get an existing room's detail
+- **WHEN** the user runs `bdk stream get-room ROOM1` and the room exists
+- **THEN** the CLI emits the `V3RoomDetail` returned by `StreamService.getRoomInfo("ROOM1")` as JSON with exit code 0
+
+#### Scenario: Get a room that does not exist
+- **WHEN** the user runs `bdk stream get-room UNKNOWN` and the underlying API responds with HTTP 404
+- **THEN** the CLI exits with code 3
+
+### Requirement: Activate and deactivate a chatroom
+The CLI SHALL provide `bdk stream activate-room <roomId>` and `bdk stream deactivate-room <roomId>` commands that toggle a room's active state via `StreamService.setRoomActive`.
+
+#### Scenario: Deactivate a room
+- **WHEN** the user runs `bdk stream deactivate-room ROOM1`
+- **THEN** the CLI calls `StreamService.setRoomActive("ROOM1", false)` and emits the resulting `RoomDetail` as JSON with exit code 0
+
+#### Scenario: Activate a room
+- **WHEN** the user runs `bdk stream activate-room ROOM1`
+- **THEN** the CLI calls `StreamService.setRoomActive("ROOM1", true)` and emits the resulting `RoomDetail` as JSON with exit code 0

--- a/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/RoomAttributesOptions.java
+++ b/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/RoomAttributesOptions.java
@@ -1,0 +1,64 @@
+package com.symphony.bdk.cli.command.stream;
+
+import com.symphony.bdk.gen.api.model.V3RoomAttributes;
+
+import picocli.CommandLine.Option;
+
+/**
+ * Shared {@code create-room}/{@code update-room} attribute options, applied to a {@link
+ * V3RoomAttributes} instance. Every field is left {@code null}/{@code false} unless the
+ * corresponding flag is explicitly passed, so {@link #applyTo} only overrides attributes the user
+ * asked for.
+ */
+class RoomAttributesOptions {
+
+  @Option(names = "--description", description = "Room description.")
+  String description;
+
+  @Option(names = "--public", description = "Make the room public.")
+  boolean publicFlag;
+
+  @Option(names = "--private", description = "Make the room private.")
+  boolean privateFlag;
+
+  @Option(names = "--discoverable", description = "Allow non-participants to search and list the room.")
+  Boolean discoverable;
+
+  @Option(names = "--members-can-invite", description = "Allow any participant (not just owners) to add new members.")
+  Boolean membersCanInvite;
+
+  @Option(names = "--read-only", description = "Restrict sending messages to room owners.")
+  Boolean readOnly;
+
+  @Option(names = "--view-history", description = "Allow new members to view the room's chat history.")
+  Boolean viewHistory;
+
+  @Option(names = "--cross-pod", description = "Mark the room as a cross-pod room.")
+  Boolean crossPod;
+
+  void applyTo(V3RoomAttributes attributes) {
+    if (description != null) {
+      attributes.setDescription(description);
+    }
+    if (publicFlag) {
+      attributes.setPublic(true);
+    } else if (privateFlag) {
+      attributes.setPublic(false);
+    }
+    if (discoverable != null) {
+      attributes.setDiscoverable(discoverable);
+    }
+    if (membersCanInvite != null) {
+      attributes.setMembersCanInvite(membersCanInvite);
+    }
+    if (readOnly != null) {
+      attributes.setReadOnly(readOnly);
+    }
+    if (viewHistory != null) {
+      attributes.setViewHistory(viewHistory);
+    }
+    if (crossPod != null) {
+      attributes.setCrossPod(crossPod);
+    }
+  }
+}

--- a/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/RoomMembershipResult.java
+++ b/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/RoomMembershipResult.java
@@ -1,0 +1,19 @@
+package com.symphony.bdk.cli.command.stream;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** JSON confirmation payload shared by the room membership/role commands. */
+final class RoomMembershipResult {
+
+  private RoomMembershipResult() {
+  }
+
+  static Map<String, Object> of(String roomId, Long userId, String status) {
+    final Map<String, Object> result = new LinkedHashMap<>();
+    result.put("roomId", roomId);
+    result.put("userId", userId);
+    result.put("status", status);
+    return result;
+  }
+}

--- a/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamActivateRoomCommand.java
+++ b/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamActivateRoomCommand.java
@@ -1,0 +1,21 @@
+package com.symphony.bdk.cli.command.stream;
+
+import com.symphony.bdk.cli.command.BaseCommand;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/** {@code bdk stream activate-room <roomId>}. */
+@Command(
+    name = "activate-room",
+    description = "Reactivate a deactivated chatroom.")
+public class StreamActivateRoomCommand extends BaseCommand {
+
+  @Parameters(index = "0", paramLabel = "<roomId>", description = "Room id.")
+  String roomId;
+
+  @Override
+  public Integer call() throws Exception {
+    return emit(bdk().streams().setRoomActive(roomId, true));
+  }
+}

--- a/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamAddMemberCommand.java
+++ b/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamAddMemberCommand.java
@@ -1,0 +1,25 @@
+package com.symphony.bdk.cli.command.stream;
+
+import com.symphony.bdk.cli.command.BaseCommand;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/** {@code bdk stream add-member <roomId> <userId>}. */
+@Command(
+    name = "add-member",
+    description = "Add a member to a room.")
+public class StreamAddMemberCommand extends BaseCommand {
+
+  @Parameters(index = "0", paramLabel = "<roomId>", description = "Room id.")
+  String roomId;
+
+  @Parameters(index = "1", paramLabel = "<userId>", description = "User id to add.")
+  Long userId;
+
+  @Override
+  public Integer call() throws Exception {
+    bdk().streams().addMemberToRoom(userId, roomId);
+    return emit(RoomMembershipResult.of(roomId, userId, "added"));
+  }
+}

--- a/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamCommand.java
+++ b/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamCommand.java
@@ -11,7 +11,17 @@ import picocli.CommandLine.Command;
     subcommands = {
         StreamListCommand.class,
         StreamMembersCommand.class,
-        StreamGetCommand.class
+        StreamGetCommand.class,
+        StreamCreateRoomCommand.class,
+        StreamUpdateRoomCommand.class,
+        StreamGetRoomCommand.class,
+        StreamActivateRoomCommand.class,
+        StreamDeactivateRoomCommand.class,
+        StreamCreateImCommand.class,
+        StreamAddMemberCommand.class,
+        StreamRemoveMemberCommand.class,
+        StreamPromoteOwnerCommand.class,
+        StreamDemoteOwnerCommand.class
     })
 public class StreamCommand extends ContainerCommand {
 }

--- a/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamCreateImCommand.java
+++ b/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamCreateImCommand.java
@@ -1,0 +1,23 @@
+package com.symphony.bdk.cli.command.stream;
+
+import com.symphony.bdk.cli.command.BaseCommand;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+import java.util.List;
+
+/** {@code bdk stream create-im <userId>...}. */
+@Command(
+    name = "create-im",
+    description = "Create an IM (one user id) or MIM (several user ids), bot included.")
+public class StreamCreateImCommand extends BaseCommand {
+
+  @Parameters(index = "0..*", paramLabel = "<userId>", description = "User id(s) to include, other than the bot.")
+  List<Long> userIds;
+
+  @Override
+  public Integer call() throws Exception {
+    return emit(bdk().streams().create(userIds));
+  }
+}

--- a/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamCreateRoomCommand.java
+++ b/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamCreateRoomCommand.java
@@ -1,0 +1,28 @@
+package com.symphony.bdk.cli.command.stream;
+
+import com.symphony.bdk.cli.command.BaseCommand;
+import com.symphony.bdk.gen.api.model.V3RoomAttributes;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Parameters;
+
+/** {@code bdk stream create-room <name> [options]}. */
+@Command(
+    name = "create-room",
+    description = "Create a chatroom.")
+public class StreamCreateRoomCommand extends BaseCommand {
+
+  @Parameters(index = "0", paramLabel = "<name>", description = "Room name.")
+  String name;
+
+  @Mixin
+  RoomAttributesOptions options;
+
+  @Override
+  public Integer call() throws Exception {
+    final V3RoomAttributes attributes = new V3RoomAttributes().name(name);
+    options.applyTo(attributes);
+    return emit(bdk().streams().create(attributes));
+  }
+}

--- a/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamDeactivateRoomCommand.java
+++ b/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamDeactivateRoomCommand.java
@@ -1,0 +1,21 @@
+package com.symphony.bdk.cli.command.stream;
+
+import com.symphony.bdk.cli.command.BaseCommand;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/** {@code bdk stream deactivate-room <roomId>}. */
+@Command(
+    name = "deactivate-room",
+    description = "Deactivate a chatroom.")
+public class StreamDeactivateRoomCommand extends BaseCommand {
+
+  @Parameters(index = "0", paramLabel = "<roomId>", description = "Room id.")
+  String roomId;
+
+  @Override
+  public Integer call() throws Exception {
+    return emit(bdk().streams().setRoomActive(roomId, false));
+  }
+}

--- a/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamDemoteOwnerCommand.java
+++ b/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamDemoteOwnerCommand.java
@@ -1,0 +1,25 @@
+package com.symphony.bdk.cli.command.stream;
+
+import com.symphony.bdk.cli.command.BaseCommand;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/** {@code bdk stream demote-owner <roomId> <userId>}. */
+@Command(
+    name = "demote-owner",
+    description = "Demote a room owner to participant.")
+public class StreamDemoteOwnerCommand extends BaseCommand {
+
+  @Parameters(index = "0", paramLabel = "<roomId>", description = "Room id.")
+  String roomId;
+
+  @Parameters(index = "1", paramLabel = "<userId>", description = "User id to demote.")
+  Long userId;
+
+  @Override
+  public Integer call() throws Exception {
+    bdk().streams().demoteUserToRoomParticipant(userId, roomId);
+    return emit(RoomMembershipResult.of(roomId, userId, "demoted"));
+  }
+}

--- a/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamGetRoomCommand.java
+++ b/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamGetRoomCommand.java
@@ -1,0 +1,27 @@
+package com.symphony.bdk.cli.command.stream;
+
+import com.symphony.bdk.cli.command.BaseCommand;
+import com.symphony.bdk.cli.internal.NotFoundException;
+import com.symphony.bdk.gen.api.model.V3RoomDetail;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/** {@code bdk stream get-room <roomId>}. */
+@Command(
+    name = "get-room",
+    description = "Get a chatroom's full detail (attributes and system info).")
+public class StreamGetRoomCommand extends BaseCommand {
+
+  @Parameters(index = "0", paramLabel = "<roomId>", description = "Room id.")
+  String roomId;
+
+  @Override
+  public Integer call() throws Exception {
+    final V3RoomDetail room = bdk().streams().getRoomInfo(roomId);
+    if (room == null) {
+      throw NotFoundException.of("room", roomId);
+    }
+    return emit(room);
+  }
+}

--- a/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamPromoteOwnerCommand.java
+++ b/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamPromoteOwnerCommand.java
@@ -1,0 +1,25 @@
+package com.symphony.bdk.cli.command.stream;
+
+import com.symphony.bdk.cli.command.BaseCommand;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/** {@code bdk stream promote-owner <roomId> <userId>}. */
+@Command(
+    name = "promote-owner",
+    description = "Promote a room member to owner.")
+public class StreamPromoteOwnerCommand extends BaseCommand {
+
+  @Parameters(index = "0", paramLabel = "<roomId>", description = "Room id.")
+  String roomId;
+
+  @Parameters(index = "1", paramLabel = "<userId>", description = "User id to promote.")
+  Long userId;
+
+  @Override
+  public Integer call() throws Exception {
+    bdk().streams().promoteUserToRoomOwner(userId, roomId);
+    return emit(RoomMembershipResult.of(roomId, userId, "promoted"));
+  }
+}

--- a/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamRemoveMemberCommand.java
+++ b/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamRemoveMemberCommand.java
@@ -1,0 +1,25 @@
+package com.symphony.bdk.cli.command.stream;
+
+import com.symphony.bdk.cli.command.BaseCommand;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/** {@code bdk stream remove-member <roomId> <userId>}. */
+@Command(
+    name = "remove-member",
+    description = "Remove a member from a room.")
+public class StreamRemoveMemberCommand extends BaseCommand {
+
+  @Parameters(index = "0", paramLabel = "<roomId>", description = "Room id.")
+  String roomId;
+
+  @Parameters(index = "1", paramLabel = "<userId>", description = "User id to remove.")
+  Long userId;
+
+  @Override
+  public Integer call() throws Exception {
+    bdk().streams().removeMemberFromRoom(userId, roomId);
+    return emit(RoomMembershipResult.of(roomId, userId, "removed"));
+  }
+}

--- a/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamUpdateRoomCommand.java
+++ b/symphony-bdk-cli/src/main/java/com/symphony/bdk/cli/command/stream/StreamUpdateRoomCommand.java
@@ -1,0 +1,35 @@
+package com.symphony.bdk.cli.command.stream;
+
+import com.symphony.bdk.cli.command.BaseCommand;
+import com.symphony.bdk.cli.internal.NotFoundException;
+import com.symphony.bdk.gen.api.model.V3RoomAttributes;
+import com.symphony.bdk.gen.api.model.V3RoomDetail;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Parameters;
+
+/** {@code bdk stream update-room <roomId> [options]}. */
+@Command(
+    name = "update-room",
+    description = "Update a chatroom's attributes. Fetches the room's current attributes first "
+        + "and only overrides the ones explicitly passed.")
+public class StreamUpdateRoomCommand extends BaseCommand {
+
+  @Parameters(index = "0", paramLabel = "<roomId>", description = "Room id.")
+  String roomId;
+
+  @Mixin
+  RoomAttributesOptions options;
+
+  @Override
+  public Integer call() throws Exception {
+    final V3RoomDetail current = bdk().streams().getRoomInfo(roomId);
+    if (current == null) {
+      throw NotFoundException.of("room", roomId);
+    }
+    final V3RoomAttributes attributes = current.getRoomAttributes();
+    options.applyTo(attributes);
+    return emit(bdk().streams().updateRoom(roomId, attributes));
+  }
+}

--- a/symphony-bdk-cli/src/test/java/com/symphony/bdk/cli/CommandTest.java
+++ b/symphony-bdk-cli/src/test/java/com/symphony/bdk/cli/CommandTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -17,6 +18,8 @@ import com.symphony.bdk.core.service.message.MessageService;
 import com.symphony.bdk.core.service.session.SessionService;
 import com.symphony.bdk.core.service.stream.StreamService;
 import com.symphony.bdk.core.service.user.UserService;
+import com.symphony.bdk.gen.api.model.RoomDetail;
+import com.symphony.bdk.gen.api.model.Stream;
 import com.symphony.bdk.gen.api.model.StreamAttributes;
 import com.symphony.bdk.gen.api.model.UserSearchQuery;
 import com.symphony.bdk.gen.api.model.UserV2;
@@ -24,7 +27,11 @@ import com.symphony.bdk.gen.api.model.V2MembershipList;
 import com.symphony.bdk.gen.api.model.V2StreamAttributes;
 import com.symphony.bdk.gen.api.model.V3Health;
 import com.symphony.bdk.gen.api.model.V3HealthStatus;
+import com.symphony.bdk.gen.api.model.V3RoomAttributes;
+import com.symphony.bdk.gen.api.model.V3RoomDetail;
 import com.symphony.bdk.gen.api.model.V4Message;
+import com.symphony.bdk.http.api.ApiException;
+import com.symphony.bdk.http.api.ApiRuntimeException;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -117,6 +124,184 @@ class CommandTest extends CliTestBase {
 
     assertThat(execute(bdk, "stream", "get", "S1")).isZero();
     assertThat(JSON.readTree(stdout()).get("id").asText()).isEqualTo("S1");
+  }
+
+  @Test
+  void streamCreateRoomWithNameOnlyPrintsResult() throws Exception {
+    final SymphonyBdk bdk = mock(SymphonyBdk.class);
+    final StreamService streams = mock(StreamService.class);
+    when(bdk.streams()).thenReturn(streams);
+    when(streams.create(any(V3RoomAttributes.class))).thenReturn(new V3RoomDetail().roomAttributes(new V3RoomAttributes().name("Trading Desk")));
+
+    assertThat(execute(bdk, "stream", "create-room", "Trading Desk")).isZero();
+    final ArgumentCaptor<V3RoomAttributes> captor = ArgumentCaptor.forClass(V3RoomAttributes.class);
+    verify(streams).create(captor.capture());
+    assertThat(captor.getValue().getName()).isEqualTo("Trading Desk");
+    assertThat(captor.getValue().getPublic()).isNull();
+    assertThat(captor.getValue().getDiscoverable()).isNull();
+    assertThat(JSON.readTree(stdout()).get("roomAttributes").get("name").asText()).isEqualTo("Trading Desk");
+  }
+
+  @Test
+  void streamCreateRoomWithOptionsPopulatesAttributes() throws Exception {
+    final SymphonyBdk bdk = mock(SymphonyBdk.class);
+    final StreamService streams = mock(StreamService.class);
+    when(bdk.streams()).thenReturn(streams);
+    when(streams.create(any(V3RoomAttributes.class))).thenReturn(new V3RoomDetail());
+
+    assertThat(execute(bdk, "stream", "create-room", "Trading Desk",
+        "--description", "Desk chat", "--public", "--discoverable")).isZero();
+    final ArgumentCaptor<V3RoomAttributes> captor = ArgumentCaptor.forClass(V3RoomAttributes.class);
+    verify(streams).create(captor.capture());
+    assertThat(captor.getValue().getDescription()).isEqualTo("Desk chat");
+    assertThat(captor.getValue().getPublic()).isTrue();
+    assertThat(captor.getValue().getDiscoverable()).isTrue();
+  }
+
+  @Test
+  void streamUpdateRoomMergesOnlyExplicitlyPassedOptions() throws Exception {
+    final SymphonyBdk bdk = mock(SymphonyBdk.class);
+    final StreamService streams = mock(StreamService.class);
+    when(bdk.streams()).thenReturn(streams);
+    final V3RoomAttributes current = new V3RoomAttributes().name("Trading Desk").description("Old").discoverable(true);
+    when(streams.getRoomInfo("ROOM1")).thenReturn(new V3RoomDetail().roomAttributes(current));
+    when(streams.updateRoom(eq("ROOM1"), any(V3RoomAttributes.class))).thenReturn(new V3RoomDetail());
+
+    assertThat(execute(bdk, "stream", "update-room", "ROOM1", "--description", "New description")).isZero();
+    final ArgumentCaptor<V3RoomAttributes> captor = ArgumentCaptor.forClass(V3RoomAttributes.class);
+    verify(streams).updateRoom(eq("ROOM1"), captor.capture());
+    assertThat(captor.getValue().getDescription()).isEqualTo("New description");
+    assertThat(captor.getValue().getName()).isEqualTo("Trading Desk");
+    assertThat(captor.getValue().getDiscoverable()).isTrue();
+  }
+
+  @Test
+  void streamUpdateRoomNotFoundExitsThree() {
+    final SymphonyBdk bdk = mock(SymphonyBdk.class);
+    final StreamService streams = mock(StreamService.class);
+    when(bdk.streams()).thenReturn(streams);
+    when(streams.getRoomInfo("UNKNOWN")).thenReturn(null);
+
+    assertThat(execute(bdk, "stream", "update-room", "UNKNOWN", "--description", "x")).isEqualTo(3);
+  }
+
+  @Test
+  void streamGetRoomPrintsDetail() throws Exception {
+    final SymphonyBdk bdk = mock(SymphonyBdk.class);
+    final StreamService streams = mock(StreamService.class);
+    when(bdk.streams()).thenReturn(streams);
+    when(streams.getRoomInfo("ROOM1")).thenReturn(new V3RoomDetail().roomAttributes(new V3RoomAttributes().name("Trading Desk")));
+
+    assertThat(execute(bdk, "stream", "get-room", "ROOM1")).isZero();
+    assertThat(JSON.readTree(stdout()).get("roomAttributes").get("name").asText()).isEqualTo("Trading Desk");
+  }
+
+  @Test
+  void streamGetRoomNotFoundExitsThree() {
+    final SymphonyBdk bdk = mock(SymphonyBdk.class);
+    final StreamService streams = mock(StreamService.class);
+    when(bdk.streams()).thenReturn(streams);
+    when(streams.getRoomInfo("UNKNOWN")).thenReturn(null);
+
+    assertThat(execute(bdk, "stream", "get-room", "UNKNOWN")).isEqualTo(3);
+  }
+
+  @Test
+  void streamActivateRoomCallsSetRoomActiveTrue() throws Exception {
+    final SymphonyBdk bdk = mock(SymphonyBdk.class);
+    final StreamService streams = mock(StreamService.class);
+    when(bdk.streams()).thenReturn(streams);
+    when(streams.setRoomActive("ROOM1", true)).thenReturn(new RoomDetail());
+
+    assertThat(execute(bdk, "stream", "activate-room", "ROOM1")).isZero();
+    verify(streams).setRoomActive("ROOM1", true);
+  }
+
+  @Test
+  void streamDeactivateRoomCallsSetRoomActiveFalse() throws Exception {
+    final SymphonyBdk bdk = mock(SymphonyBdk.class);
+    final StreamService streams = mock(StreamService.class);
+    when(bdk.streams()).thenReturn(streams);
+    when(streams.setRoomActive("ROOM1", false)).thenReturn(new RoomDetail());
+
+    assertThat(execute(bdk, "stream", "deactivate-room", "ROOM1")).isZero();
+    verify(streams).setRoomActive("ROOM1", false);
+  }
+
+  @Test
+  void streamCreateImWithSingleUserCreatesIm() throws Exception {
+    final SymphonyBdk bdk = mock(SymphonyBdk.class);
+    final StreamService streams = mock(StreamService.class);
+    when(bdk.streams()).thenReturn(streams);
+    when(streams.create(List.of(12345L))).thenReturn(new Stream().id("IM1"));
+
+    assertThat(execute(bdk, "stream", "create-im", "12345")).isZero();
+    verify(streams).create(List.of(12345L));
+    assertThat(JSON.readTree(stdout()).get("id").asText()).isEqualTo("IM1");
+  }
+
+  @Test
+  void streamCreateImWithMultipleUsersCreatesMim() throws Exception {
+    final SymphonyBdk bdk = mock(SymphonyBdk.class);
+    final StreamService streams = mock(StreamService.class);
+    when(bdk.streams()).thenReturn(streams);
+    when(streams.create(List.of(111L, 222L, 333L))).thenReturn(new Stream().id("MIM1"));
+
+    assertThat(execute(bdk, "stream", "create-im", "111", "222", "333")).isZero();
+    verify(streams).create(List.of(111L, 222L, 333L));
+  }
+
+  @Test
+  void streamAddMemberCallsAddMemberToRoom() throws Exception {
+    final SymphonyBdk bdk = mock(SymphonyBdk.class);
+    final StreamService streams = mock(StreamService.class);
+    when(bdk.streams()).thenReturn(streams);
+
+    assertThat(execute(bdk, "stream", "add-member", "ROOM1", "12345")).isZero();
+    verify(streams).addMemberToRoom(12345L, "ROOM1");
+    assertThat(JSON.readTree(stdout()).get("roomId").asText()).isEqualTo("ROOM1");
+    assertThat(JSON.readTree(stdout()).get("userId").asLong()).isEqualTo(12345L);
+  }
+
+  @Test
+  void streamAddMemberToUnknownRoomExitsThree() {
+    final SymphonyBdk bdk = mock(SymphonyBdk.class);
+    final StreamService streams = mock(StreamService.class);
+    when(bdk.streams()).thenReturn(streams);
+    doThrow(new ApiRuntimeException(new ApiException(404, "not found")))
+        .when(streams).addMemberToRoom(12345L, "UNKNOWN");
+
+    assertThat(execute(bdk, "stream", "add-member", "UNKNOWN", "12345")).isEqualTo(3);
+  }
+
+  @Test
+  void streamRemoveMemberCallsRemoveMemberFromRoom() throws Exception {
+    final SymphonyBdk bdk = mock(SymphonyBdk.class);
+    final StreamService streams = mock(StreamService.class);
+    when(bdk.streams()).thenReturn(streams);
+
+    assertThat(execute(bdk, "stream", "remove-member", "ROOM1", "12345")).isZero();
+    verify(streams).removeMemberFromRoom(12345L, "ROOM1");
+  }
+
+  @Test
+  void streamPromoteOwnerCallsPromoteUserToRoomOwner() throws Exception {
+    final SymphonyBdk bdk = mock(SymphonyBdk.class);
+    final StreamService streams = mock(StreamService.class);
+    when(bdk.streams()).thenReturn(streams);
+
+    assertThat(execute(bdk, "stream", "promote-owner", "ROOM1", "12345")).isZero();
+    verify(streams).promoteUserToRoomOwner(12345L, "ROOM1");
+  }
+
+  @Test
+  void streamDemoteOwnerCallsDemoteUserToRoomParticipant() throws Exception {
+    final SymphonyBdk bdk = mock(SymphonyBdk.class);
+    final StreamService streams = mock(StreamService.class);
+    when(bdk.streams()).thenReturn(streams);
+
+    assertThat(execute(bdk, "stream", "demote-owner", "ROOM1", "12345")).isZero();
+    verify(streams).demoteUserToRoomParticipant(12345L, "ROOM1");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Adds CLI commands for stream room lifecycle management: create, get, update, activate, deactivate
- Adds CLI commands for stream membership management: add member, remove member, promote owner, demote owner, create IM
- Updates docs/cli.md with the new commands

## Test plan
- [x] `./gradlew :symphony-bdk-cli:test`
- [x] Manually exercise the new stream commands against a Symphony pod