### PR TITLE
fix(ci): accept SemVer pre-release tags in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,9 @@ jobs:
         id: version
         run: |
           TAG="${{ github.event.release.tag_name }}"
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Release tag '$TAG' is not in the expected vMAJOR.MINOR.PATCH format (e.g. v3.3.16)"
+          # vMAJOR.MINOR.PATCH with optional SemVer pre-release (-alpha.1) and build metadata (+build.5)
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Release tag '$TAG' is not in the expected vMAJOR.MINOR.PATCH[-prerelease][+build] format (e.g. v3.3.16 or v4.0.0-alpha.1)"
             exit 1
           fi
           VERSION="${TAG#v}"
@@ -31,8 +32,9 @@ jobs:
             echo "::error::Release tag '$TAG' is a v3.x release but targets '$TARGET' instead of the '3.x' branch"
             exit 1
           fi
-          if [[ "$MAJOR" != "3" && "$TARGET" != "main" ]]; then
-            echo "::error::Release tag '$TAG' is a v${MAJOR}.x release but targets '$TARGET' instead of 'main'"
+          # 4.x is developed on 'next' until GA merges it to 'main'; both branches are valid release sources.
+          if [[ "$MAJOR" != "3" && "$TARGET" != "main" && "$TARGET" != "next" ]]; then
+            echo "::error::Release tag '$TAG' is a v${MAJOR}.x release but targets '$TARGET' instead of 'main' or 'next'"
             exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

The [Release workflow run](https://github.com/finos/symphony-bdk-java/actions/runs/31483166347/job/93752480551) failed on tag `v4.0.0-alpha.1`:

```
Release tag 'v4.0.0-alpha.1' is not in the expected vMAJOR.MINOR.PATCH format (e.g. v3.3.16)
```

Two gates in `Derive release version from tag` blocked the alpha release:

1. The tag regex `^v[0-9]+\.[0-9]+\.[0-9]+$` only matched `vMAJOR.MINOR.PATCH`, rejecting SemVer pre-release suffixes.
2. The branch check required `main` for any major ≠ 3, but 4.x alphas are cut from the `next` branch.

## Fix

- Extend the regex to accept optional SemVer pre-release (`-alpha.1`) and build-metadata (`+build.5`) suffixes.
- Accept `next` as a valid release source for 4.x, since 4.x is developed on `next` until GA merges it into `main`.

Verified in bash: `v4.0.0-alpha.1`, `v3.3.16`, `v4.0.0`, `v4.0.0-rc.1+build.5` pass; `v4`, `v4.0`, `va.b.c` still rejected.