### PR TITLE
Propose OpenSpec changes for BDK 4.x modernization

### DIFF
--- a/openspec/changes/adopt-java-25-baseline/design.md
+++ b/openspec/changes/adopt-java-25-baseline/design.md
@@ -1,0 +1,142 @@
+## Context
+
+This is the last of three changes making up the BDK 4.x platform migration:
+
+```
+modernize-build-toolchain        →  main (3.x), ships as 3.6.0
+  Gradle 9 · toolchain · bytecode tooling · dead deps
+  + records residual JDK 25 failures from a throwaway build
+        │
+        ▼
+migrate-spring-boot-4            →  next
+  Spring Boot 4 on Java 17  ← known-good intermediate state
+        │
+        ▼
+adopt-java-25-baseline           →  next   ◀── this change
+  Java 25 on Spring Boot 4  ← what 4.0.0 actually ships
+```
+
+By the time this change starts, the build is on Gradle 9 with current bytecode tooling and a green Spring Boot 4 test suite. The remaining JDK 25 work is therefore narrow and already partly inventoried: `modernize-build-toolchain` task 7.1 ran a throwaway JDK 25 build and recorded what failed.
+
+The exception is the OpenAPI generator. It was deliberately excluded from `modernize-build-toolchain` — where it would have shipped a 377-class regeneration into a 3.x minor release — and it lands here, in the major, where consumer-visible generated-API changes are expected and documented.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Java 25 as the committed, single baseline for every published module
+- CI, including the release workflow, running on JDK 25
+- `openapi-generator` on 7.x with the `jersey3` library, custom templates rebased, and the full generated diff reviewed and documented
+- Mockito working without relying on JVM self-attach
+- The Java 25 requirement and the 3.x support window both written down before 4.0.0 ships
+- No source-level use of post-17 language features — this change flips a baseline and nothing else
+
+**Non-Goals:**
+- Virtual threads in `DatafeedService` / `DatafeedAsyncLauncherService`. The most valuable thing the baseline unlocks, and precisely why it must not ride along: it is a concurrency behaviour change to the component most consumers depend on most heavily. Separate change, after 4.0.0
+- Records, sealed types, pattern matching, or any API redesign using post-17 features
+- A JDK matrix in CI. Java 25 is a floor, not an option
+- Revisiting the baseline decision itself (D1)
+- `module-info.java` / JPMS
+
+## Decisions
+
+### D1 — Java 25 is the baseline; the accepted cost is a long-lived 3.x line, and this change owns making that explicit
+
+**Decision**: Baseline Java 25. The consequence — that consumers unable to run Java 25 cannot adopt BDK 4.x at all — is accepted. This change carries the obligation to record a **stated support window for the 3.x line** before 4.0.0 ships (task 7.4).
+
+**Rationale**: The decision is a project-level one and is not re-opened here. What this change is responsible for is not leaving its consequence undocumented.
+
+The consequence is concrete. Spring Boot 4 itself baselines Java 17, so the BDK's Java requirement is *stricter than the framework it sits on*. A consumer on Spring Boot 4 and Java 21 is a perfectly supported Spring application that cannot use BDK 4.x. Given the BDK's consumer profile, that means 3.x is not a rollback branch — it is a parallel production line receiving CVE backports for as long as those consumers exist.
+
+That reframes an ordinary release into an ongoing commitment, and the commitment is much cheaper to scope now than to discover later. A stated window drives concrete decisions: whether `cve-scanning-gradle.yml` runs on both branches, whether the two builds are kept structurally identical to make backports cherry-pickable (which is why `modernize-build-toolchain` shipped on 3.x at all), and what the migration guide tells a consumer who cannot move.
+
+**Alternative considered and rejected by the project**: baseline 21 with Java 25 in a test matrix, which would have kept 4.x reachable for most consumers while still allowing virtual threads. Recorded here for the benefit of whoever reads this in two years, not as a live option.
+
+---
+
+### D2 — The generator bump is gated on a full diff review, and the diff is a deliverable
+
+**Decision**: Before the generator bump is merged, generate with 6.6.0 and 7.x into two trees, diff all 377 classes, and produce a written summary of every consumer-visible change. That summary becomes a section of the migration guide. If the diff contains changes nobody can explain, the bump does not merge until they are explained.
+
+**Rationale**: `com.symphony.bdk.gen.api.model.*` and `com.symphony.bdk.gen.api.*` are public API. Consumers construct these models, read their getters, and catch their exceptions. A generator major bump changes them in ways nobody on the team chose: nullable wrapping strategy, fluent-setter shape, `equals`/`hashCode`/`toString`, enum representation, annotation sets, required-vs-optional constructor parameters.
+
+The failure mode without this gate is not a build error — it is a consumer upgrading to 4.0.0 and finding that a model class they construct no longer compiles, with no mention of it in the migration guide. That is a worse experience than a documented breaking change, because it reads as carelessness rather than as a decision.
+
+The diff is cheap: two generator runs and `diff -r`. Treating its *output* as a deliverable rather than a checkpoint is what makes it useful, because it forces someone to read all of it.
+
+**Second, quieter risk in the same bump**: the three custom Mustache templates. `pojo.mustache` carries the project's Jakarta patch. If 7.x restructured the upstream template, a naive rebase can silently drop that patch — and since `useJakartaEe` may now be a first-class `configOption` in 7.x, the correct fix may be to **delete the customization** rather than port it. Each of the three templates should be re-justified against 7.x upstream, not merely made to apply.
+
+---
+
+### D3 — Mockito gets an explicit `-javaagent`, not a self-attach suppression
+
+**Decision**: Add the Mockito agent explicitly to the test JVM arguments in `bdk.java-common-conventions`, resolved from the Mockito artifact. Do not silence the self-attach warning with `-XX:+EnableDynamicAgentLoading`.
+
+**Rationale**: The warning is not noise — it is notice that JVM self-attach is being withdrawn. Suppressing it buys silence until the JDK release that denies self-attach outright, at which point every test module fails at once, on a JDK bump made for an unrelated reason.
+
+Configuring the agent explicitly is a few lines in one convention plugin and is the configuration the JDK is steering toward. Doing it while deliberately touching the JDK is strictly cheaper than doing it under duress later.
+
+---
+
+### D4 — No language-feature adoption in this change
+
+**Decision**: This change contains no source edits other than those forced by the generator regeneration. No records, no pattern matching, no `var` sweep, no sealed hierarchies, no virtual threads.
+
+**Rationale**: The purpose is to make "does the project build and pass on JDK 25" answerable with a clean yes or no. Every voluntary source change added here becomes a candidate explanation for a failure and dilutes that signal.
+
+There is also a review-economics argument. This change already contains a 377-class regeneration diff. Adding stylistic churn on top guarantees the regeneration diff — the part with real consumer impact — gets skimmed.
+
+Virtual threads deserve their own note, because they are the strongest argument for having baselined 25 at all. `DatafeedService` and `DatafeedAsyncLauncherService` are exactly the blocking-loop shapes that virtual threads simplify, and the retry layer wraps them. That is a concurrency behaviour change to the single component most bots depend on, with its own failure modes around thread pinning and `ThreadLocal` usage in the auth session. It is a feature, and it belongs in a change that can be reverted without reverting the baseline.
+
+---
+
+### D5 — Release tag validation gains a branch guard
+
+**Decision**: Add a check to `release.yml` that the release's target branch matches the major version in the tag: `v3.*` releases must target the `3.x` branch, `v4.*` must target `main`.
+
+**Rationale**: The current regex `^v[0-9]+\.[0-9]+\.[0-9]+$` validates the tag's *shape* and nothing about which branch it points at. Once `main` is 4.x and `3.x` is a live maintenance branch, a `v3.6.1` release drafted against `main` would build 4.x code, publish it to Maven Central as 3.6.1, and there is no undo — Maven Central releases are immutable.
+
+The guard is a handful of lines and closes a failure that is unrecoverable rather than merely inconvenient. It belongs here because this is the change that makes the two-branch topology real.
+
+Note the branch cut itself is handled outside these OpenSpec changes; only the workflow guard is in scope.
+
+## Risks / Trade-offs
+
+**[Risk — highest] The generator diff contains unnoticed public API breakage**
+→ *Mitigation*: D2 makes the reviewed diff a deliverable that feeds the migration guide, so "we bumped it and the build went green" is not a sufficient state to merge in.
+
+**[Risk] Rebasing the custom Mustache templates silently drops the Jakarta patch in `pojo.mustache`**
+→ *Mitigation*: re-justify each of the three templates against 7.x upstream rather than porting them. Verify the regenerated sources contain no `javax.*` imports, as an assertion rather than an inspection (task 3.7).
+
+**[Risk] `jackson-databind-nullable` has no place in the 7.x + Jackson-decision combination**
+→ *Mitigation*: `org.openapitools:jackson-databind-nullable:0.2.6` is constrained in the BOM and is a Jackson 2 artifact. Its fate depends on both 7.x's nullable strategy and the Jackson decision made in `migrate-spring-boot-4`. Resolve it explicitly (task 3.5) rather than letting it resolve transitively.
+
+**[Risk] Lombok on JDK 25 fails, blocking 13 modules at once**
+→ *Mitigation*: already pinned explicitly by `modernize-build-toolchain`, and its JDK 25 support was confirmed there (task 4.3) and again in the throwaway build (task 7.1/7.2). If it still fails, it fails early and loudly rather than being entangled with the Spring Boot bump — which was the reason for pinning it separately.
+
+**[Risk] JaCoCo coverage thresholds shift on JDK 25 bytecode and fail the build for non-coverage reasons**
+→ *Mitigation*: every module carries a `jacocoTestCoverageVerification` minimum of 0.8–0.9. If instrumentation of class file 69 counts differently, adjust thresholds in a dedicated commit naming the JDK, so it can never be mistaken for a real coverage regression. Same discipline as `modernize-build-toolchain` task 3.6.
+
+**[Trade-off] Single-JDK CI means no evidence the BDK works on anything but 25**
+→ Accepted, and it is the honest reflection of the baseline decision: there is no supported alternative to test. Adding 21 to a matrix would produce a green check for a configuration that is not supported, which is worse than no check.
+
+**[Trade-off] The most valuable thing the baseline unlocks — virtual threads — is explicitly deferred**
+→ Accepted. Shipping the baseline and the behaviour change together would mean a datafeed concurrency regression could only be fixed by reverting the baseline.
+
+## Migration Plan
+
+Consumer-facing, folded into the `docs/migration-4.x.md` written by `migrate-spring-boot-4`:
+
+1. **Java 25 is required.** Not recommended — required. Consumers on 17 or 21 stay on BDK 3.x.
+2. **The 3.x support window**, stated explicitly, so a consumer who cannot move to Java 25 knows what they have and for how long.
+3. **Generated API changes** from the generator bump, enumerated from D2's reviewed diff, with before/after signatures for anything a consumer constructs or reads directly.
+4. **Test infrastructure**: consumers using `symphony-bdk-test-jupiter` or `symphony-bdk-test-spring-boot` inherit the explicit Mockito agent configuration and must run tests on JDK 25.
+5. **Build tooling**: consumers building against BDK 4.x need a JDK 25 toolchain; those on Gradle need a version supporting it.
+
+Internal: after this change, `main` (once the branch cut lands) is Java 25 + Spring Boot 4, and `3.x` is Java 17 + Spring Boot 3.5. Backports across that gap are non-trivial — which is the reason `modernize-build-toolchain` was landed on 3.x rather than only on `next`.
+
+## Open Questions
+
+- **Does `openapi-generator` 7.x's `jersey3` library target the same Jersey version Spring Boot 4 pins?** `migrate-spring-boot-4` task 1.2 establishes the Jersey version; this change must confirm the generator's library targets it. A mismatch means the generated invoker layer compiles against a different Jakarta REST generation than the runtime provides.
+- **Does 7.x change `invokerPackage` output enough to affect `symphony-bdk-http-api`?** The generator writes into `com.symphony.bdk.http.api` with `supportingFiles: "false"`, so BDK owns `ApiClient`, `ApiResponse`, `Pair`, and `TypeReference` by hand while the generated APIs call them. If 7.x changes the calling convention, that hand-written seam moves.
+- **Is `dateLibrary: "java8"` still the right `configOption` in 7.x**, and does `sortParamsByRequiredFlag: "false"` still exist? Both are set today; either changing default behaviour would show up in the D2 diff as a broad signature change.
+- **What is the 3.x support window?** Blocking for 4.0.0's release notes and migration guide (task 7.4). Not answerable inside this change, but it cannot ship without an answer.

