### PR TITLE
fix: restore missing datafeed includeInvisible flag logic

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2.java
@@ -112,6 +112,9 @@ public class DatafeedLoopV2 extends AbstractAckIdEventLoop {
         .build();
 
     datafeedCreateBody = new V5DatafeedCreateBody();
+    if (config.getDatafeed().isIncludeInvisible()) {
+      datafeedCreateBody.setIncludeInvisible(true);
+    }
     if (StringUtils.isNotBlank(config.getDatafeed().getTag())) {
       datafeedCreateBody.setTag(config.getDatafeed().getTag());
     }

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2Test.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/datafeed/impl/DatafeedLoopV2Test.java
@@ -42,6 +42,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 import static com.symphony.bdk.core.test.BdkRetryConfigTestHelper.ofMinimalInterval;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -127,7 +128,7 @@ class DatafeedLoopV2Test {
   void testStartInvalidExistingFeeds(String invalidExistingFeedId) throws ApiException, AuthUnauthorizedException {
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null))
         .thenReturn(Collections.singletonList(new V5Datafeed().id(invalidExistingFeedId)));
-    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody())).thenReturn(
+    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true))).thenReturn(
         new V5Datafeed().id(DATAFEED_ID));
 
     AckId ackId = new AckId().ackId(datafeedService.getAckId());
@@ -138,10 +139,70 @@ class DatafeedLoopV2Test {
 
     this.datafeedService.start();
 
-    V5DatafeedCreateBody datafeedCreateBody = new V5DatafeedCreateBody();
+    V5DatafeedCreateBody datafeedCreateBody = new V5DatafeedCreateBody().includeInvisible(true);
     verify(datafeedApi, times(1)).listDatafeed(TOKEN, TOKEN, null);
     verify(datafeedApi, times(1)).createDatafeed(TOKEN, TOKEN, datafeedCreateBody);
     verify(datafeedApi, times(1)).readDatafeed(DATAFEED_ID, TOKEN, TOKEN, ackId);
+  }
+
+  @Test
+  void testStartWithIncludeInvisibleCreatesFeedWithTheFlag() throws Exception {
+    DatafeedLoopV2 loop = newDatafeedLoop(datafeedConfig -> datafeedConfig.setIncludeInvisible(true));
+
+    when(datafeedApi.listDatafeed(TOKEN, TOKEN, null)).thenReturn(Collections.emptyList());
+    when(datafeedApi.createDatafeed(eq(TOKEN), eq(TOKEN), any())).thenReturn(new V5Datafeed().id(DATAFEED_ID));
+    when(datafeedApi.readDatafeed(eq(DATAFEED_ID), eq(TOKEN), eq(TOKEN), any()))
+        .thenReturn(new V5EventList().addEventsItem(
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name())
+                .payload(new V4Payload().messageSent(new V4MessageSent()))).ackId("ack-id"));
+
+    loop.start();
+
+    // Without this, the agent creates the feed without SHOW_INVISIBLE_FILTER_RULES and events from
+    // invisible rooms are silently filtered out for the whole life of the feed.
+    verify(datafeedApi, times(1)).createDatafeed(TOKEN, TOKEN,
+        new V5DatafeedCreateBody().includeInvisible(true));
+  }
+
+  @Test
+  void testStartWithoutIncludeInvisibleOmitsTheFlag() throws Exception {
+    DatafeedLoopV2 loop = newDatafeedLoop(datafeedConfig -> datafeedConfig.setIncludeInvisible(false));
+
+    when(datafeedApi.listDatafeed(TOKEN, TOKEN, null)).thenReturn(Collections.emptyList());
+    when(datafeedApi.createDatafeed(eq(TOKEN), eq(TOKEN), any())).thenReturn(new V5Datafeed().id(DATAFEED_ID));
+    when(datafeedApi.readDatafeed(eq(DATAFEED_ID), eq(TOKEN), eq(TOKEN), any()))
+        .thenReturn(new V5EventList().addEventsItem(
+            new V4Event().type(RealTimeEventType.MESSAGESENT.name())
+                .payload(new V4Payload().messageSent(new V4MessageSent()))).ackId("ack-id"));
+
+    loop.start();
+
+    verify(datafeedApi, times(1)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody());
+  }
+
+  private DatafeedLoopV2 newDatafeedLoop(Consumer<BdkDatafeedConfig> datafeedConfigurer) throws BdkConfigException {
+    BdkConfig bdkConfig = BdkConfigLoader.loadFromClasspath("/config/config.yaml");
+    BdkDatafeedConfig datafeedConfig = bdkConfig.getDatafeed();
+    datafeedConfig.setVersion("v2");
+    datafeedConfig.setRetry(ofMinimalInterval(2));
+    datafeedConfigurer.accept(datafeedConfig);
+    bdkConfig.setDatafeed(datafeedConfig);
+    bdkConfig.setRetry(ofMinimalInterval(2));
+
+    final DatafeedLoopV2 loop =
+        new DatafeedLoopV2(this.datafeedApi, this.authSession, bdkConfig, Mockito.mock(UserV2.class));
+    loop.subscribe(new RealTimeEventListener() {
+      @Override
+      public boolean isAcceptingEvent(V4Event event, UserV2 botInfo) {
+        return true;
+      }
+
+      @Override
+      public void onMessageSent(V4Initiator initiator, V4MessageSent event) {
+        loop.stop();
+      }
+    });
+    return loop;
   }
 
   @ParameterizedTest
