### PR TITLE
BE-9863 add blast messaging and attachment functions to OboMessageService

### DIFF
--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/MessageService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/MessageService.java
@@ -448,13 +448,9 @@ public class MessageService implements OboMessageService, OboService<OboMessageS
   }
 
   /**
-   * Sends a message to multiple existing streams.
-   *
-   * @param streamIds the list of stream IDs to send the message to
-   * @param message   the message to be sent
-   * @return a {@link V4MessageBlastResponse} object containing the details of the sent messages
-   * @see <a href="https://developers.symphony.com/restapi/v20.9/reference#blast-message">Blast Message</a>
+   * {@inheritDoc}
    */
+  @Override
   public V4MessageBlastResponse send(@Nonnull List<String> streamIds, @Nonnull Message message) {
     if (senderOverride != null) {
       return this.executeAndRetry("sendBlast", messagesApi.getApiClient().getBasePath(),

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/MessageService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/MessageService.java
@@ -524,14 +524,9 @@ public class MessageService implements OboMessageService, OboService<OboMessageS
   }
 
   /**
-   * Downloads the attachment body by the stream ID, message ID and attachment ID.
-   *
-   * @param streamId     the stream ID where to look for the attachment
-   * @param messageId    the ID of the message containing the attachment
-   * @param attachmentId the ID of the attachment
-   * @return a byte array of attachment encoded in base 64
-   * @see <a href="https://developers.symphony.com/restapi/reference#attachment">Attachment</a>
+   * {@inheritDoc}
    */
+  @Override
   public byte[] getAttachment(@Nonnull String streamId, @Nonnull String messageId, @Nonnull String attachmentId) {
     if (senderOverride != null) {
       return executeAndRetry("getAttachment", attachmentsApi.getApiClient().getBasePath(),

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/MessageService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/MessageService.java
@@ -595,16 +595,9 @@ public class MessageService implements OboMessageService, OboService<OboMessageS
   }
 
   /**
-   * List attachments in a particular stream.
-   *
-   * @param streamId the stream ID where to look for the attachments
-   * @param since    optional instant of the first required attachment.
-   * @param to       optional instant of the last required attachment.
-   * @param limit    maximum number of attachments to return. This optional value defaults to 50 and should be between 0 and 100.
-   * @param sort     Attachment date sort direction : ASC or DESC (default to ASC)
-   * @return the list of attachments in the stream.
-   * @see <a href="https://developers.symphony.com/restapi/reference#list-attachments">List Attachments</a>
+   * {@inheritDoc}
    */
+  @Override
   public List<StreamAttachmentItem> listAttachments(@Nonnull String streamId, @Nullable Instant since,
       @Nullable Instant to, @Nullable Integer limit, @Nullable AttachmentSort sort) {
     final String sortDir = sort == null ? AttachmentSort.ASC.name() : sort.name();

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/OboMessageService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/OboMessageService.java
@@ -206,6 +206,17 @@ public interface OboMessageService {
   MessageSuppressionResponse suppressMessage(@Nonnull String messageId);
 
   /**
+   * Downloads the attachment body by the stream ID, message ID and attachment ID.
+   *
+   * @param streamId     the stream ID where to look for the attachment
+   * @param messageId    the ID of the message containing the attachment
+   * @param attachmentId the ID of the attachment
+   * @return a byte array of attachment encoded in base 64
+   * @see <a href="https://developers.symphony.com/restapi/reference#attachment">Attachment</a>
+   */
+  byte[] getAttachment(@Nonnull String streamId, @Nonnull String messageId, @Nonnull String attachmentId);
+
+  /**
    * Retrieves a list of supported file extensions for attachments.
    *
    * @return a list of String containing all allowed file extensions for attachments

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/OboMessageService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/OboMessageService.java
@@ -4,6 +4,7 @@ import com.symphony.bdk.core.service.message.model.Message;
 import com.symphony.bdk.core.service.pagination.model.PaginationAttribute;
 import com.symphony.bdk.gen.api.model.MessageSuppressionResponse;
 import com.symphony.bdk.gen.api.model.V4Message;
+import com.symphony.bdk.gen.api.model.V4MessageBlastResponse;
 import com.symphony.bdk.gen.api.model.V4Stream;
 import com.symphony.bdk.template.api.TemplateEngine;
 
@@ -163,6 +164,16 @@ public interface OboMessageService {
    * @see <a href="https://developers.symphony.com/restapi/reference/create-message-v4">Create Message v4</a>
    */
   V4Message send(@Nonnull String streamId, @Nonnull Message message);
+
+  /**
+   * Sends a message to multiple existing streams.
+   *
+   * @param streamIds the list of stream IDs to send the message to
+   * @param message   the message to be sent
+   * @return a {@link V4MessageBlastResponse} object containing the details of the sent messages
+   * @see <a href="https://developers.symphony.com/restapi/reference/blast-message">Blast Message</a>
+   */
+  V4MessageBlastResponse send(@Nonnull List<String> streamIds, @Nonnull Message message);
 
   /**
    * Update an existing message. The existing message must be a valid social message, that has not been deleted.

--- a/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/OboMessageService.java
+++ b/symphony-bdk-core/src/main/java/com/symphony/bdk/core/service/message/OboMessageService.java
@@ -2,7 +2,9 @@ package com.symphony.bdk.core.service.message;
 
 import com.symphony.bdk.core.service.message.model.Message;
 import com.symphony.bdk.core.service.pagination.model.PaginationAttribute;
+import com.symphony.bdk.core.service.stream.constant.AttachmentSort;
 import com.symphony.bdk.gen.api.model.MessageSuppressionResponse;
+import com.symphony.bdk.gen.api.model.StreamAttachmentItem;
 import com.symphony.bdk.gen.api.model.V4Message;
 import com.symphony.bdk.gen.api.model.V4MessageBlastResponse;
 import com.symphony.bdk.gen.api.model.V4Stream;
@@ -215,6 +217,19 @@ public interface OboMessageService {
    * @see <a href="https://developers.symphony.com/restapi/reference#attachment">Attachment</a>
    */
   byte[] getAttachment(@Nonnull String streamId, @Nonnull String messageId, @Nonnull String attachmentId);
+
+  /**
+   * List attachments in a particular stream.
+   *
+   * @param streamId the stream ID where to look for the attachments
+   * @param since    optional instant of the first required attachment.
+   * @param to       optional instant of the last required attachment.
+   * @param limit    maximum number of attachments to return. This optional value defaults to 50 and should be between 0 and 100.
+   * @param sort     Attachment date sort direction : ASC or DESC (default to ASC)
+   * @return the list of attachments in the stream.
+   * @see <a href="https://developers.symphony.com/restapi/reference#list-attachments">List Attachments</a>
+   */
+  List<StreamAttachmentItem> listAttachments(@Nonnull String streamId, @Nullable Instant since, @Nullable Instant to, @Nullable Integer limit, @Nullable AttachmentSort sort);
 
   /**
    * Retrieves a list of supported file extensions for attachments.

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/MessageServiceTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/MessageServiceTest.java
@@ -594,6 +594,17 @@ class MessageServiceTest {
   }
 
   @Test
+  void testListAttachmentsObo() throws IOException {
+    mockApiClient.onGet(V1_STREAM_ATTACHMENTS.replace("{sid}", STREAM_ID),
+        JsonHelper.readFromClasspath("/stream/list_attachments.json"));
+
+    List<StreamAttachmentItem> attachments =
+        messageService.obo(authSession).listAttachments(STREAM_ID, null, null, null, AttachmentSort.ASC);
+
+    assertEquals(2, attachments.size());
+  }
+
+  @Test
   void testListAttachmentWithSortDirAsc() throws ApiException {
     doReturn(Collections.emptyList()).when(streamsApi)
         .v1StreamsSidAttachmentsGet(any(), any(), any(), any(), any(), any());

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/MessageServiceTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/MessageServiceTest.java
@@ -494,6 +494,17 @@ class MessageServiceTest {
   }
 
   @Test
+  void testGetAttachmentObo() throws ApiException {
+    final String attachmentId = "attachmentId";
+
+    doReturn(new byte[0]).when(attachmentsApi).v1StreamSidAttachmentGet(any(), any(), any(), any(), any());
+
+    assertNotNull(messageService.obo(authSession).getAttachment(STREAM_ID, MESSAGE_ID, attachmentId));
+    verify(attachmentsApi).v1StreamSidAttachmentGet(eq(STREAM_ID), eq(attachmentId), eq(MESSAGE_ID), anyString(),
+        anyString());
+  }
+
+  @Test
   void testGetAttachmentThrowingApiException() throws ApiException {
     doThrow(new ApiException(400, "error")).when(attachmentsApi)
         .v1StreamSidAttachmentGet(any(), any(), any(), any(), any());

--- a/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/MessageServiceTest.java
+++ b/symphony-bdk-core/src/test/java/com/symphony/bdk/core/service/message/MessageServiceTest.java
@@ -152,6 +152,19 @@ class MessageServiceTest {
   }
 
   @Test
+  void testSendBlastObo() throws IOException {
+    mockApiClient.onPost(V4_BLAST_MESSAGE, JsonHelper.readFromClasspath("/message/blast_message.json"));
+
+    messageService = new MessageService(messagesApi, messageApi, messageSuppressionApi, streamsApi, podApi,
+        attachmentsApi, defaultApi, templateEngine, new RetryWithRecoveryBuilder<>());
+    final V4MessageBlastResponse blastResponse = messageService.obo(authSession)
+        .send(Arrays.asList("sid1", "sid2"), Message.builder().content(MESSAGE).build());
+
+    assertNotNull(blastResponse);
+    assertEquals(2, blastResponse.getMessages().size());
+  }
+
+  @Test
   void testGetMessagesWithStreamObject() {
     MessageService service = spy(messageService);
     doReturn(Collections.emptyList()).when(service).listMessages(anyString(), any(Instant.class), any(Instant.class));


### PR DESCRIPTION
### Description
- Adds `send(@Nonnull List<String> streamIds, @Nonnull Message message)` to `OboMessageService.java` for blast message support
- Adds `getAttachment` and `listAttachments` to `oboMessageService.java`