--- a/openspec/changes/adopt-java-25-baseline/proposal.md
+++ b/openspec/changes/adopt-java-25-baseline/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+BDK 4.x baselines **Java 25**, the current LTS. This is the second and final platform move of the major: `migrate-spring-boot-4` established a green build on Java 17 + Spring Boot 4, and this change flips the JDK against that known-good state.
+
+Java 25 emits class file version 69, which is what makes this a change rather than a one-line edit. Every tool in the build that reads, writes, or instruments bytecode has to understand it. `modernize-build-toolchain` already raised most of that layer on the 3.x line — Gradle, Byte Buddy, MapStruct, ArchUnit, JaCoCo, Lombok — and recorded the residual failures from a throwaway JDK 25 build. This change works through that recorded list and makes 25 the committed baseline.
+
+The one substantial piece of work not already covered is the **OpenAPI generator**. Version 6.6.0 is a 2023 release that cannot be expected to run on JDK 25, and it generates 377 classes that are part of the published API surface. That bump is the largest single risk in this change and is deliberately quarantined here rather than smuggled into an earlier one.
+
+Baselining 25 rather than 17 or 21 is a deliberate choice with a known cost: BDK 4.x becomes unavailable to consumers who cannot run Java 25, which makes the 3.x line a long-lived maintenance branch rather than a short-term safety net. That cost is accepted, and this change carries the obligation to make it explicit — see design D1 and task 7.4.
+
+## What Changes
+
+- **Toolchain 17 → 25.** One `languageVersion` line in `bdk.java-common-conventions`, which is the entire point of having introduced the toolchain in `modernize-build-toolchain`.
+- **CI on JDK 25** across all three workflows: `build.yml`, `cve-scanning-gradle.yml`, `release.yml`. Single JDK, no matrix — Java 25 is a hard requirement, not one option among several, so there is nothing to matrix over.
+- **`openapi-generator` 6.6.0 → 7.x**, with `library = 'jersey2'` → `jersey3` in both generator configurations (`bdk.java-codegen-conventions` and the `apisToGenerate` loop in `symphony-bdk-core/build.gradle`). Includes rebasing the three custom Mustache templates (`api.mustache`, `pojo.mustache`, `modelInnerEnum.mustache`) onto 7.x's upstream templates, and a full review of the resulting diff across the 377 generated classes.
+- **Mockito's dynamic agent attach** made explicit via a `-javaagent` test JVM argument rather than relying on self-attach, which the JDK warns about and is scheduled to deny.
+- **Lombok** confirmed at a JDK 25-capable version — already pinned explicitly in the BOM by `modernize-build-toolchain`, so this is a verification, not a bump hunt.
+- **Release workflow JDK bump**, plus a branch guard on the release tag: the current `^v[0-9]+\.[0-9]+\.[0-9]+$` regex matches `v3.x` and `v4.x` identically with no check on which branch the release targets.
+- **Documentation**: Java 25 stated as a hard requirement, and the 3.x support window recorded so the migration guide can answer "what if I cannot move to Java 25".
+- **No source-level modernization.** No records, pattern matching, sealed types, or virtual threads. This change flips a baseline; using what the baseline unlocks is separate work.
+
+## Capabilities
+
+### Modified Capabilities
+- `platform-baseline`: the declared minimum Java version moves from 17 to 25, and the requirement's consequence — that the previous major becomes a supported maintenance line with a stated window — is added.
+- `build-toolchain`: the declared toolchain language version moves from 17 to 25, and the generated-output-diff requirement is exercised for the OpenAPI generator rather than only for annotation processors.
+
+### New Capabilities
+*(none)*
+
+## Impact
+
+**Build**
+- `buildSrc/src/main/groovy/bdk.java-common-conventions.gradle`: `JavaLanguageVersion.of(17)` → `of(25)`
+- `buildSrc/build.gradle`: `openapi-generator-gradle-plugin` 6.6.0 → 7.x, and removal of the hand-written override block that exists only because 6.6.0 needs older transitive libraries than `owasp-dependencycheck` 12.2.2
+- `buildSrc/src/main/groovy/bdk.java-codegen-conventions.gradle`: `library` → `jersey3`; 7.x `configOptions` review (`dateLibrary`, `useJakartaEe`, nullable handling)
+- `symphony-bdk-core/build.gradle`: same generator changes in the 5-API `apisToGenerate` loop
+- `templates/api.mustache`, `templates/pojo.mustache`, `templates/modelInnerEnum.mustache`: rebased onto 7.x upstream templates
+- Test JVM args for the explicit Mockito agent, in `bdk.java-common-conventions`
+
+**CI**: `build.yml`, `cve-scanning-gradle.yml`, `release.yml` — `java-version: '17'` → `'25'`; `actions/setup-java@v3` in `release.yml` is also behind the other workflows and should be aligned
+
+**Code**: 377 generated classes under `com.symphony.bdk.gen.api` regenerate. Any hand-written call site that touches a changed generated signature follows. `symphony-bdk-http-api`'s invoker abstraction (`ApiClient`, `ApiResponse`, `Pair`, `TypeReference`) is generated against `invokerPackage = 'com.symphony.bdk.http.api'` and may shift under 7.x.
+
+**APIs** — breaking:
+- Java 25 required at runtime; consumers on 17 or 21 cannot use 4.x at all
+- Generated model and API classes may change signature under the generator bump. These are public types (`com.symphony.bdk.gen.api.model.*`), so every change is a consumer-visible change and must be enumerated in the migration guide, not discovered by consumers
+
+**Dependencies**: `openapi-generator` 7.x; `jackson-databind-nullable` may be replaced or dropped depending on 7.x's nullable strategy; explicit Mockito agent wiring.
+
+**Docs**: Java 25 requirement; the generated-API diff summary; the 3.x support window.

--- a/openspec/changes/adopt-java-25-baseline/specs/build-toolchain/spec.md
+++ b/openspec/changes/adopt-java-25-baseline/specs/build-toolchain/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: Target Java version declared via a Gradle toolchain
+The build SHALL declare the target Java version through a Gradle Java toolchain in `bdk.java-common-conventions`, not through the project-level `sourceCompatibility` convention. For BDK 4.x the declared `languageVersion` SHALL be **25**. The declared language version SHALL be the single source of truth for every module's target, so that changing the baseline is a one-line change in one file. The JDK running the Gradle daemon SHALL be independent of the declared toolchain version.
+
+#### Scenario: Baseline declared in exactly one place
+- **WHEN** the target Java version needs to change
+- **THEN** exactly one `languageVersion` declaration in `bdk.java-common-conventions` requires editing, and no module build file declares its own `sourceCompatibility` or `targetCompatibility`
+
+#### Scenario: Compilation target is independent of the daemon JDK
+- **WHEN** the build is run with a Gradle daemon JDK newer than the declared toolchain version
+- **THEN** all modules still compile to the declared toolchain version, and the produced class files carry that version
+
+#### Scenario: Parameter names and encoding are preserved
+- **WHEN** any module is compiled
+- **THEN** `-parameters` is passed to `javac` and source encoding is UTF-8, so that Spring constructor binding and Jackson parameter-name resolution continue to work
+
+#### Scenario: Toolchain is provisionable in CI
+- **WHEN** CI runs the build on a runner whose preinstalled JDK does not match the declared toolchain
+- **THEN** Gradle provisions or locates a matching JDK 25 toolchain rather than silently compiling to a different version
+
+---
+
+### Requirement: Bytecode-processing tooling supports the target class file version
+Every tool in the build that reads, writes, or instruments bytecode — the Gradle distribution, Byte Buddy, MapStruct's annotation processor, Lombok, JaCoCo, ArchUnit, and the Mockito mock maker — SHALL be at a version that supports the class file version emitted by the declared toolchain. Versions SHALL be pinned explicitly where the build already pins them directly, rather than inherited implicitly from a third-party platform whose upgrade cadence the BDK does not control. Test-time bytecode instrumentation SHALL NOT depend on JVM self-attach; agents SHALL be configured explicitly via JVM arguments.
+
+#### Scenario: Build succeeds on the declared baseline
+- **WHEN** `./gradlew build` is run with the declared toolchain
+- **THEN** no task fails with an unsupported-class-file-version, unknown-constant-pool, or unsupported-source-release error
+
+#### Scenario: Lombok version is owned by this repository
+- **WHEN** the Spring Boot platform version imported by `symphony-bdk-bom` changes
+- **THEN** the resolved Lombok version does not change, because `symphony-bdk-bom` constrains it explicitly
+
+#### Scenario: JaCoCo version is explicit
+- **WHEN** the Gradle distribution version changes
+- **THEN** the JaCoCo tool version used for coverage does not change, because it is declared via `jacoco { toolVersion }`
+
+#### Scenario: Mock agent is attached explicitly
+- **WHEN** any module's tests run
+- **THEN** the Mockito agent is supplied as a `-javaagent` JVM argument, and no dynamic-agent-loading suppression flag is used to silence a self-attach warning
+
+#### Scenario: Coverage thresholds are not silently relaxed for instrumentation reasons
+- **WHEN** a JDK or JaCoCo change alters how lines are counted and a `jacocoTestCoverageVerification` minimum no longer passes
+- **THEN** the threshold change is made in a dedicated commit naming the JDK or JaCoCo version, so it cannot be mistaken for a real coverage regression

--- a/openspec/changes/adopt-java-25-baseline/specs/platform-baseline/spec.md
+++ b/openspec/changes/adopt-java-25-baseline/specs/platform-baseline/spec.md
@@ -1,0 +1,54 @@
+## MODIFIED Requirements
+
+### Requirement: Minimum Java version is declared and enforced by the build
+The BDK SHALL declare a single minimum Java version for all published modules, enforced by the Gradle toolchain and stated in the published documentation. For BDK 4.x that minimum SHALL be **Java 25**. Consumers SHALL NOT need to inspect class files to determine the requirement. The minimum SHALL be stated as a requirement rather than a recommendation, and the BDK SHALL NOT publish artifacts targeting an older Java version for the same major line.
+
+#### Scenario: Published bytecode matches the declared minimum
+- **WHEN** any published module's jar is inspected
+- **THEN** its class file version corresponds to Java 25, and no module targets a different version
+
+#### Scenario: Declared minimum is documented
+- **WHEN** the documentation states the Java requirement for a BDK major line
+- **THEN** it names the version that the released artifacts actually require, not the version an intermediate development state built against
+
+#### Scenario: Consumer on an older Java version
+- **WHEN** a consumer's runtime is Java 17 or Java 21
+- **THEN** BDK 4.x is not usable and the documented answer is the previous major line, not a partial-support path
+
+#### Scenario: Java requirement is stricter than the framework's
+- **WHEN** a consumer is on a Spring Boot version whose own Java baseline is lower than the BDK's
+- **THEN** the BDK's requirement governs, and the documentation states the BDK's Java requirement independently of Spring Boot's
+
+## ADDED Requirements
+
+### Requirement: The previous major line has a stated support window
+When a new BDK major line raises the minimum Java version above what a substantial part of the consumer base can run, the previous major line SHALL be maintained as a supported line with a support window stated in writing before the new major is released. The window SHALL be reachable from the migration guide, and the previous line SHALL continue to receive security fixes for its duration.
+
+#### Scenario: Consumer cannot meet the new Java requirement
+- **WHEN** a consumer reads the migration guide and cannot run the required Java version
+- **THEN** the guide names the previous major line as their supported option and states how long it is maintained
+
+#### Scenario: Security fixes on the maintenance line
+- **WHEN** a vulnerability is found in a dependency shared by both lines, within the stated window
+- **THEN** the fix is released on the maintenance line as well as the current line
+
+#### Scenario: Support window is decided before the major ships
+- **WHEN** the new major version is released
+- **THEN** the support window for the previous line is already documented, not deferred to a later decision
+
+---
+
+### Requirement: Release tag validation matches the branch to the major version
+The release pipeline SHALL verify that a release's target branch corresponds to the major version in its tag. Validating the tag's shape alone SHALL NOT be sufficient, because releases published to the artifact repository cannot be withdrawn.
+
+#### Scenario: Maintenance-line release targets the maintenance branch
+- **WHEN** a release is drafted with a tag for the previous major line
+- **THEN** the workflow fails unless the release targets that line's branch
+
+#### Scenario: Current-line release targets the default branch
+- **WHEN** a release is drafted with a tag for the current major line
+- **THEN** the workflow fails unless the release targets the default branch
+
+#### Scenario: Mis-targeted release is refused before publication
+- **WHEN** a tag's major version and its target branch disagree
+- **THEN** the workflow fails before any artifact is signed or uploaded