@@ -149,7 +210,7 @@ class DatafeedLoopV2Test {
   void testStartValidExistingFeeds(String validExistingFeedId) throws ApiException, AuthUnauthorizedException {
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null))
         .thenReturn(Collections.singletonList(new V5Datafeed().id(validExistingFeedId)));
-    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody())).thenReturn(
+    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true))).thenReturn(
         new V5Datafeed().id(validExistingFeedId));
 
     AckId ackId = new AckId().ackId(datafeedService.getAckId());
@@ -160,7 +221,7 @@ class DatafeedLoopV2Test {
 
     this.datafeedService.start();
 
-    V5DatafeedCreateBody datafeedCreateBody = new V5DatafeedCreateBody();
+    V5DatafeedCreateBody datafeedCreateBody = new V5DatafeedCreateBody().includeInvisible(true);
     verify(datafeedApi, times(1)).listDatafeed(TOKEN, TOKEN, null);
     verify(datafeedApi, times(0)).createDatafeed(TOKEN, TOKEN, datafeedCreateBody);
     verify(datafeedApi, times(1)).readDatafeed(validExistingFeedId, TOKEN, TOKEN, ackId);
@@ -337,7 +398,7 @@ class DatafeedLoopV2Test {
   @Test
   void testStartEmptyListDatafeed() throws ApiException, AuthUnauthorizedException {
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null)).thenReturn(Collections.emptyList());
-    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody())).thenReturn(
+    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true))).thenReturn(
         new V5Datafeed().id(DATAFEED_ID));
     AckId initialAckId = new AckId().ackId("");
     final String secondAckId = "ack-id";
@@ -349,7 +410,7 @@ class DatafeedLoopV2Test {
     this.datafeedService.start();
 
     verify(datafeedApi, times(1)).listDatafeed(TOKEN, TOKEN, null);
-    verify(datafeedApi, times(1)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody());
+    verify(datafeedApi, times(1)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true));
     verify(datafeedApi, times(1)).readDatafeed(DATAFEED_ID, TOKEN, TOKEN, initialAckId);
     assertEquals(secondAckId, datafeedService.getAckId());
   }
@@ -370,7 +431,7 @@ class DatafeedLoopV2Test {
         .thenThrow(new ApiException(400, ""));
     when(datafeedApi.deleteDatafeed(DATAFEED_ID, TOKEN, TOKEN)).thenReturn(null);
 
-    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody())).thenReturn(
+    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true))).thenReturn(
         new V5Datafeed().id(secondDatafeedId));
     when(datafeedApi.readDatafeed(secondDatafeedId, TOKEN, TOKEN, initialAckId))
         .thenReturn(new V5EventList().addEventsItem(
@@ -470,35 +531,35 @@ class DatafeedLoopV2Test {
   @Test
   void testStartAuthErrorCreateDatafeed() throws ApiException, AuthUnauthorizedException {
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null)).thenReturn(Collections.emptyList());
-    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody())).thenThrow(
+    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true))).thenThrow(
         new ApiException(401, "unauthorized-error"));
     doThrow(AuthUnauthorizedException.class).when(authSession).refresh();
 
     assertThrows(AuthUnauthorizedException.class, this.datafeedService::start);
     verify(datafeedApi, times(1)).listDatafeed(TOKEN, TOKEN, null);
-    verify(datafeedApi, times(1)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody());
+    verify(datafeedApi, times(1)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true));
   }
 
   @Test
   void testStartClientErrorCreateDatafeed() throws ApiException {
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null)).thenReturn(Collections.emptyList());
-    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody())).thenThrow(
+    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true))).thenThrow(
         new ApiException(400, "client-error"));
 
     assertThrows(ApiException.class, this.datafeedService::start);
     verify(datafeedApi, times(1)).listDatafeed(TOKEN, TOKEN, null);
-    verify(datafeedApi, times(2)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody());
+    verify(datafeedApi, times(2)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true));
   }
 
   @Test
   void testStartServerErrorCreateDatafeed() throws ApiException {
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null)).thenReturn(Collections.emptyList());
-    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody())).thenThrow(
+    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true))).thenThrow(
         new ApiException(502, "server-error"));
 
     assertThrows(ApiException.class, this.datafeedService::start);
     verify(datafeedApi, times(1)).listDatafeed(TOKEN, TOKEN, null);
-    verify(datafeedApi, times(2)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody());
+    verify(datafeedApi, times(2)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true));
   }
 
   @Test