--- a/openspec/changes/adopt-java-25-baseline/tasks.md
+++ b/openspec/changes/adopt-java-25-baseline/tasks.md
@@ -1,0 +1,63 @@
+## 1. Prerequisites
+
+- [ ] 1.1 Confirm `migrate-spring-boot-4` is merged to `next` and `./gradlew build jacocoTestReport jacocoTestCoverageVerification` is green on Java 17 + Spring Boot 4
+- [ ] 1.2 Retrieve the residual JDK 25 failure list recorded by `modernize-build-toolchain` tasks 7.1–7.2; it is the authoritative starting inventory for sections 2 and 4
+- [ ] 1.3 Confirm the Gradle version on `next` can provision a JDK 25 toolchain (recorded in `modernize-build-toolchain` task 7.3)
+- [ ] 1.4 Rebase `next` on `main` so any 3.x fixes landed since `migrate-spring-boot-4` are present
+
+## 2. Toolchain and CI Flip
+
+- [ ] 2.1 Change `JavaLanguageVersion.of(17)` → `of(25)` in `bdk.java-common-conventions.gradle`
+- [ ] 2.2 Confirm no module build file reintroduces its own `sourceCompatibility` / `targetCompatibility`
+- [ ] 2.3 Bump `java-version: '17'` → `'25'` in `.github/workflows/build.yml`
+- [ ] 2.4 Bump `java-version: '17'` → `'25'` in `.github/workflows/cve-scanning-gradle.yml`
+- [ ] 2.5 Bump `java-version: '17'` → `'25'` in `.github/workflows/release.yml`, and align its `actions/setup-java@v3` with the version used by the other workflows
+- [ ] 2.6 Deliberately do **not** add a JDK matrix — Java 25 is a floor, not one option among several (D-note in design Non-Goals)
+- [ ] 2.7 Run `./gradlew build` and record every failure; reconcile against the 1.2 inventory and investigate anything new
+
+## 3. OpenAPI Generator 6.6.0 → 7.x (D2)
+
+- [ ] 3.1 Generate all 5 API specs with 6.6.0 and with 7.x into two separate trees and `diff -r` them
+- [ ] 3.2 Write a summary of every consumer-visible change in the 377 generated classes — signature changes, nullable wrapping, fluent-setter shape, `equals`/`hashCode`/`toString`, enum representation, required-vs-optional constructor parameters. This summary is a deliverable and feeds task 7.2, not a checkpoint
+- [ ] 3.3 Bump `org.openapitools:openapi-generator-gradle-plugin` to 7.x in `buildSrc/build.gradle`, and remove the hand-written transitive override block that exists only because 6.6.0 needed older libraries than `owasp-dependencycheck` 12.2.2
+- [ ] 3.4 Change `library = 'jersey2'` → `'jersey3'` in both places: `bdk.java-codegen-conventions.gradle` and the `apisToGenerate` loop in `symphony-bdk-core/build.gradle`
+- [ ] 3.5 Review 7.x `configOptions`: confirm `dateLibrary: "java8"` and `sortParamsByRequiredFlag: "false"` still exist and mean the same thing; decide whether `useJakartaEe` is now the correct way to get Jakarta output; resolve the fate of `org.openapitools:jackson-databind-nullable:0.2.6` against 7.x's nullable strategy and the Jackson decision from `migrate-spring-boot-4`
+- [ ] 3.6 Re-justify each of the three custom templates (`api.mustache`, `pojo.mustache`, `modelInnerEnum.mustache`) against 7.x upstream — **delete** any whose customization 7.x now handles natively, rather than porting it forward
+- [ ] 3.7 Add an assertion that the generated sources contain no `javax.*` imports, so the Jakarta patch currently living in `pojo.mustache` cannot be lost silently in a template rebase
+- [ ] 3.8 Confirm 7.x's `jersey3` library targets the Jersey version Spring Boot 4 pins (established by `migrate-spring-boot-4` task 1.2) — a mismatch means generated code compiles against a different Jakarta REST generation than the runtime provides
+- [ ] 3.9 Fix the hand-written `symphony-bdk-http-api` invoker seam (`ApiClient`, `ApiResponse`, `Pair`, `TypeReference`) if 7.x changed how generated APIs call into it — `supportingFiles: "false"` means BDK owns these by hand
+- [ ] 3.10 Fix every hand-written call site affected by a changed generated signature
+- [ ] 3.11 Confirm `skipOverwrite = true` and the `globalProperties` block still behave as intended under 7.x
+
+## 4. Test Infrastructure on JDK 25
+
+- [ ] 4.1 Add an explicit Mockito `-javaagent` to the test JVM arguments in `bdk.java-common-conventions.gradle`, resolved from the Mockito artifact (D3)
+- [ ] 4.2 Confirm no `-XX:+EnableDynamicAgentLoading` suppression is used anywhere (D3)
+- [ ] 4.3 Confirm the Lombok version pinned in `symphony-bdk-bom` compiles all 13 Lombok-consuming modules on JDK 25
+- [ ] 4.4 Confirm the 3 ArchUnit architecture tests read class file version 69 — `CoreArchitectureTest`, `SymphonyGroupExtensionArchitectureTest`, `bdk-spring-boot-example/ArchitectureTest`
+- [ ] 4.5 Confirm `jacocoTestCoverageVerification` passes in every module on JDK 25 bytecode; if thresholds shift because of instrumentation counting rather than test changes, adjust them in a dedicated commit naming the JDK
+- [ ] 4.6 Confirm the MapStruct processor and the Spring Boot configuration processor run on JDK 25, and that the generated `UserDetailMapperImpl` is unchanged from the Java 17 build
+
+## 5. Release Pipeline (D5)
+
+- [ ] 5.1 Add a branch guard to `release.yml`: `v3.*` tags must target the `3.x` branch, `v4.*` tags must target `main` — the current `^v[0-9]+\.[0-9]+\.[0-9]+$` regex validates tag shape only, and a mis-targeted release to Maven Central is immutable
+- [ ] 5.2 Verify the CLI distribution still builds and runs on JDK 25: `:symphony-bdk-cli:installDist`, then execute `bin/bdk`
+- [ ] 5.3 Verify `publishToSonatype` and the signing configuration work under the new JDK and Gradle combination
+- [ ] 5.4 Verify `./gradlew dependencyCheck` runs on JDK 25 and review `allow-list.xml` against the Spring Boot 4 dependency set
+
+## 6. Full Verification
+
+- [ ] 6.1 `./gradlew build jacocoTestReport jacocoTestCoverageVerification` green on Java 25 + Spring Boot 4
+- [ ] 6.2 Run the starter smoke tests from `migrate-spring-boot-4` section 2 — they are the check that autoconfiguration still works on the new JDK
+- [ ] 6.3 Build every example module, including `bdk-ai-agent-example` (langchain4j) and `bdk-multi-instances-example`
+- [ ] 6.4 Confirm every published jar's class file version corresponds to Java 25 and that no module targets a different version
+- [ ] 6.5 `./gradlew publishToMavenLocal` and confirm the coordinate set matches what `migrate-spring-boot-4` established
+
+## 7. Documentation and the 3.x Commitment
+
+- [ ] 7.1 State Java 25 as a hard requirement in `docs/migration-4.x.md` and in the README — required, not recommended
+- [ ] 7.2 Add the generated-API change summary from 3.2 to the migration guide, with before/after signatures for anything consumers construct or read directly
+- [ ] 7.3 Document that consumers using `symphony-bdk-test-jupiter` / `symphony-bdk-test-spring-boot` inherit the explicit Mockito agent configuration and must run tests on JDK 25
+- [ ] 7.4 **Record the 3.x support window** in the migration guide and release notes (D1). The guide cannot answer "what if I cannot move to Java 25" without it, and 4.0.0 must not ship without an answer
+- [ ] 7.5 Update `CLAUDE.md` with the Java 25 baseline and the JDK requirement for contributors
+- [ ] 7.6 Confirm the versioned documentation set up by `migrate-spring-boot-4` task 10.3 keeps 3.x docs reachable for consumers who stay on the maintenance line

--- a/openspec/changes/migrate-spring-boot-4/design.md
+++ b/openspec/changes/migrate-spring-boot-4/design.md
@@ -1,0 +1,186 @@
+## Context
+
+BDK 4.x changes two independent platform axes: the framework (Spring Boot 3.5 → 4.x) and the JDK (Java 17 → 25). Each has its own failure modes, and they are not the same kind of failure — framework breakage is mostly compile-time and package-move shaped, JDK breakage is mostly bytecode-tooling and agent-attach shaped.
+
+Doing them in one step means every failure has two candidate causes and the build is never green in between. Splitting them requires picking an order, and the order is not arbitrary:
+
+```
+     ┌──────────────── intermediate state viability ─────────────────┐
+     │                                                               │
+ A)  SB4 first                          B)  JDK 25 first             │
+                                                                     │
+ Java 17 + Spring Boot 3.5              Java 17 + Spring Boot 3.5    │
+        │                                      │                     │
+        ▼                                      ▼                     │
+ Java 17 + Spring Boot 4        ✅      Java 25 + Spring Boot 3.5  ❓ │
+ (SB4 baselines Java 17 —               (SB 3.5 was not built with   │
+  a supported, tested combo)             JDK 25 as a target)         │
+        │                                      │                     │
+        ▼                                      ▼                     │
+ Java 25 + Spring Boot 4                Java 25 + Spring Boot 4      │
+     └───────────────────────────────────────────────────────────────┘
+```
+
+Order A has a known-good checkpoint in the middle. Order B's checkpoint depends on whether Spring Boot 3.5.16 tolerates JDK 25 — plausible on a late patch release, but not something the migration plan should rest on. This change is the first half of order A.
+
+`modernize-build-toolchain` is a prerequisite and lands on `main` first, so this change starts from Gradle 9 and current bytecode tooling. `next` is cut from — or rebased onto — `main` after that merge.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `spring-boot-dependencies:4.x` imported by `symphony-bdk-bom`, with all inherited platform moves (Jakarta EE 11, Netty 4.2, Tomcat 11, Micrometer 2) absorbed
+- Both starters autoconfigure correctly under Spring Boot 4, verified by a test that boots a real application through the published starter rather than assembling a context by hand
+- The Jackson major version question answered deliberately, with the classpath-splitting outcome explicitly rejected or explicitly accepted (D2)
+- BOM cleaned of constraints that only existed to work around Spring Boot 3.5 (CVE overrides, Jakarta EE 10 API pins)
+- Breaking changes that can only happen in a major taken now: `http-jersey2` rename, JSpecify, `BdkConfigParser` signatures
+- Build and all tests green on **Java 17** + Spring Boot 4 before `adopt-java-25-baseline` starts
+- A migration guide a 3.x consumer can actually follow
+
+**Non-Goals:**
+- Changing the Java baseline — that is `adopt-java-25-baseline`, and this change must not pre-empt it
+- Virtual threads in `DatafeedService` / `DatafeedAsyncLauncherService`. Enabled by the Java 25 baseline, but a behaviour change with its own risk profile — a separate change after 4.0
+- A `RestClient`-based HTTP implementation, or retiring either existing HTTP module. Spring Boot 4 makes `RestClient` the recommended sync client, which makes this worth revisiting — but as its own change, not as scope creep here
+- `module-info.java` / full JPMS. `Automatic-Module-Name` stays as-is
+- Adopting Spring Boot 4's API-versioning or `@HttpExchange` interface-client features
+
+## Decisions
+
+### D1 — Spring Boot 4 lands before the JDK move, on Java 17
+
+**Decision**: This change keeps `bdk.java-common-conventions`' toolchain at `JavaLanguageVersion.of(17)`. The definition of done is "green on Java 17 + Spring Boot 4".
+
+**Rationale**: See Context. Spring Boot 4 baselines Java 17, so this intermediate state is one the framework vendor supports and tests. The reverse order's intermediate state (Spring Boot 3.5 on JDK 25) is unverified, and if it turns out not to work the two changes collapse back into one — losing the whole benefit of the split at the worst possible moment.
+
+A second reason: the Jackson decision (D2) is a framework question, not a JDK question. Resolving it while the JDK is held constant means a serialization difference can only have one cause.
+
+**Alternative considered**: JDK 25 first, so that the riskiest single decision (Java 25 baseline) is validated earliest. Rejected because it front-loads risk onto an *unverified* intermediate configuration. If validating the Java 25 baseline early is the priority, the cheap way is a throwaway spike — which `modernize-build-toolchain` task 7.1 already schedules — not a reordering of shippable changes.
+
+---
+
+### D2 — The Jackson major version is gated on the Jersey provider question; a split classpath is a rejected outcome, not a fallback
+
+**Decision**: Before committing to Jackson 3, determine whether a Jackson 3 JSON provider exists for the Jersey version Spring Boot 4 pins. Then:
+
+- **Provider exists** → adopt Jackson 3. Migrate the 22 hand-written `databind`/`core` usages to `tools.jackson.*`, change `BdkConfigParser`'s 3 public `JsonNode` signatures, and rewrite `symphony-bdk-http-jersey`'s `JSON.java` / `RFC3339DateFormat.java` against the Jackson 3 provider.
+- **No provider** → **ship BDK 4.0 on Jackson 2**, explicitly and documented, and revisit in 4.1. Do not adopt Jackson 3 in the Spring-facing modules while leaving the Jersey module on Jackson 2.
+
+**Rationale**: The tempting middle option is the dangerous one. `symphony-bdk-http-jersey`'s `JSON.java` is a `ContextResolver<ObjectMapper>` — a Jackson 2 construct. If Spring brings Jackson 3 while that module stays on Jackson 2, both are on the classpath and the two HTTP implementations serialize differently:
+
+```
+identical BDK call, different http module on the classpath
+        │
+        ├── http-jersey    → Jackson 2, our ContextResolver's ObjectMapper config
+        └── http-webclient → Jackson 3, Spring Boot 4's configured mapper
+                              │
+                              └─▶ divergent date format, null inclusion,
+                                  unknown-property handling
+                                  → wire-format differences that depend on
+                                    a runtimeOnly dependency choice
+```
+
+That is a bug class that reproduces only in consumer deployments and is nearly impossible to diagnose from a stack trace. Shipping 4.0 on Jackson 2 is unglamorous but honest and reversible; a split classpath is neither.
+
+Note the migration is small in either direction: 22 files, and the 377 generated classes use only `com.fasterxml.jackson.annotation.*`, which Jackson 3 retains under the original package name. Confirm that against the actual `jackson-annotations` 3.x artifact rather than trusting it — if it is wrong, the generated-code cost jumps from zero to 377 files and this decision changes completely.
+
+---
+
+### D3 — The Netty and Tomcat CVE overrides are deleted, not carried forward
+
+**Decision**: Remove `platform('io.netty:netty-bom:4.1.136.Final')` and the three `tomcat-embed-*:10.1.57` constraints from `symphony-bdk-bom`, along with their CVE comments.
+
+**Rationale**: These exist solely to resolve above Spring Boot 3.5.16's pins. Spring Boot 4 brings Netty 4.2 and Tomcat 11, both of which win conflict resolution against these constraints anyway — so they become dead weight the moment the platform bumps.
+
+Dead weight is not the real cost. The comments enumerate specific CVEs as "fixed in 10.1.56 / 10.1.57", which is true of the Tomcat 10 line and irrelevant to Tomcat 11. Anyone auditing the BOM later reads a confident, precise, obsolete claim. Stale security comments are worse than no comments.
+
+After removal, re-run `./gradlew dependencyCheck` against the Spring Boot 4 platform and add whatever *new* overrides that run genuinely justifies — with fresh comments.
+
+---
+
+### D4 — JSR-305 → JSpecify happens here, in the major
+
+**Decision**: Replace all 82 `javax.annotation.Nonnull` / `javax.annotation.Nullable` usages with JSpecify annotations, and drop `com.google.code.findbugs:jsr305` from the modules that only used it for nullability.
+
+**Rationale**: JSR-305 was never a finished standard, is unmaintained, and squats on the `javax.annotation` package — which causes split-package problems for any consumer doing JPMS or strict dependency analysis. Spring Framework 7 standardises on JSpecify, so staying on JSR-305 means the BDK's nullability contract and Spring's stop being expressible in the same vocabulary.
+
+It rides along here rather than getting its own change because it is mechanical, it is only possible in a major, and deferring it means carrying it to 5.x. The one caveat: JSpecify's defaulting semantics are not identical to JSR-305's — `@NullMarked` at package scope changes what an unannotated type means. Verify per-module rather than doing a blind find-and-replace.
+
+Note `jsr305` is also pulled in by `bdk.java-codegen-conventions` for generated code; that usage is separate and stays until the generator is bumped.
+
+---
+
+### D5 — Starter correctness is verified by booting a real application, not by assembling a context
+
+**Decision**: Add a smoke test per starter that boots a minimal `@SpringBootApplication` depending only on the published starter, and asserts the expected beans are present. These are new tests, added before the Spring Boot 4 bump so they can demonstrate they pass on 3.5 first.
+
+**Rationale**: Spring Boot 4's autoconfiguration repackaging fails *quietly*. The observable symptom is not a compile error — it is autoconfiguration silently not applying, so a consumer's application starts with missing beans while the BDK's own tests pass, because those tests construct contexts explicitly (`AutoConfigurations` is used directly in 3 places) rather than going through the discovery mechanism that actually broke.
+
+`symphony-bdk-test-spring-boot` makes this worse by re-exporting `spring-boot-starter-test` and `spring-boot-starter-web` as `api` dependencies. Consumers' *test* setups inherit our choices, so breakage there is invisible locally and lands directly on consumers.
+
+Writing these tests against Spring Boot 3.5 first is what makes them trustworthy: a test written after the bump that passes tells you nothing about whether it would have caught the failure.
+
+---
+
+### D6 — Spring Boot 3 + BDK 4 is explicitly unsupported and loudly documented
+
+**Decision**: State in the migration guide and in the BOM's documentation that BDK 4.x requires Spring Boot 4.x. Do not attempt cross-compatibility, conditional autoconfiguration, or reflective version detection.
+
+**Rationale**: The combination will half-work. Core, config, and the HTTP modules have no Spring dependency at all, so a Spring Boot 3 consumer using only `symphony-bdk-core` would appear fine — right up to the point where a transitively-pulled Jakarta EE 11 or Netty 4.2 artifact meets Spring Boot 3's expectations. Partial success is worse than a clean failure, because it produces bug reports that look like BDK bugs.
+
+The honest framing for consumers: the Spring Boot major and the BDK major move together.
+
+---
+
+### D7 — `symphony-bdk-http-jersey2` is renamed, and the old coordinate is not aliased
+
+**Decision**: Rename the module and its published artifactId to `symphony-bdk-http-jersey`. Do not publish a relocation POM or an empty forwarding artifact.
+
+**Rationale**: The module has been on Jersey 3.x since the Jakarta migration; `jersey2` is simply false, and it misleads people reading the dependency tree about which Jakarta generation they are on. An artifactId change is major-only, so the choice is now or 5.x.
+
+No alias, because the migration guide already requires consumers to make coordinate-level changes (the Spring Boot major, the BOM version), so a single additional rename is not what makes the upgrade hard — and a forwarding artifact would need maintaining for the life of 4.x to serve a one-line edit.
+
+The generator's `library = 'jersey2'` setting is a separate, unrelated string that belongs to `openapi-generator` and is addressed in `adopt-java-25-baseline` alongside the generator bump.
+
+## Risks / Trade-offs
+
+**[Risk — highest] Autoconfiguration silently stops applying and the existing test suite stays green**
+→ *Mitigation*: D5. This is the one risk where the mitigation has to be built before the change, not after. If the smoke tests slip, the change is not done.
+
+**[Risk] No Jackson 3 provider for Jersey, and schedule pressure makes the split classpath look reasonable**
+→ *Mitigation*: D2 names the split classpath as a rejected outcome up front, precisely so it is not reconsidered as a compromise later. Shipping 4.0 on Jackson 2 is the pre-agreed answer.
+
+**[Risk] `jackson-annotations` 3.x does not retain `com.fasterxml.jackson.annotation`, turning a 22-file migration into a 399-file one**
+→ *Mitigation*: verify against the published artifact as task 1.3, before any Jackson work starts. If it is wrong, D2's decision is re-opened with a completely different cost basis.
+
+**[Risk] Jakarta EE 11 moves `jakarta.validation` and `jakarta.ws.rs` in ways that break `symphony-bdk-http-api`'s abstraction**
+→ *Mitigation*: the hard pins (`ws.rs-api:3.1.0`, `validation-api:3.0.2` — the latter in two places) must be removed early rather than at the end, so that any EE 11 incompatibility surfaces at the start of the change instead of after everything else is done.
+
+**[Risk] Scope creep — a major version invites every deferred cleanup**
+→ *Mitigation*: the Non-Goals list is deliberately specific about the tempting ones (virtual threads, `RestClient`, JPMS, retiring an HTTP module). Each is a real improvement and each would extend a long-lived branch that is already accumulating merge debt against `main`. They are 4.1 material.
+
+**[Trade-off] Two breaking changes (JSpecify, the Jersey rename) ride along with the framework migration, widening the diff**
+→ Accepted. Both are mechanical, both are major-only, and the alternative is a 5.x whose entire justification is cleanups that could have shipped here. The mitigation is commit hygiene: each rides in its own commit, so the framework migration stays reviewable in isolation.
+
+**[Trade-off] Long-lived `next` branch diverging from `main`**
+→ Accepted but bounded: `main` continues to take 3.x CVE fixes throughout. Rebase `next` on `main` at each section boundary in `tasks.md` rather than at the end.
+
+## Migration Plan
+
+Consumer-facing, to be written up as `docs/migration-4.x.md`:
+
+1. **Move to Spring Boot 4 first.** BDK 4.x requires it (D6). A consumer still on Spring Boot 3 should stay on BDK 3.x.
+2. **Java 17 is still sufficient after this change** — but not after `adopt-java-25-baseline`. The published 4.0.0 requires Java 25; this intermediate state is never released. The migration guide should state the Java 25 requirement, not Java 17.
+3. **Rename the dependency**: `org.finos.symphony.bdk:symphony-bdk-http-jersey2` → `symphony-bdk-http-jersey` (D7).
+4. **`BdkConfigParser`** — if Jackson 3 is adopted (D2), the 3 `JsonNode` signatures change package. Affects only consumers calling the config parser directly, which is unusual.
+5. **Nullability annotations** change from JSR-305 to JSpecify. Source-compatible for consumers; visible to static analysis and IDE null checking.
+6. **BOM constraints removed**: Netty, Tomcat, and the two Jakarta API pins are no longer constrained by `symphony-bdk-bom` (D3). Consumers who relied on the BDK BOM to pin those now inherit Spring Boot 4's choices, which is the correct behaviour.
+7. **Test dependencies**: `symphony-bdk-test-spring-boot` re-exports Spring Boot's test starter, so consumers using it inherit Spring Boot 4's test stack — including any JUnit/Mockito version moves.
+
+Documentation must be versioned before 4.0.0 ships, so that 3.x consumers reading `symphony-bdk-java.finos.org` are not shown 4.x instructions.
+
+## Open Questions
+
+- **Which Jersey version does Spring Boot 4.x pin?** Jakarta EE 11 includes Jakarta REST 4.0. If Spring Boot 4 stays on Jersey 3.1.x, `symphony-bdk-http-jersey` is largely untouched; if it moves to a Jersey line implementing REST 4.0, the invoker layer and `JSON.java` shift. Task 1.2.
+- **Does a Jackson 3 JSON provider exist for that Jersey version?** The gate for D2. Task 1.4.
+- **Do `@ConditionalOnMissingBean` / `@ConditionalOnProperty` / `@ConditionalOnBean` stay in `org.springframework.boot.autoconfigure.condition`?** 25 of the 28 autoconfigure references are these three annotations, so the answer sets the size of section 3. Task 1.1.
+- **How long is the 3.x line supported?** Not a question this change answers, but it blocks the migration guide: the guide has to tell a consumer who cannot move to Java 25 what their options are, and "stay on 3.x" is only an answer if 3.x has a stated support window. Needs a decision before 4.0.0 ships.
+- **Should `symphony-bdk-http-webclient`'s `guava:31.1-jre` constraint survive?** It is a 2022 pin justified by a comment about "version 28.2-android that is pulled contains security issues". Whatever pulled 28.2-android may no longer do so under Spring Boot 4. Worth re-deriving rather than carrying.