@@ -506,7 +567,7 @@ class DatafeedLoopV2Test {
     AckId ackId = new AckId().ackId(datafeedService.getAckId());
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null)).thenReturn(
         Collections.singletonList(new V5Datafeed().id(DATAFEED_ID)));
-    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody()))
+    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true)))
         .thenThrow(new ApiException(400, "ALB: No matching rule found"))
         .thenReturn(new V5Datafeed().id("recreate-df-id"));
     when(datafeedApi.readDatafeed(DATAFEED_ID, TOKEN, TOKEN, ackId)).thenThrow(new ApiException(400, "client-error"));
@@ -520,7 +581,7 @@ class DatafeedLoopV2Test {
     verify(datafeedApi, times(1)).readDatafeed(DATAFEED_ID, TOKEN, TOKEN, ackId);
     verify(datafeedApi, times(1)).readDatafeed("recreate-df-id", TOKEN, TOKEN, ackId);
     verify(datafeedApi, times(1)).deleteDatafeed(DATAFEED_ID, TOKEN, TOKEN);
-    verify(datafeedApi, times(2)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody());
+    verify(datafeedApi, times(2)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true));
   }
 
   @Test
@@ -613,7 +674,7 @@ class DatafeedLoopV2Test {
     AckId ackId = new AckId().ackId(datafeedService.getAckId());
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null)).thenReturn(
         Collections.singletonList(new V5Datafeed().id(DATAFEED_ID)));
-    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody())).thenReturn(
+    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true))).thenReturn(
         new V5Datafeed().id("recreate-df-id"));
     when(datafeedApi.readDatafeed(DATAFEED_ID, TOKEN, TOKEN, ackId)).thenThrow(new ApiException(400, "client-error"));
     when(datafeedApi.readDatafeed("recreate-df-id", TOKEN, TOKEN, ackId))
@@ -626,7 +687,7 @@ class DatafeedLoopV2Test {
     verify(datafeedApi, times(1)).listDatafeed(TOKEN, TOKEN, null);
     verify(datafeedApi, times(1)).readDatafeed(DATAFEED_ID, TOKEN, TOKEN, ackId);
     verify(datafeedApi, times(1)).readDatafeed("recreate-df-id", TOKEN, TOKEN, ackId);
-    verify(datafeedApi, times(1)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody());
+    verify(datafeedApi, times(1)).createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true));
     verify(datafeedApi, times(1)).deleteDatafeed(DATAFEED_ID, TOKEN, TOKEN);
   }
 
@@ -635,7 +696,7 @@ class DatafeedLoopV2Test {
     AckId ackId = new AckId().ackId(datafeedService.getAckId());
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null)).thenReturn(
         Collections.singletonList(new V5Datafeed().id(DATAFEED_ID)));
-    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody())).thenReturn(
+    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true))).thenReturn(
         new V5Datafeed().id("recreate-df-id"));
     when(datafeedApi.readDatafeed(DATAFEED_ID, TOKEN, TOKEN, ackId)).thenThrow(new ApiException(400, "client-error"));
     when(datafeedApi.deleteDatafeed(DATAFEED_ID, TOKEN, TOKEN)).thenThrow(new ApiException(502, "client-error"));
@@ -651,7 +712,7 @@ class DatafeedLoopV2Test {
     AckId ackId = new AckId().ackId(datafeedService.getAckId());
     when(datafeedApi.listDatafeed(TOKEN, TOKEN, null)).thenReturn(
         Collections.singletonList(new V5Datafeed().id(DATAFEED_ID)));
-    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody())).thenReturn(
+    when(datafeedApi.createDatafeed(TOKEN, TOKEN, new V5DatafeedCreateBody().includeInvisible(true))).thenReturn(
         new V5Datafeed().id("recreate-df-id"));
     when(datafeedApi.readDatafeed(DATAFEED_ID, TOKEN, TOKEN, ackId)).thenThrow(new ApiException(400, "client-error"));
     when(datafeedApi.deleteDatafeed(DATAFEED_ID, TOKEN, TOKEN)).thenThrow(new ApiException(401, "client-error"));


### PR DESCRIPTION
This commit fixes a regression introduced in 22d25f0 where the DatafeedLoopV2 agent inadvertently stopped propagating the `includeInvisible` configuration flag to the datafeed creation request.

The flag's absence caused events from invisible rooms to be silently filtered out for the entire lifetime of the created feed. The same commit also broke the tests meant to safeguard this logic by changing their mock expectations to expect the flag's absence.

- Restores the propagation of `includeInvisible` from BdkDatafeedConfig to the V5DatafeedCreateBody inside DatafeedLoopV2.
- Reverts all 17 mock expectations in DatafeedLoopV2Test back to enforcing the presence of `includeInvisible(true)` (which is the configured default in the test config.yaml).
- Adds a missing `Consumer` import to DatafeedLoopV2Test to fix the resulting build failure.