--- a/openspec/changes/migrate-spring-boot-4/proposal.md
+++ b/openspec/changes/migrate-spring-boot-4/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+BDK 3.x is built on Spring Boot 3.5, whose OSS support window has closed. Spring Boot 4 / Spring Framework 7 is the supported line, and moving to it is the substance of the BDK 4.x major: Jakarta EE 11, Jackson 3, Netty 4.2, Tomcat 11, Micrometer 2, and a restructured autoconfiguration module layout.
+
+This change does the framework half of the 4.x migration and **stays on Java 17**. That is deliberate. Spring Boot 4 baselines Java 17, so "Spring Boot 4 on Java 17" is a configuration the framework itself supports and tests — a known-good intermediate state. Combining the framework move and the JDK move into one step would mean debugging two unrelated classes of failure against a build that has never been green, with no way to attribute a failure to either cause. `adopt-java-25-baseline` follows this change and flips the JDK against a build that is already known to work on Spring Boot 4.
+
+The prerequisite `modernize-build-toolchain` has already raised the build's bytecode tooling on the 3.x line, so this change starts from a modern Gradle and does not have to fight the build system while fighting the framework.
+
+## What Changes
+
+- **`symphony-bdk-bom`: `spring-boot-dependencies` 3.5.16 → 4.x.** Because this BOM is the consumer contract, this single line is what actually makes a consumer's application a Spring Boot 4 application.
+- **Delete the Netty and Tomcat CVE overrides** from the BOM. `netty-bom:4.1.136.Final` and the three `tomcat-embed-*:10.1.57` pins exist to climb above Spring Boot 3.5's choices. Spring Boot 4 brings Netty 4.2 and Tomcat 11, which supersede them. Left in place they are inert but actively misleading — the comments would send the next person auditing CVEs to the wrong conclusion.
+- **Remove the hard-pinned Jakarta EE 10 API versions.** `jakarta.ws.rs:jakarta.ws.rs-api:3.1.0` and `jakarta.validation:jakarta.validation-api:3.0.2` are pinned in the BOM, and `jakarta.validation-api:3.0.2` is pinned *again* directly in `symphony-bdk-app-spring-boot-starter/build.gradle`. Jakarta EE 11 moves both. These pins would hold EE 10 APIs against an EE 11 platform.
+- **Autoconfiguration retargeting.** Spring Boot 4 splits `spring-boot-autoconfigure` into per-technology modules and moves classes between packages. Affects the two `AutoConfiguration.imports` files, the ~28 `@ConditionalOn*` usages across the starters, `@SpringBootApplication` references, and the `AutoConfigurations` test helper used in 3 places.
+- **Starter dependency retargeting.** `spring-boot-starter-web`, `-actuator`, `-validation`, `-webflux`, and `spring-boot-configuration-processor` are consumed by the two starters, `symphony-bdk-http-webclient`, and `symphony-bdk-test-spring-boot`; each needs to point at whatever Spring Boot 4 renamed or split it into.
+- **Jackson: decide 2 vs 3, gated on the Jersey provider question** (see design D2). The blast radius is small either way — 22 hand-written files, and only 3 public method signatures (`BdkConfigParser.parse`, `parseJsonNode`, `interpolateProperties`, all taking or returning `JsonNode`). The 377 generated classes use only `com.fasterxml.jackson.annotation.*` and are expected to be unaffected.
+- **Jersey version alignment** with Spring Boot 4's pin, and **rename `symphony-bdk-http-jersey2` → `symphony-bdk-http-jersey`**. The module has been on Jersey 3.x for some time; the name is already wrong, and an artifactId change is only possible in a major.
+- **JSR-305 → JSpecify.** 82 usages of `javax.annotation.Nonnull` / `Nullable`. JSR-305 is unmaintained and has split-package problems; Spring Framework 7 standardises on JSpecify. A major is the only place this can move.
+- **New starter smoke tests** that boot a minimal application through each published starter and assert the expected beans exist — see design D5. The current tests construct explicit contexts, which cannot catch autoconfiguration that silently stops applying.
+- **Migration guide** for 3.x → 4.x consumers, and versioned documentation so the 3.x docs remain reachable.
+
+## Capabilities
+
+### New Capabilities
+- `platform-baseline`: the runtime and framework contract the BDK promises consumers — required Java version, supported Spring Boot line, Jackson major version on the public API surface, Jakarta EE generation, and the published module coordinates. This has always been an implicit contract; a major version that changes all of it at once is the point at which it needs to be written down and verified.
+
+### Modified Capabilities
+*(none — `build-toolchain` from `modernize-build-toolchain` is unaffected; the toolchain version does not change in this change)*
+
+## Impact
+
+**Code**
+- `symphony-bdk-bom/build.gradle`: Spring Boot platform bump; delete Netty BOM, 3 Tomcat pins, 2 Jakarta API pins; Jersey BOM realignment
+- `symphony-bdk-spring/symphony-bdk-core-spring-boot-starter`: `SymphonyBdkAutoConfiguration` + `AutoConfiguration.imports`; `@ConditionalOn*` imports; `BdkActivityConfig.SlashAnnotationProcessor`; starter dependency coordinates
+- `symphony-bdk-spring/symphony-bdk-app-spring-boot-starter`: `SymphonyBdkAppAutoConfiguration` + `AutoConfiguration.imports`; `SymphonyBdkHealthIndicator` (Actuator/Micrometer 2); `CircleOfTrustController`; remove the duplicated `jakarta.validation-api` pin
+- `symphony-bdk-http/symphony-bdk-http-jersey2` → **renamed** `symphony-bdk-http-jersey`: directory, `settings.gradle`, BOM constraint, and all 5 consuming modules; `JSON.java` (`ContextResolver<ObjectMapper>`) and `RFC3339DateFormat.java` if Jackson 3 is adopted
+- `symphony-bdk-http/symphony-bdk-http-webclient`: `spring-boot-starter-webflux` coordinate; the stale `guava:31.1-jre` constraint should be re-examined at the same time
+- `symphony-bdk-test/symphony-bdk-test-spring-boot`: re-exports `spring-boot-starter-test` and `spring-boot-starter-web` as `api` — consumer test setups break here first
+- `symphony-bdk-config/BdkConfigParser`: 3 public `JsonNode` signatures, if Jackson 3 is adopted
+- 82 `javax.annotation.Nonnull`/`Nullable` usages across all modules → JSpecify
+- `symphony-bdk-examples/*`: `bdk-spring-boot-example`, `bdk-app-spring-boot-example` must build against the new starters
+
+**APIs** — breaking, as expected in a major:
+- `symphony-bdk-http-jersey2` artifactId no longer published
+- `BdkConfigParser`'s 3 `JsonNode` signatures change if Jackson 3 is adopted
+- Nullability annotations change package (source-compatible for consumers, but visible to static analysis tooling)
+- Consumers must be on Spring Boot 4; Spring Boot 3 + BDK 4 is explicitly unsupported (design D6)
+
+**Dependencies**: Spring Boot 4 platform; Netty 4.2, Tomcat 11, Micrometer 2, Jakarta EE 11 inherited from it; JSpecify added; Jersey realigned; possibly Jackson 3.
+
+**Docs**: `docs/` needs a 3.x/4.x split and a `docs/migration-4.x.md`. The `symphony-bdk-java.finos.org` site currently serves a single unversioned tree.

--- a/openspec/changes/migrate-spring-boot-4/specs/platform-baseline/spec.md
+++ b/openspec/changes/migrate-spring-boot-4/specs/platform-baseline/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Supported Spring Boot line
+The BDK's Spring modules SHALL support exactly one Spring Boot major line per BDK major line. BDK 4.x SHALL require Spring Boot 4.x. Spring Boot 3.x combined with BDK 4.x SHALL NOT be supported, and the BDK SHALL NOT attempt cross-major compatibility through conditional autoconfiguration or runtime version detection. The requirement SHALL be stated in the migration guide and in the published documentation.
+
+#### Scenario: Consumer on the matching Spring Boot major
+- **WHEN** a consumer application uses Spring Boot 4.x and imports `symphony-bdk-bom` 4.x
+- **THEN** the BDK starters autoconfigure without the consumer overriding any Spring Boot managed version
+
+#### Scenario: Consumer on the previous Spring Boot major
+- **WHEN** a consumer application uses Spring Boot 3.x
+- **THEN** the documented answer is to stay on BDK 3.x, and no partial-compatibility path is offered
+
+---
+
+### Requirement: Minimum Java version is declared and enforced by the build
+The BDK SHALL declare a single minimum Java version for all published modules, enforced by the Gradle toolchain and stated in the published documentation. Consumers SHALL NOT need to inspect class files to determine the requirement.
+
+#### Scenario: Published bytecode matches the declared minimum
+- **WHEN** any published module's jar is inspected
+- **THEN** its class file version corresponds to the declared minimum Java version, and no module targets a different version
+
+#### Scenario: Declared minimum is documented
+- **WHEN** the documentation states the Java requirement for a BDK major line
+- **THEN** it names the version that the released artifacts actually require, not the version an intermediate development state built against
+
+---
+
+### Requirement: Exactly one JSON binding implementation on the runtime classpath
+The BDK SHALL resolve to exactly one JSON databind implementation across all published modules. Two implementations of the same JSON binding library SHALL NOT be simultaneously resolvable, so that a given BDK operation serializes identically regardless of which HTTP implementation module is on the classpath.
+
+#### Scenario: Serialization does not depend on the HTTP module choice
+- **WHEN** the same BDK operation is performed with the Jersey HTTP implementation and with the WebClient HTTP implementation
+- **THEN** the wire representation is identical, because both use the same configured JSON mapper
+
+#### Scenario: A second databind implementation is rejected by the build
+- **WHEN** a dependency change would put two major versions of the JSON databind library on the runtime classpath
+- **THEN** the build fails a dependency-verification check rather than resolving both
+
+---
+
+### Requirement: Nullability contract expressed in a maintained annotation vocabulary
+Public API nullability SHALL be expressed using JSpecify annotations. The BDK SHALL NOT use `javax.annotation.Nullable` or `javax.annotation.Nonnull` (JSR-305) in hand-written source, because JSR-305 is unmaintained and occupies the `javax.annotation` package, which conflicts with strict dependency analysis and module systems.
+
+#### Scenario: JSR-305 nullability annotations are absent from hand-written source
+- **WHEN** the architecture tests run
+- **THEN** no hand-written class imports `javax.annotation.Nullable` or `javax.annotation.Nonnull`, and the rule fails the build if one is reintroduced
+
+#### Scenario: Nullability defaulting is explicit per module
+- **WHEN** a module applies package-level `@NullMarked`
+- **THEN** the resulting contract for unannotated types has been verified to match the previously expressed JSR-305 intent, rather than being inherited by accident
+
+---
+
+### Requirement: Published module coordinates name the technology they actually use
+Published artifactIds SHALL NOT name a technology generation the module does not use. When a module's underlying technology generation changes, its coordinate SHALL be corrected at the next major version. Coordinate renames SHALL be listed in the migration guide, and superseded coordinates SHALL NOT be published as relocation or forwarding artifacts.
+
+#### Scenario: Jersey HTTP module coordinate
+- **WHEN** a consumer inspects the dependency tree of the Jersey-based HTTP implementation
+- **THEN** the artifactId does not claim a Jersey major version other than the one actually resolved
+
+#### Scenario: Renamed coordinate is not aliased
+- **WHEN** a consumer depends on a coordinate that a previous major published but this major renamed
+- **THEN** resolution fails outright rather than resolving an empty forwarding artifact, and the migration guide names the replacement
+
+---
+
+### Requirement: Starter autoconfiguration verified by booting a real application
+Each published Spring Boot starter SHALL have a test that boots a minimal `@SpringBootApplication` depending only on that starter and asserts the expected beans are present, exercising Spring Boot's autoconfiguration discovery mechanism. Tests that assemble a context directly from autoconfiguration classes SHALL NOT be the only verification, because they bypass the discovery mechanism that a framework upgrade can break.
+
+#### Scenario: Autoconfiguration registration is exercised end to end
+- **WHEN** the starter's autoconfiguration is not discovered — because a registration file path, a condition annotation package, or an autoconfiguration class location changed
+- **THEN** the starter smoke test fails, rather than passing because the test constructed the context explicitly
+
+#### Scenario: Re-exported test stack is verified from a consumer's perspective
+- **WHEN** `symphony-bdk-test-spring-boot` re-exports Spring Boot's test starter to consumers
+- **THEN** a test in a dependent module verifies that the re-exported stack works, so breakage is caught in this repository rather than by consumers

--- a/openspec/changes/migrate-spring-boot-4/tasks.md
+++ b/openspec/changes/migrate-spring-boot-4/tasks.md
@@ -1,0 +1,90 @@
+## 1. Investigation (blocking — resolves the open questions before any code moves)
+
+- [ ] 1.1 Determine where Spring Boot 4 places `@ConditionalOnMissingBean`, `@ConditionalOnProperty`, `@ConditionalOnBean`, `@ConditionalOnExpression`, `@SpringBootApplication`, and the `AutoConfigurations` test helper; record the old → new mapping (25 of 28 references are the three `@ConditionalOn*` annotations, so this sizes section 3)
+- [ ] 1.2 Determine which Jersey version `spring-boot-dependencies:4.x` pins, and whether it implements Jakarta REST 3.1 or 4.0
+- [ ] 1.3 Verify against the published `jackson-annotations` 3.x artifact that `com.fasterxml.jackson.annotation` is retained — this decides whether the generated-code cost is 0 files or 377
+- [ ] 1.4 Determine whether a Jackson 3 JSON provider exists for the Jersey version from 1.2 (the D2 gate)
+- [ ] 1.5 Record the D2 decision — Jackson 3, or ship 4.0 on Jackson 2 — and update this change's scope accordingly. Do not proceed to section 6 until this is written down
+- [ ] 1.6 Confirm the `AutoConfiguration.imports` file path/name is unchanged in Spring Boot 4 (`META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`)
+
+## 2. Starter Smoke Tests — written first, against Spring Boot 3.5 (D5)
+
+- [ ] 2.1 Add a smoke test to `symphony-bdk-core-spring-boot-starter` that boots a minimal `@SpringBootApplication` depending only on the starter, and asserts `SymphonyBdk` and the core service beans are present via real autoconfiguration discovery (not `AutoConfigurations`)
+- [ ] 2.2 Add the equivalent smoke test to `symphony-bdk-app-spring-boot-starter`, asserting the app-layer beans, the health indicator, and the circle-of-trust endpoints are wired
+- [ ] 2.3 Add a consumer-perspective test for `symphony-bdk-test-spring-boot` that verifies the re-exported test stack works from a dependent module
+- [ ] 2.4 Confirm all three pass on Spring Boot 3.5.16 before any bump — a smoke test written after the bump proves nothing about whether it would have caught the failure
+- [ ] 2.5 Merge sections 1–2 to `next` and rebase on `main` before continuing
+
+## 3. Spring Boot 4 Platform Bump
+
+- [ ] 3.1 Change `symphony-bdk-bom` to `platform('org.springframework.boot:spring-boot-dependencies:4.x')`
+- [ ] 3.2 Remove `platform('io.netty:netty-bom:4.1.136.Final')` and its CVE comment (D3)
+- [ ] 3.3 Remove the three `org.apache.tomcat.embed:tomcat-embed-*:10.1.57` constraints and their CVE comment (D3)
+- [ ] 3.4 Remove `jakarta.ws.rs:jakarta.ws.rs-api:3.1.0` and `jakarta.validation:jakarta.validation-api:3.0.2` from `symphony-bdk-bom`, and the duplicate `jakarta.validation-api:3.0.2` from `symphony-bdk-app-spring-boot-starter/build.gradle` — do this early so EE 11 incompatibilities surface now, not at the end
+- [ ] 3.5 Realign or remove the explicit `jersey-bom` import per 1.2
+- [ ] 3.6 Land 3.2–3.4 as their own commit naming each removed coordinate, matching the BOM-hygiene discipline from `modernize-build-toolchain`
+- [ ] 3.7 Confirm the toolchain in `bdk.java-common-conventions` is still `JavaLanguageVersion.of(17)` — this change must not flip it (D1)
+
+## 4. Autoconfiguration Retargeting
+
+- [ ] 4.1 Update imports in `SymphonyBdkAutoConfiguration` and the rest of `symphony-bdk-core-spring-boot-starter` per the 1.1 mapping
+- [ ] 4.2 Update imports in `SymphonyBdkAppAutoConfiguration` and the rest of `symphony-bdk-app-spring-boot-starter` per the 1.1 mapping
+- [ ] 4.3 Update the 3 `AutoConfigurations` test-helper usages
+- [ ] 4.4 Update both `META-INF/spring/...AutoConfiguration.imports` files if 1.6 found the path changed
+- [ ] 4.5 Retarget starter dependency coordinates for Spring Boot 4's module split: `spring-boot-starter-web`, `-actuator`, `-validation`, `spring-boot-configuration-processor` (app starter); `spring-boot-starter` (core starter); `spring-boot-starter-webflux` (`symphony-bdk-http-webclient`); `spring-boot-starter-web` + `-test` (`symphony-bdk-test-spring-boot`)
+- [ ] 4.6 Fix `SymphonyBdkHealthIndicator` against Actuator / Micrometer 2
+- [ ] 4.7 Fix `CircleOfTrustController` and the app-layer exception handling against Spring Framework 7 MVC
+- [ ] 4.8 Fix `BdkActivityConfig.SlashAnnotationProcessor` if bean-post-processor or `@ConditionalOn*` semantics moved
+- [ ] 4.9 Run the section 2 smoke tests — they are the acceptance criterion for this section, not the unit tests
+
+## 5. Jakarta EE 11 Fallout
+
+- [ ] 5.1 Rebuild and fix any `jakarta.validation` breakage from EE 10 → EE 11 (`@NotBlank` usages in the app starter models)
+- [ ] 5.2 Rebuild and fix `symphony-bdk-http-jersey2`'s `jakarta.ws.rs` usages against the version from 1.2 (24 imports across the module: `Client`, `WebTarget`, `Entity`, `Invocation`, `ClientRequestFilter`, `ClientResponseFilter`, `ContextResolver`, `Provider`, `MultivaluedHashMap`, `Form`, `GenericType`)
+- [ ] 5.3 Fix the `jakarta.servlet.http` usages in the app starter against Servlet 6.1
+- [ ] 5.4 Fix the `jakarta.annotation.PostConstruct` usages
+- [ ] 5.5 Confirm Netty 4.2 and Tomcat 11 cause no runtime breakage in `symphony-bdk-http-webclient` and the app starter — the smoke tests from section 2 are the check
+- [ ] 5.6 Re-run `./gradlew dependencyCheck` against the Spring Boot 4 platform; add only overrides that run genuinely justifies, with fresh comments (D3)
+
+## 6. Jackson — conditional on the D2 decision from 1.5
+
+- [ ] 6.1 *(Jackson 3 only)* Migrate the 22 hand-written `com.fasterxml.jackson.databind` / `.core` usages to `tools.jackson.*`, module by module: `symphony-bdk-config` (`BdkConfigLoader`, `BdkConfigParser`), `symphony-bdk-core` (7 files incl. `JwtHelper`, `AuthSessionImpl`, `MessageParser`, `Message`, `ExtensionService`, `FormReplyActivity`, `FormReplyContext`, `InputTokenizer`), `symphony-bdk-http-jersey` (`JSON`, `RFC3339DateFormat`), the starters, `symphony-group-extension`, `symphony-bdk-cli` (`internal/Json`)
+- [ ] 6.2 *(Jackson 3 only)* Change `BdkConfigParser`'s 3 public `JsonNode` signatures and note them in the migration guide as a breaking API change
+- [ ] 6.3 *(Jackson 3 only)* Rewrite `JSON.java`'s `ContextResolver<ObjectMapper>` against the Jackson 3 provider from 1.4
+- [ ] 6.4 *(Jackson 3 only)* Migrate the 5 test-side databind usages (`MockApiClient`, `JwtHelperTest`, `CircleOfTrustControllerTest`, `SymphonyBdkMockedConfiguration`, the 3 CLI tests)
+- [ ] 6.5 *(Jackson 3 only)* Replace `com.fasterxml.jackson.datatype.jsr310.JavaTimeModule`, `YAMLMapper`, `JavaPropsMapper`, and `jackson-databind-nullable` with their Jackson 3 equivalents; if `org.openapitools:jackson-databind-nullable` has no Jackson 3 release, this feeds back into 1.5
+- [ ] 6.6 *(Jackson 2 only)* Verify Jackson 2 and Spring Boot 4 coexist, and document in the migration guide that BDK 4.0 remains on Jackson 2 with Jackson 3 targeted for 4.1
+- [ ] 6.7 Assert there is exactly one Jackson databind implementation on the runtime classpath — a dependency-verification test, so the split classpath D2 rejects cannot appear later by accident
+
+## 7. Module Rename: `http-jersey2` → `http-jersey` (D7 — own commit)
+
+- [ ] 7.1 Rename the directory `symphony-bdk-http/symphony-bdk-http-jersey2` → `symphony-bdk-http-jersey` and update `settings.gradle`
+- [ ] 7.2 Update the `symphony-bdk-bom` constraint to the new artifactId
+- [ ] 7.3 Update all consuming modules: `symphony-bdk-core` (test), `symphony-bdk-core-spring-boot-starter`, `symphony-bdk-cli`, `bdk-ai-agent-example`, and any other example
+- [ ] 7.4 Update `docs/` and every code sample referencing the old coordinate
+- [ ] 7.5 Confirm no relocation POM or forwarding artifact is published (D7)
+
+## 8. JSR-305 → JSpecify (D4 — own commit)
+
+- [ ] 8.1 Add JSpecify to `symphony-bdk-bom`
+- [ ] 8.2 Replace the 52 `javax.annotation.Nonnull` and 30 `javax.annotation.Nullable` usages, module by module — not as a global find-and-replace, because JSpecify's `@NullMarked` defaulting changes what an *unannotated* type means
+- [ ] 8.3 Decide per module whether to apply `@NullMarked` at package level, and verify the resulting contract matches the previous JSR-305 intent
+- [ ] 8.4 Drop `com.google.code.findbugs:jsr305` from modules that only used it for nullability; keep it where `bdk.java-codegen-conventions` requires it for generated code
+- [ ] 8.5 Confirm the 3 ArchUnit architecture tests still pass, and add a rule forbidding `javax.annotation.Nullable`/`Nonnull` so it cannot come back
+
+## 9. Examples and Verification
+
+- [ ] 9.1 Build `bdk-spring-boot-example` and `bdk-app-spring-boot-example` against Spring Boot 4; fix `ApiExceptionHandler` and the example `ArchitectureTest`
+- [ ] 9.2 Build the non-Spring examples (`bdk-core-examples`, `bdk-multi-instances-example`, `bdk-group-example`, `bdk-ai-agent-example`) — the last one also pulls `langchain4j`, verify no Jackson or Netty conflict
+- [ ] 9.3 Build `symphony-bdk-cli` and verify `installDist` still produces a working `bin/bdk`
+- [ ] 9.4 Full green run of `./gradlew build jacocoTestReport jacocoTestCoverageVerification` on **Java 17** + Spring Boot 4 — the definition of done for this change (D1)
+- [ ] 9.5 Confirm `./gradlew publishToMavenLocal` publishes the expected coordinates, with `symphony-bdk-http-jersey2` absent
+
+## 10. Documentation
+
+- [ ] 10.1 Write `docs/migration-4.x.md` covering all 7 items from the design's migration plan
+- [ ] 10.2 State prominently that BDK 4.x requires Spring Boot 4.x and that Spring Boot 3 + BDK 4 is unsupported (D6)
+- [ ] 10.3 Set up versioned documentation so `symphony-bdk-java.finos.org` serves 3.x and 4.x separately, and 3.x consumers are never shown 4.x instructions
+- [ ] 10.4 Update `docs/extension.md` and any doc referencing the `jersey2` coordinate or JSR-305 annotations
+- [ ] 10.5 Note the Java requirement in the migration guide as **25** (what 4.0.0 actually ships), not the 17 this intermediate state builds against
+- [ ] 10.6 Record the 3.x support window in the migration guide once decided — the guide cannot answer "what if I can't move to Java 25" without it

--- a/openspec/changes/modernize-build-toolchain/design.md
+++ b/openspec/changes/modernize-build-toolchain/design.md
@@ -1,0 +1,140 @@
+## Context
+
+BDK 4.x will make two moves that each invalidate build tooling: **Spring Boot 3.5 → 4.x** (`migrate-spring-boot-4`) and **Java 17 → 25** (`adopt-java-25-baseline`). The second is the destructive one for the build, because JDK 25 emits class file version 69 and every tool in the build that reads bytecode has a version ceiling:
+
+```
+JDK 25  ──emits──▶  class file v69
+                        │
+        ┌───────────────┴────────────────────────────────┐
+        │  tools in this build that must understand v69  │
+        ├───────────────────────────────────────────────┤
+        │  Gradle 8.14.5      → cannot target JDK 25     │
+        │  byte-buddy 1.12.19 → explicit pin in core     │
+        │  mapstruct 1.4.2    → annotation processor     │
+        │  archunit 1.2.1     → reads our own classes    │
+        │  jacoco (default)   → instruments bytecode     │
+        │  mockito (via SB BOM) → byte-buddy transitively│
+        │  lombok (via SB BOM) → hooks compiler internals│
+        └────────────────────────────────────────────────┘
+```
+
+All of these can be raised while still targeting Java 17 and Spring Boot 3.5. That makes this change a self-contained, independently shippable prerequisite rather than part of the migration proper. It is sequenced **first** and lands on `main` (the 3.x line); the `next` branch is cut from — or rebased onto — `main` after it merges.
+
+The scope boundary is drawn at "does this alter what consumers compile against?" Gradle version, processor versions, and test-harness versions do not. Java version, Spring Boot version, and generated model classes do. The latter three are excluded.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Build runs on Gradle 9.x with no deprecation warnings that block Gradle 10
+- Target Java version declared via a **toolchain**, so a later change flips one number in one place
+- Every bytecode-processing tool in the build sits at a version that supports class file version 69, verified by actually building on JDK 25 in a throwaway run — even though the committed toolchain stays at 17
+- Lombok's version controlled by this repo, not inherited from `spring-boot-dependencies`
+- Three dead dependencies gone (`jaxb-api`, `reactor-spring`, `jsr250-api`)
+- Shippable as 3.6.0 with zero source changes and zero public API change
+
+**Non-Goals:**
+- Changing the Java baseline — the toolchain lands pinned at 17 (`adopt-java-25-baseline` flips it)
+- Changing the Spring Boot version (`migrate-spring-boot-4`)
+- Bumping `openapi-generator` 6.6.0 → 7.x — it regenerates 377 consumer-visible classes and belongs on the 4.x line (but see **D1**, which can force it)
+- Adopting Java 17+ language features, `module-info.java`, or any source-level modernization
+- CI JDK matrix changes — CI stays on JDK 17 here
+
+## Decisions
+
+### D1 — Gradle 9 and `openapi-generator` 6.6.0 are interlocked; verify before committing to the split
+
+**Decision**: Before any other work, verify that `org.openapitools:openapi-generator-gradle-plugin:6.6.0` runs under Gradle 9.x. Treat the result as a fork in the plan:
+
+- **If it works** → proceed as proposed. Generator bump stays out of this change and lands in `adopt-java-25-baseline`.
+- **If it does not work** → choose one, do not improvise:
+  - **(a)** Pull the generator bump forward into this change, and take on the 377-class generated diff review here. Still shippable as 3.6.0, but the diff must be reviewed against the public API surface before release.
+  - **(b)** Hold Gradle at 8.14.5 in this change, ship only the processor/tooling bumps and dead-dependency removals as 3.6.0, and move Gradle 9 into `adopt-java-25-baseline` where the generator bump already lives.
+
+**Rationale**: `openapi-generator-gradle-plugin` 6.6.0 is a 2023 release, and Gradle 9 removed APIs that plugins of that era commonly use. `buildSrc/build.gradle` already carries a hand-written dependency override block because "owasp-dependencycheck 12.2.2 requires newer versions of several libraries than openapi-generator 6.6.0" — evidence that this plugin is already the awkward one in the build.
+
+This is the single decision most likely to reshape the change. It is cheap to answer (one wrapper bump, one `./gradlew :symphony-bdk-core:openApiGenerate`) and expensive to discover late, so it is task 1.1.
+
+**Alternative considered**: assume it works and find out mid-change. Rejected — the fallback branches lead to materially different scopes and release plans, and picking one under time pressure is how the generated-code diff ships unreviewed.
+
+---
+
+### D2 — Java toolchain, pinned at 17 in this change
+
+**Decision**: Replace `sourceCompatibility = JavaVersion.VERSION_17` in `bdk.java-common-conventions.gradle` with:
+
+```groovy
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+```
+
+**Rationale**: Two reasons, one forced and one strategic.
+
+Forced: Gradle 9 removed the project-level `sourceCompatibility` convention that the current line relies on, so this file has to change regardless.
+
+Strategic: a toolchain is what makes `adopt-java-25-baseline` a one-line change instead of a hunt. It also decouples "which JDK runs Gradle" from "which JDK compiles the code", which is what lets us test-build on JDK 25 during *this* change without committing to it.
+
+**Note on `-parameters`**: the existing `options.compilerArgs << '-parameters'` stays. It matters to Spring's constructor binding and to Jackson parameter-name resolution, and is easy to lose in a conventions rewrite.
+
+---
+
+### D3 — Replace `mockserver-netty`, don't bump it
+
+**Decision**: Replace `org.mock-server:mockserver-netty:5.15.0` with WireMock or OkHttp `MockWebServer` across the 4 test files that use it, rather than chasing a newer MockServer release.
+
+**Rationale**: MockServer 5.15.0 is stale, and it embeds Netty — which Spring Boot 4 moves from 4.1 to 4.2. That means it is a version-conflict source in *two* future changes, not one. The BOM already hand-pins Netty above Spring Boot's choice for CVE reasons, so this build has a history of fighting Netty resolution.
+
+4 test files is a small enough surface that replacing the dependency outright is cheaper than carrying it through two migrations.
+
+**Alternative considered**: bump MockServer and keep it. Viable if a current release exists that tracks Netty 4.2 — worth a look before committing, but the default is replacement.
+
+---
+
+### D4 — BOM constraint removals get their own commit
+
+**Decision**: The removal of `reactor-spring` and the addition of the explicit Lombok constraint land as a separate, self-contained commit with the reasoning in the message — not folded into the Gradle 9 commit.
+
+**Rationale**: A BOM constraint is a promise to consumers. Any consumer who imports `symphony-bdk-bom` and does not declare `reactor-spring` themselves gets a different resolved version — or none — after this change. Nothing fails at build time; something moves at runtime. That class of change deserves a reviewable diff of its own rather than being three lines inside a hundred-line build modernization.
+
+The same discipline applies (and is repeated) in `migrate-spring-boot-4`, which deletes the Netty and Tomcat CVE overrides.
+
+---
+
+### D5 — MapStruct's generated output is diffed, not assumed
+
+**Decision**: After the `mapstruct-processor` bump, diff the generated implementation of `UserDetailMapper` (the tree's only mapper) before and after.
+
+**Rationale**: MapStruct 1.4 → 1.6 spans several years of null-handling and default-value behaviour changes. `UserDetailMapper` maps into `symphony-bdk-core`'s user service surface, so a silent change in how unmapped or null fields are treated is a behaviour change in a shipped 3.6.0 — exactly the kind of thing a "build-only" change is assumed not to contain. One mapper makes this a five-minute check.
+
+## Risks / Trade-offs
+
+**[Risk — highest] `openapi-generator` 6.6.0 is incompatible with Gradle 9, collapsing the clean scope split**
+→ *Mitigation*: D1 makes this task 1.1 with two pre-agreed fallbacks. The change is explicitly allowed to shrink (option b) rather than silently absorb the generator bump.
+
+**[Risk] Lombok pinned explicitly now diverges from `spring-boot-dependencies` later**
+→ *Mitigation*: this is the intended trade-off, not an accident. Pinning means a Spring Boot bump can no longer silently move Lombok — which is the point, since Lombok is used in 13 modules and lags JDK releases. Cost is one more version to watch; `dependencyUpdates` already covers it.
+
+**[Risk] Gradle 9 deprecation cleanup is wider than the 5 known call sites**
+→ *Mitigation*: run with `--warning-mode all` and treat the output as the real task list. The known surface (3 `buildDir`, 2 `tasks.create`, 1 `sourceCompatibility`) is what static grep finds; configuration-time deprecations in `buildSrc` plugins won't show up that way.
+
+**[Trade-off] Shipping this as 3.6.0 means the 3.x line takes a build change it doesn't strictly need**
+→ Accepted. The alternative — doing it only on `next` — means the 3.x maintenance line stays on Gradle 8 indefinitely while receiving CVE backports, and every backport from `next` has to be translated across a build-system gap. Given that 3.x becomes a long-lived line under the Java 25 baseline decision, keeping the two builds structurally identical is worth more than avoiding one minor release.
+
+## Migration Plan
+
+Consumer-facing: none required. 3.6.0 is a drop-in replacement for 3.5.x with two exceptions to note in release notes:
+
+1. `org.projectreactor:reactor-spring` is no longer constrained by `symphony-bdk-bom`. Consumers who relied on it must declare a version themselves. (Expected impact: zero — the artifact was last released in 2017.)
+2. Lombok is now constrained by `symphony-bdk-bom` rather than inherited from `spring-boot-dependencies`. Consumers who import both platforms will see `symphony-bdk-bom`'s constraint participate in resolution.
+
+Contributor-facing: Gradle 9 requires a JDK that Gradle 9 supports for the daemon. `./gradlew` handles the distribution; the toolchain handles compilation. Document the minimum daemon JDK in `CONTRIBUTING`/`CLAUDE.md` once the exact Gradle 9.x patch is chosen.
+
+Branch: lands on `main`. `next` is cut from or rebased onto `main` after merge — see `migrate-spring-boot-4`.
+
+## Open Questions
+
+- **Which exact Gradle 9.x patch?** Pick the latest that supports the JDK CI runs, and confirm it supports toolchain provisioning for JDK 25 (needed by `adopt-java-25-baseline`, not by this change).
+- **Does a current MockServer release track Netty 4.2?** If yes, D3's default (replace) could become a bump. Worth ten minutes before rewriting 4 test files.
+- **Is `jacoco` coverage output stable across the toolVersion bump?** Every module has a `jacocoTestCoverageVerification` rule with a hard minimum (0.8–0.9). A change in how JaCoCo counts lines — not a change in test quality — could fail the build. If thresholds need adjusting, adjust them in a separate commit with the JaCoCo version named in the message, so it is never confused with a real coverage regression.

--- a/openspec/changes/modernize-build-toolchain/proposal.md
+++ b/openspec/changes/modernize-build-toolchain/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+The build has accumulated tooling that predates the current codebase by several years: Gradle 8.14.5, `byte-buddy 1.12.19` (2022), `mapstruct 1.4.2.Final` (2021), `archunit 1.2.1`, `mockserver-netty 5.15.0`, and a bare `sourceCompatibility = JavaVersion.VERSION_17` rather than a Java toolchain. None of this is a problem on JDK 17 — which is precisely why it has stayed invisible.
+
+It becomes a hard blocker the moment the BDK targets a newer JDK. Every one of those tools reads, writes, or instruments bytecode, and each carries a class-file-version floor. BDK 4.x will baseline Java 25 (class file version 69), so the entire bytecode-touching layer of the build must move before the JDK does.
+
+Doing that work here, on the 3.x line, has three payoffs:
+
+1. It isolates a large, mechanical, low-risk diff from the genuinely risky framework migration that follows — the two failure modes don't get tangled together in one branch.
+2. The 4.x branch (`next`) starts from an already-modern build instead of re-doing this work.
+3. It is independently valuable to 3.x consumers: a build that runs on current Gradle, and three dead dependencies removed from the published BOM.
+
+This change deliberately does **not** touch the Java version, the Spring Boot version, or the OpenAPI generator. Those are the three things that alter the consumer contract, and each gets its own change.
+
+## What Changes
+
+- **Gradle 8.14.5 → 9.x.** Includes the associated deprecation cleanup: `project.buildDir` → `layout.buildDirectory` (3 build files), `tasks.create` → `tasks.register` (2 call sites), and replacing the project-level `sourceCompatibility` convention — removed in Gradle 9 — with an explicit `java { toolchain { ... } }` block in `bdk.java-common-conventions`. The toolchain stays pinned to **17** in this change.
+- **Bytecode-processing tooling raised to versions that support current class file versions**: `byte-buddy` (explicit pin in `symphony-bdk-core`), `mapstruct` + `mapstruct-processor`, `archunit-junit5`, and an explicit `jacoco { toolVersion }` rather than the Gradle-default JaCoCo.
+- **Lombok pinned explicitly in `symphony-bdk-bom`** instead of inheriting from `spring-boot-dependencies`. Lombok is used in 13 modules and is the most JDK-version-sensitive dependency in the build; controlling it independently of the Spring Boot version decouples two otherwise-coupled risks.
+- **`mock-server:mockserver-netty 5.15.0` addressed** (bump or replace — see design D3). 4 test files depend on it; it is stale and interacts with the Netty version, which Spring Boot 4 will move.
+- **Dead dependencies removed**: `javax.xml.bind:jaxb-api:2.3.1` from `symphony-bdk-core` (zero source usage — verified), `org.projectreactor:reactor-spring:1.0.1.RELEASE` from the BOM (a 2017 artifact), and `javax.annotation:jsr250-api:1.0` → `jakarta.annotation:jakarta.annotation-api` in `bdk.java-codegen-conventions`.
+- **No change** to: Java baseline (stays 17), Spring Boot version (stays 3.5.16), OpenAPI generator version (stays 6.6.0 — unless the Gradle 9 interlock in D1 forces it), any `src/main` source file, or any published module coordinate.
+
+## Capabilities
+
+### New Capabilities
+- `build-toolchain`: the build's own contract — how the target Java version is declared, and the floor that any bytecode-processing tool in the build must meet. Written now because BDK 4.x will move the target twice (Spring Boot, then JDK) and each move needs to check the same invariants.
+
+### Modified Capabilities
+*(none — no existing spec-level requirement changes; this change is build-internal and consumer-visible only through the removed BOM constraints)*
+
+## Impact
+
+**Build**
+- `gradle/wrapper/gradle-wrapper.properties`: distribution 8.14.5 → 9.x
+- `buildSrc/src/main/groovy/bdk.java-common-conventions.gradle`: `sourceCompatibility` → toolchain block; explicit `jacoco.toolVersion`
+- `buildSrc/src/main/groovy/bdk.java-codegen-conventions.gradle`: `buildDir` → `layout.buildDirectory`; jsr250 → jakarta.annotation
+- `buildSrc/build.gradle`: plugin dependency alignment for Gradle 9 (already carries a manual override block for `owasp-dependencycheck` vs `openapi-generator` conflicts)
+- `symphony-bdk-core/build.gradle`: `buildDir` → `layout.buildDirectory`; `tasks.create` → `tasks.register` (× 2, in the `apisToGenerate` loop); byte-buddy and mapstruct bumps; drop `jaxb-api`
+- `symphony-bdk-extensions/symphony-group-extension/build.gradle`: `buildDir` → `layout.buildDirectory`
+- `symphony-bdk-bom/build.gradle`: explicit Lombok constraint; archunit / mockserver / assertj bumps; remove `reactor-spring`
+
+**Source**: none expected. `UserDetailMapper` is the only MapStruct mapper in the tree — its *generated* implementation may change with the processor bump and must be diffed.
+
+**APIs**: no public API change.
+
+**Dependencies**: the published BOM loses `reactor-spring` and gains an explicit Lombok constraint. Both are consumer-visible version-resolution changes and are reviewed as their own commit (see design D4).
+
+**Release**: ships as a **3.6.0 minor**, not a patch — the BOM constraint removals are behaviour-visible to consumers who rely on the BOM for versions they don't declare themselves.

--- a/openspec/changes/modernize-build-toolchain/specs/build-toolchain/spec.md
+++ b/openspec/changes/modernize-build-toolchain/specs/build-toolchain/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Target Java version declared via a Gradle toolchain
+The build SHALL declare the target Java version through a Gradle Java toolchain in `bdk.java-common-conventions`, not through the project-level `sourceCompatibility` convention. The declared language version SHALL be the single source of truth for every module's target, so that changing the baseline is a one-line change in one file. The JDK running the Gradle daemon SHALL be independent of the declared toolchain version.
+
+#### Scenario: Baseline declared in exactly one place
+- **WHEN** the target Java version needs to change
+- **THEN** exactly one `languageVersion` declaration in `bdk.java-common-conventions` requires editing, and no module build file declares its own `sourceCompatibility` or `targetCompatibility`
+
+#### Scenario: Compilation target is independent of the daemon JDK
+- **WHEN** the build is run with a Gradle daemon JDK newer than the declared toolchain version
+- **THEN** all modules still compile to the declared toolchain version, and the produced class files carry that version
+
+#### Scenario: Parameter names and encoding are preserved
+- **WHEN** any module is compiled
+- **THEN** `-parameters` is passed to `javac` and source encoding is UTF-8, so that Spring constructor binding and Jackson parameter-name resolution continue to work
+
+---
+
+### Requirement: Bytecode-processing tooling supports the target class file version
+Every tool in the build that reads, writes, or instruments bytecode — the Gradle distribution, Byte Buddy, MapStruct's annotation processor, Lombok, JaCoCo, ArchUnit, and the Mockito mock maker — SHALL be at a version that supports the class file version emitted by the declared toolchain. Versions SHALL be pinned explicitly where the build already pins them directly, rather than inherited implicitly from a third-party platform whose upgrade cadence the BDK does not control.
+
+#### Scenario: Build succeeds when the toolchain is raised to a newer JDK
+- **WHEN** the declared toolchain `languageVersion` is temporarily raised to the next Java LTS and `./gradlew build` is run
+- **THEN** no task fails with an unsupported-class-file-version, unknown-constant-pool, or unsupported-source-release error
+
+#### Scenario: Lombok version is owned by this repository
+- **WHEN** the Spring Boot platform version imported by `symphony-bdk-bom` changes
+- **THEN** the resolved Lombok version does not change, because `symphony-bdk-bom` constrains it explicitly
+
+#### Scenario: JaCoCo version is explicit
+- **WHEN** the Gradle distribution version changes
+- **THEN** the JaCoCo tool version used for coverage does not change, because it is declared via `jacoco { toolVersion }`
+
+---
+
+### Requirement: Build is free of deprecation warnings that block the next Gradle major
+`./gradlew build --warning-mode all` SHALL complete without emitting Gradle deprecation warnings. This applies to build scripts in every module and to the convention plugins in `buildSrc`.
+
+#### Scenario: No deprecation warnings on a full build
+- **WHEN** `./gradlew build --warning-mode all` is run on a clean checkout
+- **THEN** no deprecation warnings are emitted, including from `buildSrc` convention plugins at configuration time
+
+#### Scenario: Build directory and task registration use current APIs
+- **WHEN** any build script references the build output directory or registers a task
+- **THEN** it uses `layout.buildDirectory` and `tasks.register`, not `project.buildDir` or `tasks.create`
+
+---
+
+### Requirement: Published BOM constrains only dependencies the project actually uses
+`symphony-bdk-bom` SHALL NOT carry version constraints for artifacts that no module in the project resolves. Removing a constraint from the published BOM is a consumer-visible change to dependency resolution and SHALL be released in a minor or major version, never a patch, and SHALL be recorded in release notes.
+
+#### Scenario: Dead constraint is removed
+- **WHEN** a constraint in `symphony-bdk-bom` names an artifact that no module resolves
+- **THEN** the constraint is removed, and the removal is listed in the release notes for the version that drops it
+
+#### Scenario: Constraint removal is not shipped as a patch
+- **WHEN** a release removes one or more constraints from `symphony-bdk-bom`
+- **THEN** that release increments at least the minor version
+
+---
+
+### Requirement: Generated and processor-derived output is diffed across tooling upgrades
+When an annotation processor or code generator used by the build is upgraded, the output it produces SHALL be compared before and after the upgrade, and any change to a consumer-visible type or to null/default-value handling SHALL be reviewed before release. A tooling upgrade SHALL NOT be treated as build-internal if it changes generated output.
+
+#### Scenario: MapStruct processor upgrade
+- **WHEN** the MapStruct processor version changes
+- **THEN** the generated mapper implementations are diffed, and any change in unmapped-property or null handling is reviewed as a behaviour change rather than a build change
+
+#### Scenario: OpenAPI generator upgrade
+- **WHEN** the OpenAPI generator version changes
+- **THEN** the generated sources under `com.symphony.bdk.gen.api` are diffed in full, because those types are part of the published API surface

--- a/openspec/changes/modernize-build-toolchain/tasks.md
+++ b/openspec/changes/modernize-build-toolchain/tasks.md
@@ -1,0 +1,58 @@
+## 1. Gradle 9 Compatibility Spike (blocking — resolves D1)
+
+- [ ] 1.1 Bump `gradle/wrapper/gradle-wrapper.properties` to the chosen Gradle 9.x on a throwaway branch and run `./gradlew :symphony-bdk-core:openApiGenerate` — record whether `openapi-generator-gradle-plugin:6.6.0` works
+- [ ] 1.2 Run `./gradlew build --warning-mode all` and capture the full deprecation list; this is the authoritative task list for section 2, superseding the statically-found call sites
+- [ ] 1.3 Verify `owasp-dependencycheck:12.2.2` and `com.github.ben-manes.versions` still resolve under Gradle 9 (`buildSrc/build.gradle` already carries a manual override block for a 6.6.0-vs-dependencycheck conflict)
+- [ ] 1.4 Per D1, choose and record the branch: proceed as scoped / (a) pull generator bump forward / (b) defer Gradle 9 to `adopt-java-25-baseline`. Update this change's proposal scope if (a) or (b)
+
+## 2. Gradle 9 Migration
+
+- [ ] 2.1 Bump the wrapper to Gradle 9.x (`gradle/wrapper/gradle-wrapper.properties`, and commit the regenerated wrapper scripts)
+- [ ] 2.2 Replace `sourceCompatibility = JavaVersion.VERSION_17` in `bdk.java-common-conventions.gradle` with a `java { toolchain { languageVersion = JavaLanguageVersion.of(17) } }` block (D2)
+- [ ] 2.3 Confirm `options.compilerArgs << '-parameters'` and `options.encoding = 'UTF-8'` survive the conventions rewrite — both are load-bearing (Spring constructor binding, Jackson parameter names)
+- [ ] 2.4 Replace `project.buildDir` with `layout.buildDirectory` in `bdk.java-codegen-conventions.gradle`, `symphony-bdk-core/build.gradle`, and `symphony-bdk-extensions/symphony-group-extension/build.gradle`
+- [ ] 2.5 Convert the two `tasks.create(...)` calls in `symphony-bdk-core/build.gradle`'s `apisToGenerate` loop (`download$api`, `generate$api`) to `tasks.register(...)`, preserving the `compileJava.dependsOn` / `sourcesJar.dependsOn` wiring
+- [ ] 2.6 Work through the remaining deprecations from 1.2 until `./gradlew build --warning-mode all` is clean
+- [ ] 2.7 Add an explicit `jacoco { toolVersion = '...' }` to `bdk.java-common-conventions.gradle` rather than relying on the Gradle-bundled default
+
+## 3. Bytecode-Processing Tooling Bumps
+
+- [ ] 3.1 Bump the explicit `net.bytebuddy:byte-buddy` pin in `symphony-bdk-core/build.gradle` (currently 1.12.19) to a release supporting class file version 69
+- [ ] 3.2 Bump `org.mapstruct:mapstruct` and `org.mapstruct:mapstruct-processor` in `symphony-bdk-core/build.gradle` (currently 1.4.2.Final) to 1.6.x
+- [ ] 3.3 Diff the generated `UserDetailMapperImpl` before and after the MapStruct bump; investigate any change in null-handling or unmapped-property behaviour (D5)
+- [ ] 3.4 Bump `com.tngtech.archunit:archunit-junit5` in the BOM (currently 1.2.1); confirm the 3 architecture tests still pass — `CoreArchitectureTest`, `SymphonyGroupExtensionArchitectureTest`, `bdk-spring-boot-example/ArchitectureTest`
+- [ ] 3.5 Bump `org.assertj:assertj-core` in the BOM if a newer release is available for the JaCoCo/JDK combination
+- [ ] 3.6 Verify `jacocoTestCoverageVerification` still passes in every module after the JaCoCo toolVersion bump; if thresholds shift because of JaCoCo counting changes rather than test changes, adjust them in a dedicated commit naming the JaCoCo version
+
+## 4. Lombok Version Ownership
+
+- [ ] 4.1 Add an explicit `org.projectlombok:lombok` constraint to `symphony-bdk-bom/build.gradle`, at the version currently resolved from `spring-boot-dependencies:3.5.16` or newer
+- [ ] 4.2 Verify all 13 Lombok-consuming modules still compile with the pinned version
+- [ ] 4.3 Confirm the pinned version has published JDK 25 support (needed later by `adopt-java-25-baseline`, recorded here so the check isn't repeated)
+
+## 5. MockServer Replacement (D3)
+
+- [ ] 5.1 Check whether a current MockServer release tracks Netty 4.2; if so, reduce this section to a version bump and skip 5.2–5.4
+- [ ] 5.2 Choose the replacement (WireMock or OkHttp MockWebServer) and add it to the BOM
+- [ ] 5.3 Migrate the 4 test files using `mockserver` off it, preserving assertion coverage
+- [ ] 5.4 Remove `org.mock-server:mockserver-netty` from `symphony-bdk-bom` and from `symphony-bdk-core` / `symphony-bdk-http-webclient` test dependencies
+
+## 6. Dead Dependency Removal (D4 — own commit)
+
+- [ ] 6.1 Remove `javax.xml.bind:jaxb-api:2.3.1` from `symphony-bdk-core/build.gradle` (verified: zero source usage anywhere in the tree)
+- [ ] 6.2 Replace `javax.annotation:jsr250-api:1.0` with `jakarta.annotation:jakarta.annotation-api` in `bdk.java-codegen-conventions.gradle`, and confirm the generated sources still compile
+- [ ] 6.3 Remove `org.projectreactor:reactor-spring:1.0.1.RELEASE` from `symphony-bdk-bom` after confirming no module resolves it
+- [ ] 6.4 Land 6.1–6.3 plus the Lombok constraint from 4.1 as a single commit whose message names each removed coordinate and why
+
+## 7. Forward-Compatibility Verification (does not change committed config)
+
+- [ ] 7.1 On a throwaway branch, flip the toolchain to `JavaLanguageVersion.of(25)` and run `./gradlew build` — record every failure as a task in `adopt-java-25-baseline`, then discard the branch
+- [ ] 7.2 Specifically record: whether Mockito's dynamic agent attach warns or fails, whether ArchUnit reads class file 69, whether Lombok compiles, and whether `openApiGenerate` runs
+- [ ] 7.3 Confirm the chosen Gradle 9.x can provision a JDK 25 toolchain (needed by `adopt-java-25-baseline`)
+
+## 8. Release
+
+- [ ] 8.1 Confirm `./gradlew build jacocoTestReport jacocoTestCoverageVerification` is green on JDK 17 (the CI command)
+- [ ] 8.2 Confirm `./gradlew publishToMavenLocal` produces the same module coordinates as 3.5.x
+- [ ] 8.3 Draft 3.6.0 release notes covering the two consumer-visible BOM changes from D4's migration plan
+- [ ] 8.4 Update `CLAUDE.md` with the new Gradle version and the minimum daemon JDK for contributors


### PR DESCRIPTION
## Summary
- Adds an OpenSpec proposal to adopt a Java 25 baseline
- Adds an OpenSpec proposal to migrate to Spring Boot 4
- Adds an OpenSpec proposal to modernize the Gradle build toolchain

Each proposal includes a design doc, spec deltas, and a task breakdown, for discussion before implementation begins.

## Test plan
- [x] Docs-only change; no build/test impact